### PR TITLE
CB-20943 remove the plain text userdata from the database and move it to vault

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudStack.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudStack.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 
 /**
  * Class that describes complete structure of infrastructure that needs to be started on the Cloud Provider
@@ -40,16 +41,22 @@ public class CloudStack {
 
     private final List<CloudLoadBalancer> loadBalancers;
 
+    private final String gatewayUserData;
+
+    private final String coreUserData;
+
     public CloudStack(Collection<Group> groups, Network network, Image image, Map<String, String> parameters, Map<String, String> tags, String template,
-            InstanceAuthentication instanceAuthentication, String loginUserName, String publicKey, SpiFileSystem fileSystem) {
-        this(groups, network, image, parameters, tags, template, instanceAuthentication, loginUserName, publicKey, fileSystem, Collections.emptyList());
+            InstanceAuthentication instanceAuthentication, String loginUserName, String publicKey, SpiFileSystem fileSystem,
+            String gatewayUserData, String coreUserData) {
+        this(groups, network, image, parameters, tags, template, instanceAuthentication, loginUserName, publicKey, fileSystem,
+                Collections.emptyList(), gatewayUserData, coreUserData);
     }
 
     public CloudStack(Collection<Group> groups, Network network, Image image, Map<String, String> parameters, Map<String, String> tags,
             String template, InstanceAuthentication instanceAuthentication, String loginUserName, String publicKey, SpiFileSystem fileSystem,
-            List<CloudLoadBalancer> loadBalancers) {
-        this(groups, network, image, parameters, tags, template, instanceAuthentication, loginUserName, publicKey, fileSystem, loadBalancers,
-                null);
+            List<CloudLoadBalancer> loadBalancers, String gatewayUserData, String coreUserData) {
+        this(groups, network, image, parameters, tags, template, instanceAuthentication, loginUserName, publicKey, fileSystem,
+                loadBalancers, null, gatewayUserData, coreUserData);
     }
 
     @JsonCreator
@@ -65,8 +72,9 @@ public class CloudStack {
             @JsonProperty("publicKey") String publicKey,
             @JsonProperty("fileSystem") SpiFileSystem fileSystem,
             @JsonProperty("loadBalancers") List<CloudLoadBalancer> loadBalancers,
-            @JsonProperty("additionalFileSystem") SpiFileSystem additionalFileSystem) {
-
+            @JsonProperty("additionalFileSystem") SpiFileSystem additionalFileSystem,
+            @JsonProperty("gatewayUserData") String gatewayUserData,
+            @JsonProperty("coreUserData") String coreUserData) {
         this.groups = ImmutableList.copyOf(groups);
         this.network = network;
         this.image = image;
@@ -79,11 +87,13 @@ public class CloudStack {
         this.fileSystem = Optional.ofNullable(fileSystem);
         this.loadBalancers = loadBalancers != null ? loadBalancers : Collections.emptyList();
         this.additionalFileSystem = Optional.ofNullable(additionalFileSystem);
+        this.gatewayUserData = gatewayUserData;
+        this.coreUserData = coreUserData;
     }
 
     public CloudStack replaceImage(Image newImage) {
         return new CloudStack(groups, network, newImage, parameters, tags, template, instanceAuthentication, loginUserName, publicKey,
-                fileSystem.orElse(null), loadBalancers, additionalFileSystem.orElse(null));
+                fileSystem.orElse(null), loadBalancers, additionalFileSystem.orElse(null), gatewayUserData, coreUserData);
     }
 
     public List<Group> getGroups() {
@@ -136,6 +146,22 @@ public class CloudStack {
 
     public List<CloudLoadBalancer> getLoadBalancers() {
         return loadBalancers;
+    }
+
+    public String getGatewayUserData() {
+        return gatewayUserData;
+    }
+
+    public String getCoreUserData() {
+        return coreUserData;
+    }
+
+    public String getUserDataByType(InstanceGroupType key) {
+        if (key.equals(InstanceGroupType.CORE)) {
+            return coreUserData;
+        } else {
+            return gatewayUserData;
+        }
     }
 
     @Override

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Image.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Image.java
@@ -19,6 +19,7 @@ public class Image {
 
     private final String imageName;
 
+    @Deprecated
     private Map<InstanceGroupType, String> userdata;
 
     private final String os;
@@ -56,15 +57,13 @@ public class Image {
         return imageName;
     }
 
-    public String getUserDataByType(InstanceGroupType key) {
-        return userdata.get(key);
-    }
-
     public Map<InstanceGroupType, String> getUserdata() {
         return userdata;
     }
 
     public void setUserdata(Map<InstanceGroupType, String> userdata) {
+        // This is a deprecated field because of FedRAMP we moved this value into vault. Old clusters still
+        // using this value but the new clusters using stack.coreUserData and stack.gatewayUserData
         this.userdata = userdata;
     }
 

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelper.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelper.java
@@ -29,7 +29,6 @@ import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
-import com.sequenceiq.common.api.type.InstanceGroupType;
 
 import software.amazon.awssdk.services.cloudformation.model.CreateStackRequest;
 import software.amazon.awssdk.services.cloudformation.model.DeleteStackRequest;
@@ -130,10 +129,10 @@ public class AwsStackRequestHelper {
         }
 
         Collection<Parameter> parameters = new ArrayList<>();
-        if (stack.getImage().getUserDataByType(InstanceGroupType.CORE) != null) {
-            addParameterChunks(parameters, "CBUserData", stack.getImage().getUserDataByType(InstanceGroupType.CORE), CHUNK_COUNT);
+        if (stack.getCoreUserData() != null) {
+            addParameterChunks(parameters, "CBUserData", stack.getCoreUserData(), CHUNK_COUNT);
         }
-        addParameterChunks(parameters, "CBGateWayUserData", stack.getImage().getUserDataByType(InstanceGroupType.GATEWAY), CHUNK_COUNT);
+        addParameterChunks(parameters, "CBGateWayUserData", stack.getGatewayUserData(), CHUNK_COUNT);
         parameters.addAll(asList(
                 Parameter.builder().parameterKey("StackName").parameterValue(stackName).build(),
                 Parameter.builder().parameterKey("KeyName").parameterValue(keyPairName).build(),

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsValidatorsTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsValidatorsTest.java
@@ -146,7 +146,7 @@ class AwsValidatorsTest {
         CloudInstance instance = new CloudInstance("", template, null, "subnet-1", "az1");
         Group group = new Group("worker", InstanceGroupType.CORE, List.of(instance), null, null, null, "", "", 0, Optional.empty(), createGroupNetwork(),
                 emptyMap());
-        CloudStack cloudStack = new CloudStack(List.of(group), null, null, Map.of(), Map.of(), "", null, "", "", null);
+        CloudStack cloudStack = new CloudStack(List.of(group), null, null, Map.of(), Map.of(), "", null, "", "", null, null, null);
         awsStackValidatorUnderTest.validate(authenticatedContext, cloudStack);
     }
 
@@ -229,7 +229,8 @@ class AwsValidatorsTest {
     }
 
     private CloudStack getTestCloudStackWithTags(Map<String, String> tags) {
-        return new CloudStack(List.of(), null, null, Map.of(), tags, "", null, null, null, null);
+        return new CloudStack(List.of(), null, null, Map.of(), tags,
+                "", null, null, null, null, null, null);
     }
 
     private GroupNetwork createGroupNetwork() {

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderTest.java
@@ -782,7 +782,7 @@ public class CloudFormationTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 "publickey", ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         CloudStack cloudStack = new CloudStack(groups, new Network(new Subnet(CIDR)), image, emptyMap(), emptyMap(), "template",
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), "publicKey", null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), "publicKey", null, null, null);
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -815,7 +815,7 @@ public class CloudFormationTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 "publickey", ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         CloudStack cloudStack = new CloudStack(groups, new Network(new Subnet(CIDR)), image, emptyMap(), emptyMap(), "template",
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), "publicKey", null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), "publicKey", null, null, null);
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -845,7 +845,7 @@ public class CloudFormationTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 "publickey", ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         CloudStack cloudStack = new CloudStack(groups, new Network(new Subnet(CIDR)), image, emptyMap(), emptyMap(), "template",
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), "publicKey", null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), "publicKey", null, null, null);
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -1581,7 +1581,7 @@ public class CloudFormationTemplateBuilderTest {
     private CloudStack createDefaultCloudStack(Collection<Group> groups, Map<String, String> parameters, Map<String, String> tags) {
         Network network = new Network(new Subnet("testSubnet"));
         return new CloudStack(groups, network, image, parameters, tags, null, instanceAuthentication,
-                instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
     }
 
     private Group createDefaultGroupMasterGroup(Optional<CloudFileSystemView> cloudFileSystemView) {

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/ComponentTestUtil.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/ComponentTestUtil.java
@@ -122,7 +122,7 @@ public class ComponentTestUtil {
         Image image = new Image("cb-centos66-amb200-2015-05-25", userData, "redhat6", "redhat6", "", "default", "default-id", new HashMap<>());
 
         String template = configuration.getTemplate(LATEST_AWS_CLOUD_FORMATION_TEMPLATE_PATH, "UTF-8").toString();
-        return new CloudStack(groups, network, image, Map.of(), Map.of(), template, instanceAuthentication, LOGIN_USER_NAME, PUBLIC_KEY, null);
+        return new CloudStack(groups, network, image, Map.of(), Map.of(), template, instanceAuthentication, LOGIN_USER_NAME, PUBLIC_KEY, null, null, null);
     }
 
     public CloudStack getStackForLaunch(InstanceStatus createRequested, InstanceStatus createRequested1) throws IOException {
@@ -146,7 +146,8 @@ public class ComponentTestUtil {
 
         SpiFileSystem efsFileSystem = getEfsFileSystem();
 
-        return new CloudStack(groups, network, image, Map.of(), Map.of(), template, instanceAuthentication, LOGIN_USER_NAME, PUBLIC_KEY, efsFileSystem);
+        return new CloudStack(groups, network, image, Map.of(), Map.of(), template, instanceAuthentication,
+                LOGIN_USER_NAME, PUBLIC_KEY, efsFileSystem, null, null);
     }
 
     private SpiFileSystem getEfsFileSystem() {

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleServiceTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleServiceTest.java
@@ -169,7 +169,7 @@ class AwsUpscaleServiceTest {
         tags.put("owner", "cbuser");
         tags.put("created", "yesterday");
         CloudStack cloudStack = new CloudStack(groups, getNetwork(), null, emptyMap(), tags, null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
 
         List<CloudResource> cloudResourceList = Collections.emptyList();
         AdjustmentTypeWithThreshold adjustmentTypeWithThreshold = new AdjustmentTypeWithThreshold(AdjustmentType.EXACT, 0L);
@@ -229,7 +229,7 @@ class AwsUpscaleServiceTest {
         groups.add(worker);
 
         CloudStack cloudStack = new CloudStack(groups, getNetwork(), null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
 
         List<CloudResource> cloudResourceList = Collections.emptyList();
 
@@ -307,7 +307,7 @@ class AwsUpscaleServiceTest {
         groups.add(worker);
 
         CloudStack cloudStack = new CloudStack(groups, getNetwork(), null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
 
         List<CloudResource> cloudResourceList = Collections.emptyList();
 
@@ -392,7 +392,7 @@ class AwsUpscaleServiceTest {
         tags.put("owner", "cbuser");
         tags.put("created", "yesterday");
         CloudStack cloudStack = new CloudStack(groups, getNetwork(), null, emptyMap(), tags, null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, loadBalancers);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, loadBalancers, null, null);
 
         List<CloudResource> cloudResourceList = Collections.emptyList();
         AdjustmentTypeWithThreshold adjustmentTypeWithThreshold = new AdjustmentTypeWithThreshold(AdjustmentType.EXACT, 0L);

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/connector/resource/AwsNetworkServiceTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/connector/resource/AwsNetworkServiceTest.java
@@ -81,7 +81,7 @@ public class AwsNetworkServiceTest {
         networkParameters.put("internetGatewayId", "igw-12345678");
         Network network = new Network(new Subnet(null), networkParameters);
         CloudStack cloudStack = new CloudStack(singletonList(group1), network, null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
         AuthenticatedContext authenticatedContext = mock(AuthenticatedContext.class);
         CloudContext cloudContext = mock(CloudContext.class);
         Location location = mock(Location.class);
@@ -124,7 +124,7 @@ public class AwsNetworkServiceTest {
         networkParameters.put("internetGatewayId", "igw-12345678");
         Network network = new Network(new Subnet(null), networkParameters);
         CloudStack cloudStack = new CloudStack(singletonList(group1), network, null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
         AuthenticatedContext authenticatedContext = mock(AuthenticatedContext.class);
         CloudContext cloudContext = mock(CloudContext.class);
         Location location = mock(Location.class);
@@ -165,7 +165,7 @@ public class AwsNetworkServiceTest {
         networkParameters.put("internetGatewayId", "igw-12345678");
         Network network = new Network(new Subnet(null), networkParameters);
         CloudStack cloudStack = new CloudStack(singletonList(group1), network, null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
         AuthenticatedContext authenticatedContext = mock(AuthenticatedContext.class);
         CloudContext cloudContext = mock(CloudContext.class);
         Location location = mock(Location.class);
@@ -206,7 +206,7 @@ public class AwsNetworkServiceTest {
         networkParameters.put("internetGatewayId", "igw-12345678");
         Network network = new Network(new Subnet(null), networkParameters);
         CloudStack cloudStack = new CloudStack(singletonList(group1), network, null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
         AuthenticatedContext authenticatedContext = mock(AuthenticatedContext.class);
         CloudContext cloudContext = mock(CloudContext.class);
         Location location = mock(Location.class);
@@ -246,7 +246,7 @@ public class AwsNetworkServiceTest {
         networkParameters.put("internetGatewayId", "igw-12345678");
         Network network = new Network(new Subnet(null), networkParameters);
         CloudStack cloudStack = new CloudStack(singletonList(group1), network, null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
         AuthenticatedContext authenticatedContext = mock(AuthenticatedContext.class);
         CloudContext cloudContext = mock(CloudContext.class);
         Location location = mock(Location.class);
@@ -282,7 +282,7 @@ public class AwsNetworkServiceTest {
         networkParameters.put("internetGatewayId", "igw-12345678");
         Network network = new Network(new Subnet(null), networkParameters);
         CloudStack cloudStack = new CloudStack(singletonList(group1), network, null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
         AuthenticatedContext authenticatedContext = mock(AuthenticatedContext.class);
         CloudContext cloudContext = mock(CloudContext.class);
         Location location = mock(Location.class);
@@ -316,7 +316,7 @@ public class AwsNetworkServiceTest {
         networkParameters.put("internetGatewayId", "igw-12345678");
         Network network = new Network(new Subnet(null), networkParameters);
         CloudStack cloudStack = new CloudStack(singletonList(group1), network, null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
         AuthenticatedContext authenticatedContext = mock(AuthenticatedContext.class);
         CloudContext cloudContext = mock(CloudContext.class);
         Location location = mock(Location.class);
@@ -356,7 +356,7 @@ public class AwsNetworkServiceTest {
         networkParameters.put("internetGatewayId", "igw-12345678");
         Network network = new Network(new Subnet(null), networkParameters);
         CloudStack cloudStack = new CloudStack(singletonList(group1), network, null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
         AuthenticatedContext authenticatedContext = mock(AuthenticatedContext.class);
         CloudContext cloudContext = mock(CloudContext.class);
         Location location = mock(Location.class);
@@ -396,7 +396,7 @@ public class AwsNetworkServiceTest {
         networkParameters.put("internetGatewayId", "igw-12345678");
         Network network = new Network(new Subnet(null), networkParameters);
         CloudStack cloudStack = new CloudStack(singletonList(group1), network, null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
         AuthenticatedContext authenticatedContext = mock(AuthenticatedContext.class);
         CloudContext cloudContext = mock(CloudContext.class);
         Location location = mock(Location.class);
@@ -440,7 +440,7 @@ public class AwsNetworkServiceTest {
         networkParameters.put("internetGatewayId", "igw-12345678");
         Network network = new Network(new Subnet(null), networkParameters);
         CloudStack cloudStack = new CloudStack(singletonList(group1), network, null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
         AuthenticatedContext authenticatedContext = mock(AuthenticatedContext.class);
         CloudContext cloudContext = mock(CloudContext.class);
         Location location = mock(Location.class);
@@ -484,7 +484,7 @@ public class AwsNetworkServiceTest {
         networkParameters.put("internetGatewayId", "igw-12345678");
         Network network = new Network(new Subnet(null), networkParameters);
         CloudStack cloudStack = new CloudStack(singletonList(group1), network, null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
         AuthenticatedContext authenticatedContext = mock(AuthenticatedContext.class);
         CloudContext cloudContext = mock(CloudContext.class);
         Location location = mock(Location.class);
@@ -528,7 +528,7 @@ public class AwsNetworkServiceTest {
         networkParameters.put("internetGatewayId", "igw-12345678");
         Network network = new Network(new Subnet(null), networkParameters);
         CloudStack cloudStack = new CloudStack(singletonList(group1), network, null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
         AuthenticatedContext authenticatedContext = mock(AuthenticatedContext.class);
         CloudContext cloudContext = mock(CloudContext.class);
         Location location = mock(Location.class);
@@ -572,7 +572,7 @@ public class AwsNetworkServiceTest {
         networkParameters.put("internetGatewayId", "igw-12345678");
         Network network = new Network(new Subnet(null), networkParameters);
         CloudStack cloudStack = new CloudStack(singletonList(group1), network, null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
         AuthenticatedContext authenticatedContext = mock(AuthenticatedContext.class);
         CloudContext cloudContext = mock(CloudContext.class);
         Location location = mock(Location.class);
@@ -618,7 +618,7 @@ public class AwsNetworkServiceTest {
         networkParameters.put("internetGatewayId", "igw-12345678");
         Network network = new Network(new Subnet(null), networkParameters);
         CloudStack cloudStack = new CloudStack(singletonList(group1), network, null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
         AuthenticatedContext authenticatedContext = mock(AuthenticatedContext.class);
         CloudContext cloudContext = mock(CloudContext.class);
         Location location = mock(Location.class);

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsStorageValidatorsTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsStorageValidatorsTest.java
@@ -133,7 +133,7 @@ public class AwsStorageValidatorsTest {
                 List.of(noStorageInstance), null, null, null, "", "", 0, Optional.empty(), createGroupNetwork(), emptyMap());
         Group storageGroup = new Group("compute", InstanceGroupType.CORE,
                 List.of(storageInstance), null, null, null, "", "", 0, Optional.empty(), createGroupNetwork(), emptyMap());
-        CloudStack cloudStack = new CloudStack(List.of(noStoragegroup, storageGroup), null, null, Map.of(), Map.of(), "", null, "", "", null);
+        CloudStack cloudStack = new CloudStack(List.of(noStoragegroup, storageGroup), null, null, Map.of(), Map.of(), "", null, "", "", null, null, null);
 
         CloudVmTypes cloudVmTypes = new CloudVmTypes();
         VmType storageType = VmType.vmTypeWithMeta("storage", VmTypeMeta.VmTypeMetaBuilder.builder()
@@ -217,7 +217,7 @@ public class AwsStorageValidatorsTest {
 
     private CloudStack getTestCloudStackWithTags(Map<String, String> tags) {
         return new CloudStack(List.of(), null, null, Map.of(), tags,
-                "", null, null, null, null);
+                "", null, null, null, null, null, null);
     }
 
     private GroupNetwork createGroupNetwork() {

--- a/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilder.java
+++ b/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilder.java
@@ -258,7 +258,7 @@ public class AwsNativeInstanceResourceBuilder extends AbstractAwsNativeComputeBu
     }
 
     private String getUserData(CloudStack cloudStack, Group group) {
-        String userdata = cloudStack.getImage().getUserDataByType(group.getType());
+        String userdata = cloudStack.getUserDataByType(group.getType());
         String base64EncodedUserData = "";
         if (StringUtils.isNotEmpty(userdata)) {
             base64EncodedUserData = Base64.getEncoder().encodeToString(userdata.getBytes());

--- a/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/loadbalancer/AwsNativeLoadBalancerLaunchServiceTest.java
+++ b/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/loadbalancer/AwsNativeLoadBalancerLaunchServiceTest.java
@@ -859,7 +859,7 @@ class AwsNativeLoadBalancerLaunchServiceTest {
 
     private CloudStack getCloudStack() {
         Network network = new Network(new Subnet("10.0.0.0/16"), Map.of(NetworkConstants.VPC_ID, "vpc-avpcarn"));
-        return new CloudStack(List.of(), network, null, Map.of(), Map.of(), null, null, null, null, null, null);
+        return new CloudStack(List.of(), network, null, Map.of(), Map.of(), null, null, null, null, null, null, null, null);
     }
 
     private AwsLoadBalancer getAwsLoadBalancer() {

--- a/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsGatewaySubnetMultiAzValidatorTest.java
+++ b/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsGatewaySubnetMultiAzValidatorTest.java
@@ -134,7 +134,7 @@ class AwsGatewaySubnetMultiAzValidatorTest {
     }
 
     private CloudStack getCloudStack(Collection<Group> groups) {
-        return new CloudStack(groups, null, null, Map.of(), Map.of(), "", null, "", "", null);
+        return new CloudStack(groups, null, null, Map.of(), Map.of(), "", null, "", "", null, null, null);
     }
 
     private Group getGroup(String groupName, InstanceGroupType groupType, GroupNetwork groupNetwork) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
@@ -29,7 +29,6 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
-import com.sequenceiq.common.api.type.InstanceGroupType;
 
 import freemarker.template.Configuration;
 import freemarker.template.Template;
@@ -112,8 +111,8 @@ public class AzureTemplateBuilder {
             model.put("igs", armStack.getInstanceGroups());
             model.put("securities", armSecurityView.getPorts());
             model.put("securityGroups", armSecurityView.getSecurityGroupIds());
-            model.put("corecustomData", base64EncodedUserData(cloudStack.getImage().getUserDataByType(InstanceGroupType.CORE)));
-            model.put("gatewaycustomData", base64EncodedUserData(cloudStack.getImage().getUserDataByType(InstanceGroupType.GATEWAY)));
+            model.put("corecustomData", base64EncodedUserData(cloudStack.getCoreUserData()));
+            model.put("gatewaycustomData", base64EncodedUserData(cloudStack.getGatewayUserData()));
             model.put("disablePasswordAuthentication", !azureInstanceCredentialView.passwordAuthenticationRequired());
             model.put("existingVPC", azureUtils.isExistingNetwork(network));
             model.put("resourceGroupName", azureUtils.getCustomResourceGroupName(network));

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
@@ -269,7 +269,8 @@ public class AzureTemplateBuilderTest {
         userDefinedTags.put("testtagkey2", "testtagvalue2");
 
         cloudStack = new CloudStack(groups, network, image, parameters, userDefinedTags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
         //WHEN
         when(azureStorage.getImageStorageName(any(AzureCredentialView.class), any(CloudContext.class), any(CloudStack.class))).thenReturn("test");
@@ -307,7 +308,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -340,7 +342,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -374,7 +377,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -409,7 +413,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -441,7 +446,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -473,7 +479,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -512,7 +519,8 @@ public class AzureTemplateBuilderTest {
         loadBalancers.add(loadBalancer);
 
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, loadBalancers);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, loadBalancers, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -556,7 +564,8 @@ public class AzureTemplateBuilderTest {
         loadBalancers.add(loadBalancer);
 
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, loadBalancers);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, loadBalancers, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -601,7 +610,8 @@ public class AzureTemplateBuilderTest {
         loadBalancers.add(loadBalancer);
 
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, loadBalancers);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, loadBalancers, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -650,7 +660,8 @@ public class AzureTemplateBuilderTest {
         loadBalancers.add(outboundLb);
 
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, loadBalancers);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, loadBalancers, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -726,7 +737,8 @@ public class AzureTemplateBuilderTest {
         loadBalancers.add(loadBalancer);
 
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, loadBalancers);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, loadBalancers, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -768,7 +780,8 @@ public class AzureTemplateBuilderTest {
         loadBalancers.add(privateLb);
 
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, loadBalancers);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, loadBalancers, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -826,7 +839,8 @@ public class AzureTemplateBuilderTest {
         loadBalancers.add(privateLb);
 
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, loadBalancers);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, loadBalancers, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -888,7 +902,8 @@ public class AzureTemplateBuilderTest {
         loadBalancers.add(privateLb);
 
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, loadBalancers);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, loadBalancers, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -933,7 +948,8 @@ public class AzureTemplateBuilderTest {
         loadBalancers.add(privateLb);
 
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, loadBalancers);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, loadBalancers, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -995,7 +1011,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -1030,7 +1047,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -1066,7 +1084,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -1105,7 +1124,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -1142,7 +1162,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -1177,7 +1198,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -1212,7 +1234,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -1249,7 +1272,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -1285,7 +1309,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -1322,7 +1347,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -1369,7 +1395,8 @@ public class AzureTemplateBuilderTest {
         groups.add(coreGroup);
 
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -1409,7 +1436,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -1444,7 +1472,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -1484,7 +1513,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE,
                 Optional.of(cloudAdlsGen2View), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -1523,7 +1553,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN
@@ -1562,7 +1593,8 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), ROOT_VOLUME_SIZE, Optional.empty(), createGroupNetwork(), emptyMap()));
         cloudStack = new CloudStack(groups, network, image, parameters, tags, azureTemplateBuilder.getTemplateString(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(),
+                null, GATEWAY_CUSTOM_DATA, CORE_CUSTOM_DATA);
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy, Collections.emptyMap());
 
         //WHEN

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureImageFormatValidatorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureImageFormatValidatorTest.java
@@ -67,7 +67,7 @@ public class AzureImageFormatValidatorTest {
     @Test
     void testImageHasValidVhdFormat() {
         Image image = new Image(VALID_IMAGE_NAME, new HashMap<>(), "centos7", "redhat7", "", "default", "default-id", new HashMap<>());
-        cloudStack = new CloudStack(List.of(), null, image, Map.of(), Map.of(), null, null, null, null, null);
+        cloudStack = new CloudStack(List.of(), null, image, Map.of(), Map.of(), null, null, null, null, null, null, null);
         when(entitlementService.azureOnlyMarketplaceImagesEnabled(TEST_ACCOUNT_ID)).thenReturn(false);
 
         ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.validate(authenticatedContext, cloudStack));
@@ -79,7 +79,7 @@ public class AzureImageFormatValidatorTest {
     @Test
     void testVhdImageOnlyAzureMarketplaceImageAllowed() {
         Image image = new Image(VALID_IMAGE_NAME, new HashMap<>(), "centos7", "redhat7", "", "default", "default-id", new HashMap<>());
-        cloudStack = new CloudStack(List.of(), null, image, Map.of(), Map.of(), null, null, null, null, null);
+        cloudStack = new CloudStack(List.of(), null, image, Map.of(), Map.of(), null, null, null, null, null, null, null);
         when(entitlementService.azureOnlyMarketplaceImagesEnabled(TEST_ACCOUNT_ID)).thenReturn(true);
 
         CloudConnectorException exception = Assertions.assertThrows(CloudConnectorException.class,
@@ -97,7 +97,7 @@ public class AzureImageFormatValidatorTest {
     void testImageHasValidMarketplaceFormatNoEntitlement() {
         Image image = new Image(MARKETPLACE_IMAGE_NAME, new HashMap<>(), "centos7", "redhat7", "", "default",
                 "default-id", new HashMap<>());
-        cloudStack = new CloudStack(List.of(), null, image, Map.of(), Map.of(), null, null, null, null, null);
+        cloudStack = new CloudStack(List.of(), null, image, Map.of(), Map.of(), null, null, null, null, null, null, null);
 
         when(entitlementService.azureMarketplaceImagesEnabled(TEST_ACCOUNT_ID)).thenReturn(false);
 
@@ -111,7 +111,7 @@ public class AzureImageFormatValidatorTest {
     void testImageHasValidMarketplaceFormatEntitlement() {
         Image image = new Image(MARKETPLACE_IMAGE_NAME, new HashMap<>(), "centos7", "redhat7", "", "default",
                 "default-id", new HashMap<>());
-        cloudStack = new CloudStack(List.of(), null, image, Map.of(), Map.of(), null, null, null, null, null);
+        cloudStack = new CloudStack(List.of(), null, image, Map.of(), Map.of(), null, null, null, null, null, null, null);
 
         setupAuthenticatedContext();
         when(entitlementService.azureMarketplaceImagesEnabled(TEST_ACCOUNT_ID)).thenReturn(true);
@@ -127,7 +127,7 @@ public class AzureImageFormatValidatorTest {
     void testImageHasValidMarketplaceFormatEntitlementNoTermsAccepted() {
         Image image = new Image(MARKETPLACE_IMAGE_NAME, new HashMap<>(), "centos7", "redhat7", "", "default",
                 "default-id", new HashMap<>());
-        cloudStack = new CloudStack(List.of(), null, image, Map.of(), Map.of(), null, null, null, null, null);
+        cloudStack = new CloudStack(List.of(), null, image, Map.of(), Map.of(), null, null, null, null, null, null, null);
         setupAuthenticatedContext();
         when(entitlementService.azureMarketplaceImagesEnabled(TEST_ACCOUNT_ID)).thenReturn(true);
         when(azureImageTermsSignerService.isSigned(anyString(), any(), any())).thenReturn(false);
@@ -148,7 +148,7 @@ public class AzureImageFormatValidatorTest {
     void testImageHasInvalidFormat() {
         Image image = new Image(INVALID_IMAGE_NAME, new HashMap<>(), "centos7", "redhat7", "", "default",
                 "default-id", new HashMap<>());
-        cloudStack = new CloudStack(List.of(), null, image, Map.of(), Map.of(), null, null, null, null, null);
+        cloudStack = new CloudStack(List.of(), null, image, Map.of(), Map.of(), null, null, null, null, null, null, null);
 
         CloudConnectorException exception = Assertions.assertThrows(CloudConnectorException.class,
                 () -> ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.validate(authenticatedContext, cloudStack)));

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilder.java
@@ -182,7 +182,7 @@ public class GcpInstanceResourceBuilder extends AbstractGcpComputeBuilder {
 
         Items startupScript = new Items();
         startupScript.setKey("startup-script");
-        startupScript.setValue(cloudStack.getImage().getUserDataByType(group.getType()));
+        startupScript.setValue(cloudStack.getUserDataByType(group.getType()));
 
         metadata.getItems().add(sshMetaData);
         metadata.getItems().add(startupScript);

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpAttachedDiskResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpAttachedDiskResourceBuilderTest.java
@@ -189,8 +189,8 @@ public class GcpAttachedDiskResourceBuilderTest {
         Map<InstanceGroupType, String> userData = ImmutableMap.of(InstanceGroupType.CORE, "CORE", InstanceGroupType.GATEWAY, "GATEWAY");
         Image image = new Image("cb-centos66-amb200-2015-05-25", userData, "redhat6", "redhat6", "", "default",
                 "default-id", new HashMap<>());
-        cloudStack = new CloudStack(emptyList(), null, image, emptyMap(), emptyMap(), null,
-                null, null, null, null);
+        cloudStack = new CloudStack(Collections.emptyList(), null, image, emptyMap(), emptyMap(), null,
+                null, null, null, null, null, null);
 
         when(intermediateBuilderExecutor.submit(any(Callable.class))).thenAnswer(invocation -> {
             Callable<Void> callable = invocation.getArgument(0);

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilderTest.java
@@ -175,8 +175,8 @@ class GcpDiskResourceBuilderTest {
         Map<InstanceGroupType, String> userData = ImmutableMap.of(InstanceGroupType.CORE, "CORE", InstanceGroupType.GATEWAY, "GATEWAY");
         Image image = new Image("cb-centos66-amb200-2015-05-25", userData, "redhat6", "redhat6", "", "default",
                 "default-id", new HashMap<>());
-        cloudStack = new CloudStack(emptyList(), null, image, emptyMap(), emptyMap(), null,
-                null, null, null, null);
+        cloudStack = new CloudStack(Collections.emptyList(), null, image, emptyMap(), emptyMap(), null,
+                null, null, null, null, null, null);
 
         Operation operation = new Operation();
         operation.setName("operation");

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -203,8 +204,8 @@ public class GcpInstanceResourceBuilderTest {
         ReflectionTestUtils.setField(resourceNameService, "maxResourceNameLength", 50);
         ReflectionTestUtils.setField(builder, "resourceNameService", resourceNameService);
         Network network = new Network(null);
-        cloudStack = new CloudStack(emptyList(), network, image, emptyMap(), emptyMap(), null,
-                null, null, null, null);
+        cloudStack = new CloudStack(Collections.emptyList(), network, image, emptyMap(), emptyMap(), null,
+                null, null, null, null, null, null);
     }
 
     @Test
@@ -304,7 +305,7 @@ public class GcpInstanceResourceBuilderTest {
         context.addComputeResources(0L, buildableResources);
         cloudStack = new CloudStack(singletonList(group), new Network(null), image,
                 ImmutableMap.of(CLOUD_STACK_TYPE_PARAMETER, FREEIPA_STACK_TYPE), emptyMap(), null,
-                null, null, null, null);
+                null, null, null, null, null, null);
 
         // WHEN
         when(compute.instances()).thenReturn(instances);
@@ -358,7 +359,7 @@ public class GcpInstanceResourceBuilderTest {
 
         CloudStack cloudStack = new CloudStack(emptyList(), new Network(null), image,
                 emptyMap(), emptyMap(), null, null, null, null,
-                new SpiFileSystem("test", FileSystemType.GCS, List.of(cloudGcsView)));
+                new SpiFileSystem("test", FileSystemType.GCS, List.of(cloudGcsView)), null, null);
 
         Group group = newGroupWithParams(ImmutableMap.of(), cloudGcsView);
         List<CloudResource> buildableResources = builder.create(context, group.getInstances().get(0), privateId, authenticatedContext, group, image);

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpBackendServiceResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpBackendServiceResourceBuilderTest.java
@@ -97,7 +97,7 @@ public class GcpBackendServiceResourceBuilderTest {
         ReflectionTestUtils.setField(underTest, "resourceNameService", resourceNameService);
         Network network = new Network(null);
         cloudStack = new CloudStack(Collections.emptyList(), network, image, emptyMap(), emptyMap(), null,
-                null, null, null, null);
+                null, null, null, null, null, null);
     }
 
     @Test

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpForwardingRuleResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpForwardingRuleResourceBuilderTest.java
@@ -115,7 +115,7 @@ class GcpForwardingRuleResourceBuilderTest {
         ReflectionTestUtils.setField(underTest, "resourceNameService", resourceNameService);
         Network network = new Network(null);
         cloudStack = new CloudStack(Collections.emptyList(), network, image, emptyMap(), emptyMap(), null,
-                null, null, null, null);
+                null, null, null, null, null, null);
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("hcport", 8080);
         parameters.put("trafficport", 8080);

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpHealthCheckResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpHealthCheckResourceBuilderTest.java
@@ -86,7 +86,7 @@ public class GcpHealthCheckResourceBuilderTest {
         ReflectionTestUtils.setField(underTest, "resourceNameService", resourceNameService);
         Network network = new Network(null);
         cloudStack = new CloudStack(Collections.emptyList(), network, image, emptyMap(), emptyMap(), null,
-                null, null, null, null);
+                null, null, null, null, null, null);
     }
 
     @Test

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/util/GcpLabelUtilTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/util/GcpLabelUtilTest.java
@@ -26,7 +26,7 @@ class GcpLabelUtilTest {
         tags.put(CREATOR_CRN, "crn:altus:timbuk2:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:user:05ca1026-c028-466b-8943-b04f765fa3f6");
         tags.put(RESOURCE_CRN, "crn:cdp:freeipa:us-west-2:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:freeipa:8111d534-8c7e-4a68-a8ba-7ebb389a3a20");
         tags.put(ENVIRONMENT_CRN, "crn:cdp:environments:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:environment:12474ddc-6e44-4f4c-806a-b197ef12cbb8");
-        CloudStack cloudStack = new CloudStack(new HashSet<>(), null, null, new HashMap<>(), tags, null, null, null, null, null);
+        CloudStack cloudStack = new CloudStack(new HashSet<>(), null, null, new HashMap<>(), tags, null, null, null, null, null, null, null);
 
         Map<String, String> result = gcpLabelUtil.createLabelsFromTags(cloudStack);
 

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/ParameterGenerator.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/ParameterGenerator.java
@@ -106,7 +106,7 @@ public class ParameterGenerator {
         network.putParameter("publicNetId", "028ffc0c-63c5-4ca0-802a-3ac753eaf76c");
 
         return new CloudStack(groups, network, image, new HashMap<>(), new HashMap<>(), null, instanceAuthentication,
-                instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
     }
 
     public String getSshFingerprint() {

--- a/cloud-template/src/test/java/com/sequenceiq/cloudbreak/cloud/template/loadbalancer/LoadBalancerResourceServiceTest.java
+++ b/cloud-template/src/test/java/com/sequenceiq/cloudbreak/cloud/template/loadbalancer/LoadBalancerResourceServiceTest.java
@@ -98,7 +98,7 @@ public class LoadBalancerResourceServiceTest {
         context.addNetworkResources(networkResources);
         Network network = new Network(null);
         cloudStack = new CloudStack(Collections.emptyList(), network, image, emptyMap(), emptyMap(), null,
-                null, null, null, null);
+                null, null, null, null, null, null);
     }
 
     @Test

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
@@ -138,7 +138,7 @@ public class YarnResourceConnector implements ResourceConnector {
         YarnComponent component = new YarnComponent();
         component.setName(group.getName());
         component.setNumberOfContainers(group.getInstancesSize());
-        String userData = stack.getImage().getUserDataByType(group.getType());
+        String userData = stack.getUserDataByType(group.getType());
         component.setLaunchCommand(String.format("/bootstrap/start-systemd '%s' '%s' '%s'", Base64.getEncoder().encodeToString(userData.getBytes()),
                 stack.getLoginUserName(), stack.getPublicKey()));
         component.setArtifact(artifact);

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/loadbalancer/service/component/YarnLoadBalancerComponentFactoryService.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/loadbalancer/service/component/YarnLoadBalancerComponentFactoryService.java
@@ -126,7 +126,7 @@ public class YarnLoadBalancerComponentFactoryService {
      */
     private String createLoadBalancerLaunchCommand(CloudStack cloudStack) {
         return String.format("/bootstrap/start-systemd '%s' '%s' '%s'",
-                Base64.getEncoder().encodeToString(cloudStack.getImage().getUserDataByType(InstanceGroupType.CORE).getBytes()),
+                Base64.getEncoder().encodeToString(cloudStack.getUserDataByType(InstanceGroupType.CORE).getBytes()),
                 cloudStack.getLoginUserName(), cloudStack.getPublicKey());
     }
 

--- a/cloud-yarn/src/test/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnectorTest.java
+++ b/cloud-yarn/src/test/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnectorTest.java
@@ -141,7 +141,7 @@ public class YarnResourceConnectorTest {
         when(stackMock.getGroups()).thenReturn(groupList);
         when(stackMock.getLoginUserName()).thenReturn(LOGIN_USER_NAME);
         when(stackMock.getPublicKey()).thenReturn(PUBLIC_KEY);
-        when(imageMock.getUserDataByType(InstanceGroupType.CORE)).thenReturn(USER_DATA);
+        when(stackMock.getUserDataByType(InstanceGroupType.CORE)).thenReturn(USER_DATA);
         when(cloudInstanceMock.getTemplate()).thenReturn(instanceTemplateMock);
         when(instanceTemplateMock.getParameter(PlatformParametersConsts.CUSTOM_INSTANCETYPE_CPUS, Integer.class)).thenReturn(2);
         when(instanceTemplateMock.getParameter(PlatformParametersConsts.CUSTOM_INSTANCETYPE_MEMORY, Integer.class)).thenReturn(4096);

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/Userdata.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/Userdata.java
@@ -117,6 +117,7 @@ public class Userdata implements ProvisionEntity, AccountIdAwareResource {
         return "Userdata{" +
                 "id=" + id +
                 ", accountId='" + accountId + '\'' +
+                ", stackId='" + stack.getId() + '\'' +
                 '}';
     }
 }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/Userdata.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/Userdata.java
@@ -1,0 +1,122 @@
+package com.sequenceiq.cloudbreak.domain;
+
+import java.util.Objects;
+
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.SequenceGenerator;
+
+import com.sequenceiq.cloudbreak.common.dal.model.AccountIdAwareResource;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.secret.SecretValue;
+import com.sequenceiq.cloudbreak.service.secret.domain.Secret;
+import com.sequenceiq.cloudbreak.service.secret.domain.SecretToString;
+
+@Entity
+public class Userdata implements ProvisionEntity, AccountIdAwareResource {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "userdata_generator")
+    @SequenceGenerator(name = "userdata_generator", sequenceName = "userdata_id_seq", allocationSize = 1)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Stack stack;
+
+    @Convert(converter = SecretToString.class)
+    @SecretValue
+    private Secret gatewayUserdata = Secret.EMPTY;
+
+    @Convert(converter = SecretToString.class)
+    @SecretValue
+    private Secret coreUserdata = Secret.EMPTY;
+
+    private String accountId;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Stack getStack() {
+        return stack;
+    }
+
+    public void setStack(Stack stack) {
+        this.stack = stack;
+    }
+
+    public String getGatewayUserdata() {
+        return gatewayUserdata.getRaw();
+    }
+
+    public String getGatewayUserdataSecret() {
+        return gatewayUserdata.getSecret();
+    }
+
+    public void setGatewayUserdata(String gatewayUserdata) {
+        if (gatewayUserdata != null) {
+            this.gatewayUserdata = new Secret(gatewayUserdata);
+        }
+    }
+
+    public String getCoreUserdata() {
+        return coreUserdata.getRaw();
+    }
+
+    public String getCoreUserdataSecret() {
+        return coreUserdata.getSecret();
+    }
+
+    public void setCoreUserdata(String coreUserdata) {
+        if (coreUserdata != null) {
+            this.coreUserdata = new Secret(coreUserdata);
+        }
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    @Override
+    public String getAccountId() {
+        return accountId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Userdata userdata = (Userdata) o;
+        return Objects.equals(id, userdata.id)
+                && Objects.equals(stack, userdata.stack)
+                && Objects.equals(gatewayUserdata, userdata.gatewayUserdata)
+                && Objects.equals(coreUserdata, userdata.coreUserdata)
+                && Objects.equals(accountId, userdata.accountId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, gatewayUserdata, coreUserdata, accountId);
+    }
+
+    @Override
+    public String toString() {
+        return "Userdata{" +
+                "id=" + id +
+                ", accountId='" + accountId + '\'' +
+                '}';
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
@@ -97,6 +97,7 @@ import com.sequenceiq.cloudbreak.workspace.model.WorkspaceAwareResource;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
 import com.sequenceiq.common.api.type.Tunnel;
+
 @Entity
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = { "workspace_id", "name", "resourceCrn" }))
 public class Stack implements ProvisionEntity, WorkspaceAwareResource, OrchestratorAware, StackView, StackDtoDelegate, IdAware {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
@@ -97,7 +97,6 @@ import com.sequenceiq.cloudbreak.workspace.model.WorkspaceAwareResource;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
 import com.sequenceiq.common.api.type.Tunnel;
-
 @Entity
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = { "workspace_id", "name", "resourceCrn" }))
 public class Stack implements ProvisionEntity, WorkspaceAwareResource, OrchestratorAware, StackView, StackDtoDelegate, IdAware {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/update/userdata/UserDataUpdateActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/update/userdata/UserDataUpdateActions.java
@@ -17,8 +17,8 @@ import org.springframework.statemachine.action.Action;
 
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.converter.spi.ResourceToCloudResourceConverter;
-import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.core.flow2.stack.StackContext;
 import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.dto.StackDtoDelegate;
@@ -29,6 +29,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.stack.userdata.UserDataUpdate
 import com.sequenceiq.cloudbreak.reactor.api.event.stack.userdata.UserDataUpdateRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.stack.userdata.UserDataUpdateSuccess;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
+import com.sequenceiq.cloudbreak.service.image.userdata.UserDataService;
 import com.sequenceiq.cloudbreak.service.resource.ResourceService;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.InstanceGroupType;
@@ -46,6 +47,9 @@ public class UserDataUpdateActions {
 
     @Inject
     private ResourceToCloudResourceConverter resourceToCloudResourceConverter;
+
+    @Inject
+    private UserDataService userDataService;
 
     @Bean(name = "UPDATE_USERDATA_STATE")
     public AbstractUserDataUpdateAction<?> updateUserData() {
@@ -71,8 +75,8 @@ public class UserDataUpdateActions {
                 StackDtoDelegate stack = context.getStack();
                 Map<InstanceGroupType, String> userData;
                 try {
-                    userData = imageService.getImage(stack.getId()).getUserdata();
-                } catch (CloudbreakImageNotFoundException e) {
+                    userData = userDataService.getUserData(stack.getId());
+                } catch (CloudbreakServiceException e) {
                     return new UserDataUpdateFailed(stack.getId(), e);
                 }
                 List<CloudResource> cloudResources = getCloudResources(stack.getId());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/ImageFallbackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/ImageFallbackService.java
@@ -22,7 +22,6 @@ import com.sequenceiq.cloudbreak.service.image.ImageService;
 import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.service.image.userdata.UserDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
-import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.view.StackView;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.model.ImageCatalogPlatform;
@@ -46,9 +45,6 @@ public class ImageFallbackService {
 
     @Inject
     private UserDataService userDataService;
-
-    @Inject
-    private StackService stackService;
 
     @Inject
     private PlatformStringTransformer platformStringTransformer;
@@ -80,7 +76,7 @@ public class ImageFallbackService {
                 currentImage.getImageId(),
                 currentImage.getPackageVersions())));
 
-        userDataService.updateUserData(stackId, userData);
+        userDataService.createOrUpdateUserData(stackId, userData);
         componentConfigProviderService.store(component);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/ImageFallbackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/ImageFallbackService.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.reactor.handler;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -18,8 +20,11 @@ import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
 import com.sequenceiq.cloudbreak.service.image.StatedImage;
+import com.sequenceiq.cloudbreak.service.image.userdata.UserDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.view.StackView;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.model.ImageCatalogPlatform;
 
 @Service
@@ -40,6 +45,12 @@ public class ImageFallbackService {
     private ImageService imageService;
 
     @Inject
+    private UserDataService userDataService;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
     private PlatformStringTransformer platformStringTransformer;
 
     public void fallbackToVhd(Long stackId) throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException, IOException {
@@ -58,15 +69,18 @@ public class ImageFallbackService {
         StatedImage image = imageCatalogService.getImage(stackView.getWorkspaceId(), currentImage.getImageCatalogUrl(),
                 currentImage.getImageCatalogName(), currentImage.getImageId());
         String imageName = imageService.determineImageNameByRegion(stackView.getCloudPlatform(), platformString, stackView.getRegion(), image.getImage());
+        Map<InstanceGroupType, String> userData = userDataService.getUserData(stackView.getId());
 
         component.setAttributes(new Json(new Image(imageName,
-                currentImage.getUserdata(),
+                new HashMap<>(),
                 currentImage.getOs(),
                 currentImage.getOsType(),
                 currentImage.getImageCatalogUrl(),
                 currentImage.getImageCatalogName(),
                 currentImage.getImageId(),
                 currentImage.getPackageVersions())));
+
+        userDataService.updateUserData(stackId, userData);
         componentConfigProviderService.store(component);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/UserdataRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/UserdataRepository.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.repository;
+
+import java.util.Optional;
+
+import javax.transaction.Transactional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.sequenceiq.cloudbreak.domain.Userdata;
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+
+@EntityType(entityClass = Userdata.class)
+@Transactional(Transactional.TxType.REQUIRED)
+public interface UserdataRepository extends JpaRepository<Userdata, Long> {
+
+    @Query("SELECT u FROM Userdata u WHERE u.stack.id = :stackId")
+    Optional<Userdata> findByStackId(Long stackId);
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/UserdataRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/UserdataRepository.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import javax.transaction.Transactional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import com.sequenceiq.cloudbreak.domain.Userdata;
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
@@ -14,7 +13,6 @@ import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 @Transactional(Transactional.TxType.REQUIRED)
 public interface UserdataRepository extends JpaRepository<Userdata, Long> {
 
-    @Query("SELECT u FROM Userdata u WHERE u.stack.id = :stackId")
     Optional<Userdata> findByStackId(Long stackId);
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/InstanceMetadataUpdater.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/InstanceMetadataUpdater.java
@@ -46,6 +46,7 @@ import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFa
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.cloudbreak.service.image.userdata.UserDataService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
@@ -73,6 +74,9 @@ public class InstanceMetadataUpdater {
     @Inject
     private StackService stackService;
 
+    @Inject
+    private UserDataService userDataService;
+
     public void updatePackageVersionsOnAllInstances(Long stackId) throws Exception {
         Stack stack = getStackForFreshInstanceStatuses(stackId);
         GatewayConfig gatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
@@ -85,7 +89,7 @@ public class InstanceMetadataUpdater {
 
         Set<InstanceMetaData> instanceMetaDataSet = stack.getNotDeletedAndNotZombieInstanceMetaDataSet();
 
-        updateInstanceMetaDataWithPackageVersions(packageVersionsByNameByHost, instanceMetaDataSet);
+        updateInstanceMetaDataWithPackageVersions(stackId, packageVersionsByNameByHost, instanceMetaDataSet);
 
         List<String> packagesWithMultipleVersions = collectPackagesWithMultipleVersions(instanceMetaDataSet);
         notifyIfPackagesHaveDifferentVersions(stack, packagesWithMultipleVersions);
@@ -118,8 +122,8 @@ public class InstanceMetadataUpdater {
         return failedVersionQueriesByHost;
     }
 
-    private Map<String, Multimap<String, String>> updateInstanceMetaDataWithPackageVersions(Map<String, Map<String, String>> packageVersionsByNameByHost,
-            Set<InstanceMetaData> instanceMetaDataSet) throws IOException {
+    private Map<String, Multimap<String, String>> updateInstanceMetaDataWithPackageVersions(Long stackId, Map<String,
+            Map<String, String>> packageVersionsByNameByHost, Set<InstanceMetaData> instanceMetaDataSet) throws IOException {
         Map<String, Multimap<String, String>> changedVersionsByHost = new HashMap<>();
         for (InstanceMetaData im : instanceMetaDataSet) {
             Map<String, String> packageVersionsOnHost = packageVersionsByNameByHost.get(im.getDiscoveryFQDN());
@@ -132,7 +136,7 @@ public class InstanceMetadataUpdater {
                     pkgVersionsMMap.putAll(Multimaps.forMap(Maps.transformValues(image.getPackageVersions(), this::removeBuildVersion)));
                     changedVersionsByHost.put(im.getDiscoveryFQDN(), pkgVersionsMMap);
                 }
-                image = updatePackageVersions(image, packageVersionsOnHost);
+                image = updatePackageVersions(stackId, image, packageVersionsOnHost);
                 im.setImage(new Json(image));
                 instanceMetaDataService.save(im);
             }
@@ -318,8 +322,9 @@ public class InstanceMetadataUpdater {
         return version.split("-")[0];
     }
 
-    private Image updatePackageVersions(Image image, Map<String, String> packageVersionsOnHost) {
-        return new Image(image.getImageName(), image.getUserdata(), image.getOs(), image.getOsType(), image.getImageCatalogUrl(),
+    private Image updatePackageVersions(Long stackId, Image image, Map<String, String> packageVersionsOnHost) {
+        userDataService.updateUserData(stackId, image.getUserdata());
+        return new Image(image.getImageName(), new HashMap<>(), image.getOs(), image.getOsType(), image.getImageCatalogUrl(),
                 image.getImageCatalogName(), image.getImageId(), packageVersionsOnHost);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/InstanceMetadataUpdater.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/InstanceMetadataUpdater.java
@@ -323,7 +323,7 @@ public class InstanceMetadataUpdater {
     }
 
     private Image updatePackageVersions(Long stackId, Image image, Map<String, String> packageVersionsOnHost) {
-        userDataService.updateUserData(stackId, image.getUserdata());
+        userDataService.createOrUpdateUserData(stackId, image.getUserdata());
         return new Image(image.getImageName(), new HashMap<>(), image.getOs(), image.getOsType(), image.getImageCatalogUrl(),
                 image.getImageCatalogName(), image.getImageId(), packageVersionsOnHost);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
@@ -9,6 +9,7 @@ import static com.sequenceiq.cloudbreak.service.image.ImageCatalogService.CDP_DE
 import java.io.IOException;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -54,6 +55,7 @@ import com.sequenceiq.cloudbreak.domain.stack.Component;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.StackMatrixService;
+import com.sequenceiq.cloudbreak.service.image.userdata.UserDataService;
 import com.sequenceiq.cloudbreak.service.parcel.ClouderaManagerProductTransformer;
 import com.sequenceiq.cloudbreak.workspace.model.User;
 import com.sequenceiq.common.api.type.InstanceGroupType;
@@ -95,6 +97,9 @@ public class ImageService {
 
     @Inject
     private EntitlementService entitlementService;
+
+    @Inject
+    private UserDataService userDataService;
 
     public Image getImage(Long stackId) throws CloudbreakImageNotFoundException {
         return componentConfigProviderService.getImage(stackId);
@@ -342,7 +347,7 @@ public class ImageService {
 
     private void addImage(Stack stack, Map<InstanceGroupType, String> userData, StatedImage statedImage, String imageName,
             com.sequenceiq.cloudbreak.cloud.model.catalog.Image catalogBasedImage, Set<Component> components) {
-        Image image = new Image(imageName, userData, catalogBasedImage.getOs(), catalogBasedImage.getOsType(),
+        Image image = new Image(imageName, new HashMap<>(), catalogBasedImage.getOs(), catalogBasedImage.getOsType(),
                 statedImage.getImageCatalogUrl(), statedImage.getImageCatalogName(), catalogBasedImage.getUuid(),
                 catalogBasedImage.getPackageVersions());
         components.add(new Component(IMAGE, IMAGE.name(), new Json(image), stack));
@@ -411,13 +416,6 @@ public class ImageService {
                 withName(stackInfo.get(StackRepoDetails.REPO_ID_TAG).split("-")[0]).
                 withParcel(stackInfo.get(osType));
         return cmProduct;
-    }
-
-    public void decorateImageWithUserDataForStack(Stack stack, Map<InstanceGroupType, String> userData) throws CloudbreakImageNotFoundException {
-        Image image = componentConfigProviderService.getImage(stack.getId());
-        image.setUserdata(userData);
-        Component imageComponent = new Component(IMAGE, IMAGE.name(), new Json(image), stack);
-        componentConfigProviderService.replaceImageComponentWithNew(imageComponent);
     }
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/userdata/UserDataService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/userdata/UserDataService.java
@@ -25,12 +25,16 @@ import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.SaltSecurityConfig;
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
+import com.sequenceiq.cloudbreak.domain.Userdata;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.dto.ProxyConfig;
+import com.sequenceiq.cloudbreak.repository.UserdataRepository;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
 import com.sequenceiq.cloudbreak.service.proxy.ProxyConfigDtoService;
 import com.sequenceiq.cloudbreak.service.proxy.ProxyConfigUserDataReplacer;
+import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
 import com.sequenceiq.cloudbreak.service.securityconfig.SecurityConfigService;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stack.connector.adapter.ServiceProviderConnectorAdapter;
 import com.sequenceiq.cloudbreak.util.UserDataReplacer;
@@ -40,6 +44,9 @@ import com.sequenceiq.common.api.type.InstanceGroupType;
 public class UserDataService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UserDataService.class);
+
+    @Inject
+    private UserdataRepository userdataRepository;
 
     @Inject
     private UserDataBuilder userDataBuilder;
@@ -60,6 +67,12 @@ public class UserDataService {
     private ImageService imageService;
 
     @Inject
+    private StackDtoService stackDtoService;
+
+    @Inject
+    private SecretService secretService;
+
+    @Inject
     private ProxyConfigDtoService proxyConfigDtoService;
 
     @Inject
@@ -78,8 +91,7 @@ public class UserDataService {
                 .replace("IS_CCM_ENABLED",  false)
                 .getUserData();
         userdata.put(InstanceGroupType.GATEWAY, result);
-        Stack stack = stackService.getByIdWithLists(stackId);
-        updateUserData(stack, userdata);
+        updateUserData(stackId, userdata);
     }
 
     public void updateProxyConfig(Long stackId) {
@@ -89,24 +101,54 @@ public class UserDataService {
         String gatewayUserData = userDataByInstanceGroup.get(InstanceGroupType.GATEWAY);
         String result = proxyConfigUserDataReplacer.replaceProxyConfigInUserDataByEnvCrn(gatewayUserData, stack.getEnvironmentCrn());
         userDataByInstanceGroup.put(InstanceGroupType.GATEWAY, result);
-        updateUserData(stack, userDataByInstanceGroup);
+        updateUserData(stack.getId(), userDataByInstanceGroup);
     }
 
-    private Map<InstanceGroupType, String> getUserData(Long stackId) {
+    public Map<InstanceGroupType, String> getUserData(Long stackId) {
         try {
             Image image = imageService.getImage(stackId);
-            return new HashMap<>(image.getUserdata());
+            if (image.getUserdata() == null || image.getUserdata().isEmpty()) {
+                Map<InstanceGroupType, String> map = new HashMap<>();
+                Optional<Userdata> userdataOptional = userdataRepository.findByStackId(stackId);
+                if (userdataOptional.isPresent()) {
+                    map.put(InstanceGroupType.CORE, userdataOptional.get().getCoreUserdata());
+                    map.put(InstanceGroupType.GATEWAY, userdataOptional.get().getGatewayUserdata());
+                }
+                return map;
+            } else {
+                return new HashMap<>(image.getUserdata());
+            }
         } catch (CloudbreakImageNotFoundException e) {
             throw convertToServiceException(e);
         }
     }
 
-    private void updateUserData(Stack stack, Map<InstanceGroupType, String> userdata) {
-        try {
-            imageService.decorateImageWithUserDataForStack(stack, userdata);
-        } catch (CloudbreakImageNotFoundException e) {
-            throw convertToServiceException(e);
+    public Userdata updateUserData(Long stackId, Map<InstanceGroupType, String> userdata) {
+        Stack stack = stackService.get(stackId);
+        Userdata result;
+
+        Optional<Userdata> userdataOptional = userdataRepository.findByStackId(stackId);
+
+        if (userdataOptional.isPresent()) {
+            Userdata existingUserData = userdataOptional.get();
+            String coreUserdataSecret = existingUserData.getCoreUserdataSecret();
+            String gatewayUserdataSecret = existingUserData.getGatewayUserdataSecret();
+
+            existingUserData.setCoreUserdata(userdata.get(InstanceGroupType.CORE));
+            existingUserData.setGatewayUserdata(userdata.get(InstanceGroupType.GATEWAY));
+            result = userdataRepository.save(existingUserData);
+
+            secretService.delete(coreUserdataSecret);
+            secretService.delete(gatewayUserdataSecret);
+        } else {
+            Userdata newUserdata = new Userdata();
+            newUserdata.setAccountId(stack.getWorkspace().getTenant().getName());
+            newUserdata.setCoreUserdata(userdata.get(InstanceGroupType.CORE));
+            newUserdata.setGatewayUserdata(userdata.get(InstanceGroupType.GATEWAY));
+            newUserdata.setStack(stack);
+            result = userdataRepository.save(newUserdata);
         }
+        return result;
     }
 
     private static CloudbreakServiceException convertToServiceException(CloudbreakImageNotFoundException e) {
@@ -137,7 +179,7 @@ public class UserDataService {
             Optional<ProxyConfig> proxyConfig = proxyConfigDtoService.getByEnvironmentCrn(stack.getEnvironmentCrn());
             Map<InstanceGroupType, String> userData = userDataBuilder.buildUserData(Platform.platform(stack.getCloudPlatform()), cbSshKeyDer,
                     sshUser, platformParameters, saltBootPassword, cbCert, ccmParameters, proxyConfig.orElse(null));
-            imageService.decorateImageWithUserDataForStack(stack, userData);
+            updateUserData(stackId, userData);
         } catch (InterruptedException | ExecutionException e) {
             LOGGER.error("Failed to get Platform parmaters", e);
             throw new GetCloudParameterException("Failed to get Platform parmaters", e);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/userdata/UserDataService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/userdata/UserDataService.java
@@ -87,11 +87,11 @@ public class UserDataService {
         String gatewayUserdata = userdata.get(InstanceGroupType.GATEWAY);
         String result = new UserDataReplacer(gatewayUserdata)
                 .replace("IS_CCM_V2_JUMPGATE_ENABLED", true)
-                .replace("IS_CCM_V2_ENABLED",  true)
-                .replace("IS_CCM_ENABLED",  false)
+                .replace("IS_CCM_V2_ENABLED", true)
+                .replace("IS_CCM_ENABLED", false)
                 .getUserData();
         userdata.put(InstanceGroupType.GATEWAY, result);
-        updateUserData(stackId, userdata);
+        createOrUpdateUserData(stackId, userdata);
     }
 
     public void updateProxyConfig(Long stackId) {
@@ -101,7 +101,7 @@ public class UserDataService {
         String gatewayUserData = userDataByInstanceGroup.get(InstanceGroupType.GATEWAY);
         String result = proxyConfigUserDataReplacer.replaceProxyConfigInUserDataByEnvCrn(gatewayUserData, stack.getEnvironmentCrn());
         userDataByInstanceGroup.put(InstanceGroupType.GATEWAY, result);
-        updateUserData(stack.getId(), userDataByInstanceGroup);
+        createOrUpdateUserData(stack.getId(), userDataByInstanceGroup);
     }
 
     public Map<InstanceGroupType, String> getUserData(Long stackId) {
@@ -111,6 +111,7 @@ public class UserDataService {
                 Map<InstanceGroupType, String> map = new HashMap<>();
                 Optional<Userdata> userdataOptional = userdataRepository.findByStackId(stackId);
                 if (userdataOptional.isPresent()) {
+                    LOGGER.debug("Collecting user data from UserData table with stack id: {}", stackId);
                     map.put(InstanceGroupType.CORE, userdataOptional.get().getCoreUserdata());
                     map.put(InstanceGroupType.GATEWAY, userdataOptional.get().getGatewayUserdata());
                 }
@@ -123,30 +124,35 @@ public class UserDataService {
         }
     }
 
-    public Userdata updateUserData(Long stackId, Map<InstanceGroupType, String> userdata) {
+    public Userdata createOrUpdateUserData(Long stackId, Map<InstanceGroupType, String> userdata) {
         Stack stack = stackService.get(stackId);
         Userdata result;
-
         Optional<Userdata> userdataOptional = userdataRepository.findByStackId(stackId);
+        if (!userdata.isEmpty() && userdata.containsKey(InstanceGroupType.CORE) && userdata.containsKey(InstanceGroupType.GATEWAY)) {
+            if (userdataOptional.isPresent()) {
+                LOGGER.debug("Updating existing user data in the user data table for stack: {}", stackId);
+                Userdata existingUserData = userdataOptional.get();
+                String coreUserdataSecret = existingUserData.getCoreUserdataSecret();
+                String gatewayUserdataSecret = existingUserData.getGatewayUserdataSecret();
 
-        if (userdataOptional.isPresent()) {
-            Userdata existingUserData = userdataOptional.get();
-            String coreUserdataSecret = existingUserData.getCoreUserdataSecret();
-            String gatewayUserdataSecret = existingUserData.getGatewayUserdataSecret();
+                existingUserData.setCoreUserdata(userdata.get(InstanceGroupType.CORE));
+                existingUserData.setGatewayUserdata(userdata.get(InstanceGroupType.GATEWAY));
+                result = userdataRepository.save(existingUserData);
 
-            existingUserData.setCoreUserdata(userdata.get(InstanceGroupType.CORE));
-            existingUserData.setGatewayUserdata(userdata.get(InstanceGroupType.GATEWAY));
-            result = userdataRepository.save(existingUserData);
-
-            secretService.delete(coreUserdataSecret);
-            secretService.delete(gatewayUserdataSecret);
+                secretService.delete(coreUserdataSecret);
+                secretService.delete(gatewayUserdataSecret);
+            } else {
+                LOGGER.info("Creating new user data entry and stop managing user data in the image component for stack: {}", stackId);
+                Userdata newUserdata = new Userdata();
+                newUserdata.setAccountId(stack.getWorkspace().getTenant().getName());
+                newUserdata.setCoreUserdata(userdata.get(InstanceGroupType.CORE));
+                newUserdata.setGatewayUserdata(userdata.get(InstanceGroupType.GATEWAY));
+                newUserdata.setStack(stack);
+                result = userdataRepository.save(newUserdata);
+            }
         } else {
-            Userdata newUserdata = new Userdata();
-            newUserdata.setAccountId(stack.getWorkspace().getTenant().getName());
-            newUserdata.setCoreUserdata(userdata.get(InstanceGroupType.CORE));
-            newUserdata.setGatewayUserdata(userdata.get(InstanceGroupType.GATEWAY));
-            newUserdata.setStack(stack);
-            result = userdataRepository.save(newUserdata);
+            LOGGER.info("No need for user data update in case of stack '{}' as the provided user data is empty", stackId);
+            result = userdataOptional.orElse(null);
         }
         return result;
     }
@@ -179,7 +185,7 @@ public class UserDataService {
             Optional<ProxyConfig> proxyConfig = proxyConfigDtoService.getByEnvironmentCrn(stack.getEnvironmentCrn());
             Map<InstanceGroupType, String> userData = userDataBuilder.buildUserData(Platform.platform(stack.getCloudPlatform()), cbSshKeyDer,
                     sshUser, platformParameters, saltBootPassword, cbCert, ccmParameters, proxyConfig.orElse(null));
-            updateUserData(stackId, userData);
+            createOrUpdateUserData(stackId, userData);
         } catch (InterruptedException | ExecutionException e) {
             LOGGER.error("Failed to get Platform parmaters", e);
             throw new GetCloudParameterException("Failed to get Platform parmaters", e);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackImageService.java
@@ -77,7 +77,7 @@ public class StackImageService {
                     stack.getPlatformVariant());
             String cloudPlatform = platform(stack.getCloudPlatform()).value().toLowerCase();
             String newImageName = imageService.determineImageName(cloudPlatform, platformString, stack.getRegion(), targetImage.getImage());
-            userDataService.updateUserData(stack.getId(), currentImage.getUserdata());
+            userDataService.createOrUpdateUserData(stack.getId(), currentImage.getUserdata());
             return new Image(newImageName, new HashMap<>(), targetImage.getImage().getOs(), targetImage.getImage().getOsType(),
                     targetImage.getImageCatalogUrl(), targetImage.getImageCatalogName(), targetImage.getImage().getUuid(),
                     targetImage.getImage().getPackageVersions());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackImageService.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.service.stack;
 import static com.sequenceiq.cloudbreak.cloud.model.Platform.platform;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Optional;
 
 import javax.inject.Inject;
@@ -30,6 +31,7 @@ import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
 import com.sequenceiq.cloudbreak.service.image.StatedImage;
+import com.sequenceiq.cloudbreak.service.image.userdata.UserDataService;
 import com.sequenceiq.cloudbreak.view.StackView;
 import com.sequenceiq.common.model.ImageCatalogPlatform;
 
@@ -54,6 +56,9 @@ public class StackImageService {
     private PlatformStringTransformer platformStringTransformer;
 
     @Inject
+    private UserDataService userDataService;
+
+    @Inject
     private StackDtoService stackDtoService;
 
     public void storeNewImageComponent(StackDtoDelegate stack, StatedImage targetImage) {
@@ -72,7 +77,8 @@ public class StackImageService {
                     stack.getPlatformVariant());
             String cloudPlatform = platform(stack.getCloudPlatform()).value().toLowerCase();
             String newImageName = imageService.determineImageName(cloudPlatform, platformString, stack.getRegion(), targetImage.getImage());
-            return new Image(newImageName, currentImage.getUserdata(), targetImage.getImage().getOs(), targetImage.getImage().getOsType(),
+            userDataService.updateUserData(stack.getId(), currentImage.getUserdata());
+            return new Image(newImageName, new HashMap<>(), targetImage.getImage().getOs(), targetImage.getImage().getOsType(),
                     targetImage.getImageCatalogUrl(), targetImage.getImageCatalogName(), targetImage.getImage().getUuid(),
                     targetImage.getImage().getPackageVersions());
         } catch (CloudbreakImageNotFoundException e) {

--- a/core/src/main/resources/schema/app/20230224135630_CB-20943_Remove_the_secrets_from_the_userdata_script_which_are_stored_in_the_database.sql
+++ b/core/src/main/resources/schema/app/20230224135630_CB-20943_Remove_the_secrets_from_the_userdata_script_which_are_stored_in_the_database.sql
@@ -1,0 +1,21 @@
+-- // CB-20943 Remove the secrets from the userdata script which are stored in the database
+-- Migration SQL that makes the change goes here.
+
+CREATE TABLE IF NOT EXISTS userdata (
+    id                      bigserial NOT NULL,
+    stack_id                bigint,
+    accountid               VARCHAR (255),
+    coreuserdata            TEXT,
+    gatewayuserdata         TEXT,
+    PRIMARY KEY (id)
+);
+
+ALTER TABLE ONLY userdata ADD CONSTRAINT fk_userdata_stack_id FOREIGN KEY (stack_id) REFERENCES stack(id);
+CREATE SEQUENCE IF NOT EXISTS userdata_id_seq START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;
+CREATE INDEX IF NOT EXISTS idx_userdata_stackid ON userdata(stack_id);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP TABLE userdata;
+

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
@@ -79,6 +79,7 @@ import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
 import com.sequenceiq.cloudbreak.service.environment.marketplace.AzureMarketplaceTermsClientService;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
+import com.sequenceiq.cloudbreak.service.image.userdata.UserDataService;
 import com.sequenceiq.cloudbreak.service.loadbalancer.TargetGroupPortProvider;
 import com.sequenceiq.cloudbreak.service.securityrule.SecurityRuleService;
 import com.sequenceiq.cloudbreak.service.stack.DefaultRootVolumeSizeProvider;
@@ -200,6 +201,9 @@ public class StackToCloudStackConverterTest {
     @Mock
     private AzureMarketplaceTermsClientService azureMarketplaceTermsClientService;
 
+    @Mock
+    private UserDataService userDataService;
+
     @BeforeEach
     public void setUp() {
         when(stack.getStackAuthentication()).thenReturn(stackAuthentication);
@@ -212,6 +216,7 @@ public class StackToCloudStackConverterTest {
         when(cluster.getExtendedBlueprintText()).thenReturn(BLUEPRINT_TEXT);
         when(cmTemplateProcessorFactory.get(anyString())).thenReturn(cmTemplateProcessor);
         when(cmTemplateProcessor.getComponentsByHostGroup()).thenReturn(mock(Map.class));
+        when(userDataService.getUserData(anyLong())).thenReturn(mock(Map.class));
         when(cloudFileSystemViewProvider.getCloudFileSystemView(any(), any(), any())).thenReturn(Optional.empty());
         DetailedEnvironmentResponse environmentResponse = new DetailedEnvironmentResponse();
         environmentResponse.setCloudPlatform(CloudPlatform.AWS.name());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeCcmFlowChainIntegrationTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeCcmFlowChainIntegrationTest.java
@@ -272,6 +272,9 @@ class UpgradeCcmFlowChainIntegrationTest {
         mockStackService();
         Image image = new Image("alma", USER_DATA_MAP, "", "", "", "", "", null);
         when(imageService.getImage(STACK_ID)).thenReturn(image);
+        when(userDataService.getUserData(anyLong())).thenReturn(Map.of(
+                InstanceGroupType.CORE, "core",
+                InstanceGroupType.GATEWAY, "gateway"));
 
         CloudConnector connector = mock(CloudConnector.class);
         AuthenticatedContext context = mock(AuthenticatedContext.class);
@@ -281,6 +284,7 @@ class UpgradeCcmFlowChainIntegrationTest {
         when(connector.resources()).thenReturn(resourcesApi);
         when(authApi.authenticate(any(), any())).thenReturn(context);
         when(clusterApiConnectors.getConnector(any(), any())).thenReturn(clusterApi);
+        when(userDataService.getUserData(anyLong())).thenReturn(USER_DATA_MAP);
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/handler/CloudProviderUpdateCheckHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/handler/CloudProviderUpdateCheckHandlerTest.java
@@ -39,7 +39,7 @@ class CloudProviderUpdateCheckHandlerTest {
     @Test
     void doAcceptShouldCallPlatformConnectorsGet() {
         when(cloudPlatformConnectors.get(any(), any())).thenReturn(cloudConnector);
-        CloudStack cloudStack = new CloudStack(List.of(), null, null, Map.of(), Map.of(), "", null, "", "", null);
+        CloudStack cloudStack = new CloudStack(List.of(), null, null, Map.of(), Map.of(), "", null, "", "", null, null, null);
         CloudContext cloudContext = CloudContext.Builder.builder().withId(0L).build();
         ClusterUpgradeUpdateCheckRequest checkRequest = new ClusterUpgradeUpdateCheckRequest(0L, cloudStack, new CloudCredential(), cloudContext, List.of());
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleServiceTest.java
@@ -155,7 +155,7 @@ class StackUpscaleServiceTest {
                 mock(InstanceAuthentication.class), "admin", "ssh", 100, Optional.empty(), null, emptyMap()));
 
         CloudStack cloudStack = new CloudStack(groups, mock(Network.class), mock(Image.class), Collections.emptyMap(), Collections.emptyMap(), "template",
-                mock(InstanceAuthentication.class), "username", "publickey", mock(SpiFileSystem.class));
+                mock(InstanceAuthentication.class), "username", "publickey", mock(SpiFileSystem.class), null, null);
         UpscaleStackRequest<UpscaleStackResult> upscaleStackRequest = new UpscaleStackRequest<>(mock(CloudContext.class), mock(CloudCredential.class),
                 cloudStack, new ArrayList<>(), adjustmentTypeWithThreshold, false);
         stackUpscaleService.upscale(mock(AuthenticatedContext.class), upscaleStackRequest, connector);
@@ -203,7 +203,7 @@ class StackUpscaleServiceTest {
                 mock(InstanceAuthentication.class), "admin", "ssh", 100, Optional.empty(), null, emptyMap()));
 
         CloudStack cloudStack = new CloudStack(groups, mock(Network.class), mock(Image.class), Collections.emptyMap(), Collections.emptyMap(), "template",
-                mock(InstanceAuthentication.class), "username", "publickey", mock(SpiFileSystem.class));
+                mock(InstanceAuthentication.class), "username", "publickey", mock(SpiFileSystem.class), null, null);
         UpscaleStackRequest<UpscaleStackResult> upscaleStackRequest = new UpscaleStackRequest<>(mock(CloudContext.class), mock(CloudCredential.class),
                 cloudStack, new ArrayList<>(), adjustmentTypeWithThreshold, false);
         Assertions.assertThrows(CloudConnectorException.class, () -> stackUpscaleService.upscale(mock(AuthenticatedContext.class), upscaleStackRequest,
@@ -245,7 +245,7 @@ class StackUpscaleServiceTest {
                 mock(InstanceAuthentication.class), "admin", "ssh", 100, Optional.empty(), null, emptyMap()));
 
         CloudStack cloudStack = new CloudStack(groups, mock(Network.class), mock(Image.class), Collections.emptyMap(), Collections.emptyMap(), "template",
-                mock(InstanceAuthentication.class), "username", "publickey", mock(SpiFileSystem.class));
+                mock(InstanceAuthentication.class), "username", "publickey", mock(SpiFileSystem.class), null, null);
         UpscaleStackRequest<UpscaleStackResult> upscaleStackRequest = new UpscaleStackRequest<>(mock(CloudContext.class), mock(CloudCredential.class),
                 cloudStack, new ArrayList<>(), adjustmentTypeWithThreshold, false);
         Assertions.assertThrows(CloudConnectorException.class, () -> stackUpscaleService.upscale(mock(AuthenticatedContext.class), upscaleStackRequest,
@@ -289,7 +289,7 @@ class StackUpscaleServiceTest {
                 mock(InstanceAuthentication.class), "admin", "ssh", 100, Optional.empty(), null, emptyMap()));
 
         CloudStack cloudStack = new CloudStack(groups, mock(Network.class), mock(Image.class), Collections.emptyMap(), Collections.emptyMap(), "template",
-                mock(InstanceAuthentication.class), "username", "publickey", mock(SpiFileSystem.class));
+                mock(InstanceAuthentication.class), "username", "publickey", mock(SpiFileSystem.class), null, null);
         UpscaleStackRequest<UpscaleStackResult> upscaleStackRequest = new UpscaleStackRequest<>(mock(CloudContext.class), mock(CloudCredential.class),
                 cloudStack, new ArrayList<>(), adjustmentTypeWithThreshold, false);
         stackUpscaleService.upscale(mock(AuthenticatedContext.class), upscaleStackRequest, connector);
@@ -337,7 +337,7 @@ class StackUpscaleServiceTest {
                 mock(InstanceAuthentication.class), "admin", "ssh", 100, Optional.empty(), null, emptyMap()));
 
         CloudStack cloudStack = new CloudStack(groups, mock(Network.class), mock(Image.class), Collections.emptyMap(), Collections.emptyMap(), "template",
-                mock(InstanceAuthentication.class), "username", "publickey", mock(SpiFileSystem.class));
+                mock(InstanceAuthentication.class), "username", "publickey", mock(SpiFileSystem.class), null, null);
         UpscaleStackRequest<UpscaleStackResult> upscaleStackRequest = new UpscaleStackRequest<>(mock(CloudContext.class), mock(CloudCredential.class),
                 cloudStack, new ArrayList<>(), adjustmentTypeWithThreshold, false);
         Assertions.assertThrows(CloudConnectorException.class, () -> stackUpscaleService.upscale(mock(AuthenticatedContext.class), upscaleStackRequest,
@@ -380,7 +380,7 @@ class StackUpscaleServiceTest {
                 mock(InstanceAuthentication.class), "admin", "ssh", 100, Optional.empty(), null, emptyMap()));
 
         CloudStack cloudStack = new CloudStack(groups, mock(Network.class), mock(Image.class), Collections.emptyMap(), Collections.emptyMap(), "template",
-                mock(InstanceAuthentication.class), "username", "publickey", mock(SpiFileSystem.class));
+                mock(InstanceAuthentication.class), "username", "publickey", mock(SpiFileSystem.class), null, null);
         UpscaleStackRequest<UpscaleStackResult> upscaleStackRequest = new UpscaleStackRequest<>(mock(CloudContext.class), mock(CloudCredential.class),
                 cloudStack, new ArrayList<>(), adjustmentTypeWithThreshold, false);
         stackUpscaleService.upscale(mock(AuthenticatedContext.class), upscaleStackRequest, connector);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ambari/InstanceMetadataUpdaterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ambari/InstanceMetadataUpdaterTest.java
@@ -31,6 +31,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.domain.Orchestrator;
+import com.sequenceiq.cloudbreak.domain.Userdata;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
@@ -44,6 +45,7 @@ import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.cluster.InstanceMetadataUpdater;
 import com.sequenceiq.cloudbreak.service.cluster.Package;
 import com.sequenceiq.cloudbreak.service.cluster.PackageName;
+import com.sequenceiq.cloudbreak.service.image.userdata.UserDataService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
@@ -69,6 +71,9 @@ public class InstanceMetadataUpdaterTest {
     @Mock
     private StackService stackService;
 
+    @Mock
+    private UserDataService userDataService;
+
     @InjectMocks
     private InstanceMetadataUpdater underTest;
 
@@ -76,6 +81,7 @@ public class InstanceMetadataUpdaterTest {
     public void setUp() throws CloudbreakException, JsonProcessingException, CloudbreakOrchestratorFailedException {
         MockitoAnnotations.openMocks(this);
         when(gatewayConfigService.getPrimaryGatewayConfig(any(Stack.class))).thenReturn(gatewayConfig);
+        when(userDataService.updateUserData(anyLong(), any())).thenReturn(new Userdata());
 
         Package packageByName = new Package();
         packageByName.setName("packageByName");

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ambari/InstanceMetadataUpdaterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ambari/InstanceMetadataUpdaterTest.java
@@ -81,7 +81,7 @@ public class InstanceMetadataUpdaterTest {
     public void setUp() throws CloudbreakException, JsonProcessingException, CloudbreakOrchestratorFailedException {
         MockitoAnnotations.openMocks(this);
         when(gatewayConfigService.getPrimaryGatewayConfig(any(Stack.class))).thenReturn(gatewayConfig);
-        when(userDataService.updateUserData(anyLong(), any())).thenReturn(new Userdata());
+        when(userDataService.createOrUpdateUserData(anyLong(), any())).thenReturn(new Userdata());
 
         Package packageByName = new Package();
         packageByName.setName("packageByName");

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/userdata/UserDataServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/userdata/UserDataServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,10 +21,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
+import com.sequenceiq.cloudbreak.domain.Userdata;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.repository.UserdataRepository;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
 import com.sequenceiq.cloudbreak.service.proxy.ProxyConfigUserDataReplacer;
+import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.workspace.model.Tenant;
+import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,6 +47,12 @@ public class UserDataServiceTest {
     private UserDataService underTest;
 
     @Mock
+    private UserdataRepository userdataRepository;
+
+    @Mock
+    private SecretService secretService;
+
+    @Mock
     private ImageService imageService;
 
     @Mock
@@ -53,13 +65,26 @@ public class UserDataServiceTest {
     private Stack stack;
 
     @Mock
+    private Workspace workspace;
+
+    @Mock
+    private Tenant tenant;
+
+    @Mock
     private Image image;
 
     @Captor
     private ArgumentCaptor<Map<InstanceGroupType, String>> imageCaptor;
 
+    @Captor
+    private ArgumentCaptor<Userdata> userdataCaptor;
+
     @BeforeEach
     void setUp() throws Exception {
+        lenient().when(tenant.getName()).thenReturn("tenant");
+        lenient().when(workspace.getTenant()).thenReturn(tenant);
+        lenient().when(stack.getWorkspace()).thenReturn(workspace);
+        lenient().when(stackService.get(any())).thenReturn(stack);
         lenient().when(stackService.getByIdWithLists(STACK_ID)).thenReturn(stack);
         lenient().when(imageService.getImage(STACK_ID)).thenReturn(image);
         lenient().when(stack.getEnvironmentCrn()).thenReturn(ENV_CRN);
@@ -67,14 +92,15 @@ public class UserDataServiceTest {
 
     @Test
     void updateJumpgateFlagOnly() throws CloudbreakImageNotFoundException {
-        when(image.getUserdata()).thenReturn(Map.of(InstanceGroupType.GATEWAY,
-                "export FLAG=foo\nexport IS_CCM_ENABLED=true\nexport IS_CCM_V2_ENABLED=false\nexport IS_CCM_V2_JUMPGATE_ENABLED=false\n" +
-                        "export OTHER_FLAG=bar"));
+        Userdata userdata = new Userdata();
+        userdata.setGatewayUserdata("export FLAG=foo\nexport IS_CCM_ENABLED=true\nexport IS_CCM_V2_ENABLED=false\nexport IS_CCM_V2_JUMPGATE_ENABLED=false\n" +
+                "export OTHER_FLAG=bar");
+        when(userdataRepository.findByStackId(any())).thenReturn(Optional.of(userdata));
 
         underTest.updateJumpgateFlagOnly(STACK_ID);
 
-        verify(imageService, times(1)).decorateImageWithUserDataForStack(any(), imageCaptor.capture());
-        assertThat(imageCaptor.getValue().get(InstanceGroupType.GATEWAY))
+        verify(userdataRepository, times(1)).save(userdataCaptor.capture());
+        assertThat(userdataCaptor.getValue().getGatewayUserdata())
                 .isEqualTo("export FLAG=foo\nexport IS_CCM_ENABLED=false\nexport IS_CCM_V2_ENABLED=true\nexport IS_CCM_V2_JUMPGATE_ENABLED=true\n" +
                         "export OTHER_FLAG=bar");
     }
@@ -82,16 +108,17 @@ public class UserDataServiceTest {
     @Test
     void updateProxyConfig() throws CloudbreakImageNotFoundException {
         String gwUserData = "gwUserData";
-        Map<InstanceGroupType, String> userData = Map.of(InstanceGroupType.GATEWAY, gwUserData);
-        when(image.getUserdata()).thenReturn(userData);
+        Userdata userdata = new Userdata();
+        userdata.setGatewayUserdata(gwUserData);
+        when(userdataRepository.findByStackId(any())).thenReturn(Optional.of(userdata));
         String replacedGwUserData = "replacedGwUserData";
         when(proxyConfigUserDataReplacer.replaceProxyConfigInUserDataByEnvCrn(gwUserData, ENV_CRN)).thenReturn(replacedGwUserData);
 
         underTest.updateProxyConfig(STACK_ID);
 
         verify(proxyConfigUserDataReplacer).replaceProxyConfigInUserDataByEnvCrn(gwUserData, ENV_CRN);
-        verify(imageService).decorateImageWithUserDataForStack(any(), imageCaptor.capture());
-        assertThat(imageCaptor.getValue().get(InstanceGroupType.GATEWAY))
+        verify(userdataRepository).save(userdataCaptor.capture());
+        assertThat(userdataCaptor.getValue().getGatewayUserdata())
                 .isEqualTo(replacedGwUserData);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackImageServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackImageServiceTest.java
@@ -161,7 +161,7 @@ public class StackImageServiceTest {
                 stack.getRegion(), targetStatedImage.getImage())).thenReturn(IMAGE_NAME);
         when(platformStringTransformer.getPlatformStringForImageCatalog(stack.getCloudPlatform(), stack.getPlatformVariant()))
                 .thenReturn(imageCatalogPlatform);
-        when(userDataService.updateUserData(anyLong(), any())).thenReturn(new Userdata());
+        when(userDataService.createOrUpdateUserData(anyLong(), any())).thenReturn(new Userdata());
 
         victim.changeImageCatalog(stack, TARGET_IMAGE_CATALOG);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackImageServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackImageServiceTest.java
@@ -38,12 +38,14 @@ import com.sequenceiq.cloudbreak.common.type.ComponentType;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
+import com.sequenceiq.cloudbreak.domain.Userdata;
 import com.sequenceiq.cloudbreak.domain.stack.Component;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
 import com.sequenceiq.cloudbreak.service.image.StatedImage;
+import com.sequenceiq.cloudbreak.service.image.userdata.UserDataService;
 import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 import com.sequenceiq.common.model.ImageCatalogPlatform;
 
@@ -77,6 +79,9 @@ public class StackImageServiceTest {
 
     @Mock
     private ImageService imageService;
+
+    @Mock
+    private UserDataService userDataService;
 
     @Mock
     private ImageCatalogService imageCatalogService;
@@ -156,6 +161,7 @@ public class StackImageServiceTest {
                 stack.getRegion(), targetStatedImage.getImage())).thenReturn(IMAGE_NAME);
         when(platformStringTransformer.getPlatformStringForImageCatalog(stack.getCloudPlatform(), stack.getPlatformVariant()))
                 .thenReturn(imageCatalogPlatform);
+        when(userDataService.updateUserData(anyLong(), any())).thenReturn(new Userdata());
 
         victim.changeImageCatalog(stack, TARGET_IMAGE_CATALOG);
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
@@ -111,7 +111,8 @@ public class StackToCloudStackConverter implements Converter<Stack, CloudStack> 
     }
 
     public CloudStack convert(Stack stack, Collection<String> deleteRequestedInstances) {
-        Image image = imageConverter.convert(imageService.getByStack(stack));
+        ImageEntity imageEntity = imageService.getByStack(stack);
+        Image image = imageConverter.convert(imageEntity);
         Optional<CloudFileSystemView> fileSystemView = buildFileSystemView(stack);
         List<Group> instanceGroups = buildInstanceGroups(
                 stack,
@@ -126,7 +127,7 @@ public class StackToCloudStackConverter implements Converter<Stack, CloudStack> 
         return new CloudStack(instanceGroups, network, image, parameters,
                 getUserDefinedTags(stack), stack.getTemplate(), instanceAuthentication, instanceAuthentication.getLoginUserName(),
                 instanceAuthentication.getPublicKey(), null,
-                image.getUserdata().get(InstanceGroupType.GATEWAY), null);
+                imageEntity.getUserdataWrapper(), null);
     }
 
     public CloudInstance buildInstance(Stack stack, InstanceMetaData instanceMetaData, InstanceGroup instanceGroup,

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
@@ -110,14 +110,6 @@ public class StackToCloudStackConverter implements Converter<Stack, CloudStack> 
         return convert(stack, Collections.emptySet());
     }
 
-    public CloudStack convertForDownscale(Stack stack, Set<String> deleteRequestedInstances) {
-        return convert(stack, deleteRequestedInstances);
-    }
-
-    public CloudStack convertForTermination(Stack stack, String instanceId) {
-        return convert(stack, Collections.singleton(instanceId));
-    }
-
     public CloudStack convert(Stack stack, Collection<String> deleteRequestedInstances) {
         Image image = imageConverter.convert(imageService.getByStack(stack));
         Optional<CloudFileSystemView> fileSystemView = buildFileSystemView(stack);
@@ -133,7 +125,8 @@ public class StackToCloudStackConverter implements Converter<Stack, CloudStack> 
 
         return new CloudStack(instanceGroups, network, image, parameters,
                 getUserDefinedTags(stack), stack.getTemplate(), instanceAuthentication, instanceAuthentication.getLoginUserName(),
-                instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication.getPublicKey(), null,
+                image.getUserdata().get(InstanceGroupType.GATEWAY), null);
     }
 
     public CloudInstance buildInstance(Stack stack, InstanceMetaData instanceMetaData, InstanceGroup instanceGroup,

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/image/ImageConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/image/ImageConverter.java
@@ -16,7 +16,10 @@ public class ImageConverter implements Converter<ImageEntity, Image> {
     @Override
     public Image convert(ImageEntity source) {
         return new Image(source.getImageName(),
-                Map.of(InstanceGroupType.GATEWAY, Optional.ofNullable(source.getUserdata()).orElse("")),
+                Map.of(
+                        InstanceGroupType.GATEWAY, Optional.ofNullable(source.getUserdataWrapper()).orElse(""),
+                        InstanceGroupType.CORE, Optional.ofNullable(source.getUserdataWrapper()).orElse("")
+                ),
                 source.getOs(),
                 source.getOsType(),
                 source.getImageCatalogUrl(),

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/image/ImageToImageEntityConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/image/ImageToImageEntityConverter.java
@@ -8,8 +8,9 @@ import com.sequenceiq.freeipa.entity.ImageEntity;
 @Component
 public class ImageToImageEntityConverter {
 
-    public ImageEntity convert(Image source) {
+    public ImageEntity convert(String accountId, Image source) {
         ImageEntity imageEntity = new ImageEntity();
+        imageEntity.setAccountId(accountId);
         imageEntity.setImageId(source.getUuid());
         imageEntity.setOs(source.getOs());
         imageEntity.setOsType(source.getOsType());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/image/change/action/ImageChangeFailureHandlerAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/image/change/action/ImageChangeFailureHandlerAction.java
@@ -35,7 +35,9 @@ class ImageChangeFailureHandlerAction extends AbstractStackFailureAction<ImageCh
         LOGGER.error("Image change failed", payload.getException());
         if (variables.containsKey(ImageChangeActions.ORIGINAL_IMAGE_REVISION) && variables.containsKey(ImageChangeActions.IMAGE_CHANGED_IN_DB)) {
             LOGGER.info("Reverting to original image using revision [{}]", variables.get(ImageChangeActions.ORIGINAL_IMAGE_REVISION));
-            imageService.revertImageToRevision((Long) variables.get(ImageChangeActions.IMAGE_ENTITY_ID),
+            imageService.revertImageToRevision(
+                    context.getStack().getAccountId(),
+                    (Long) variables.get(ImageChangeActions.IMAGE_ENTITY_ID),
                     (Number) variables.get(ImageChangeActions.ORIGINAL_IMAGE_REVISION));
         } else if (variables.containsKey(ImageChangeActions.ORIGINAL_IMAGE) && variables.containsKey(ImageChangeActions.IMAGE_CHANGED_IN_DB)) {
             LOGGER.info("Reverting to original image using entity stored in variables");

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/provision/handler/ImageFallbackHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/provision/handler/ImageFallbackHandler.java
@@ -82,6 +82,7 @@ public class ImageFallbackHandler extends ExceptionCatcherEventHandler<ImageFall
                     .orElseThrow(() -> new ImageNotFoundException(imgNotFoundMsg));
             String newImageName = imageService.determineImageNameByRegion(stack.getCloudPlatform(), stack.getRegion(), imageWrapper.getImage());
             currentImage.setImageName(newImageName);
+            currentImage.setAccountId(stack.getAccountId());
             imageService.save(currentImage);
             LOGGER.info("Selected image to fallback to: {}", currentImage);
         } catch (Exception e) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/action/UserDataUpdateActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/action/UserDataUpdateActions.java
@@ -80,7 +80,7 @@ public class UserDataUpdateActions {
             @Override
             protected Selectable createRequest(StackContext context) {
                 Stack stack = context.getStack();
-                String userData = stack.getImage().getUserdata();
+                String userData = stack.getImage().getUserdataWrapper();
                 List<CloudResource> cloudResources = getCloudResources(stack.getId());
                 return new UserDataUpdateOnProviderRequest(context.getCloudContext(), context.getCloudCredential(), context.getCloudStack(),
                         cloudResources, userData);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageService.java
@@ -31,6 +31,7 @@ import com.sequenceiq.freeipa.entity.ImageEntity;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.flow.stack.image.change.action.ImageRevisionReaderService;
 import com.sequenceiq.freeipa.repository.ImageRepository;
+import com.sequenceiq.freeipa.service.image.userdata.UserDataService;
 
 @Service
 public class ImageService {
@@ -57,6 +58,9 @@ public class ImageService {
     @Value("${freeipa.image.catalog.default.os}")
     private String defaultOs;
 
+    @Inject
+    private UserDataService userDataService;
+
     public ImageEntity create(Stack stack, ImageSettingsRequest imageRequest) {
         Pair<ImageWrapper, String> imageWrapperAndNamePair = fetchImageWrapperAndName(stack, imageRequest);
         ImageEntity imageEntity = createImageEntity(stack, imageWrapperAndNamePair);
@@ -65,9 +69,10 @@ public class ImageService {
 
     private ImageEntity createImageEntity(Stack stack, Pair<ImageWrapper, String> imageWrapperAndNamePair) {
         ImageWrapper imageWrapper = imageWrapperAndNamePair.getLeft();
-        ImageEntity imageEntity = imageConverter.convert(imageWrapper.getImage());
+        ImageEntity imageEntity = imageConverter.convert(stack.getAccountId(), imageWrapper.getImage());
         imageEntity.setStack(stack);
         imageEntity.setImageName(imageWrapperAndNamePair.getRight());
+        imageEntity.setAccountId(stack.getAccountId());
         imageEntity.setImageCatalogUrl(imageWrapper.getCatalogUrl());
         imageEntity.setImageCatalogName(imageWrapper.getCatalogName());
         return imageEntity;
@@ -115,6 +120,7 @@ public class ImageService {
     private ImageEntity updateImageWithNewValues(Stack stack, ImageWrapper imageWrapper, String imageName) {
         ImageEntity imageEntity = imageRepository.getByStack(stack);
         imageEntity.setImageName(imageName);
+        imageEntity.setAccountId(stack.getAccountId());
         imageEntity.setImageId(imageWrapper.getImage().getUuid());
         imageEntity.setImageCatalogUrl(imageWrapper.getCatalogUrl());
         imageEntity.setImageCatalogName(imageWrapper.getCatalogName());
@@ -123,11 +129,12 @@ public class ImageService {
         return imageEntity;
     }
 
-    public void revertImageToRevision(Long imageEntityId, Number revision) {
+    public void revertImageToRevision(String accountId, Long imageEntityId, Number revision) {
         ImageEntity originalImageEntity = imageRevisionReaderService.find(imageEntityId, revision);
         LOGGER.info("Reverting to revision [{}] using {}", revision, originalImageEntity);
         ImageEntity imageEntity = imageRepository.findById(imageEntityId).get();
         imageEntity.setImageName(originalImageEntity.getImageName());
+        imageEntity.setAccountId(accountId);
         imageEntity.setImageId(originalImageEntity.getImageId());
         imageEntity.setImageCatalogName(originalImageEntity.getImageCatalogName());
         imageEntity.setImageCatalogUrl(originalImageEntity.getImageCatalogUrl());
@@ -148,9 +155,7 @@ public class ImageService {
     }
 
     public ImageEntity decorateImageWithUserDataForStack(Stack stack, String userdata) {
-        ImageEntity imageEntity = getByStack(stack);
-        imageEntity.setUserdata(userdata);
-        return imageRepository.save(imageEntity);
+        return userDataService.updateUserData(stack.getId(), userdata);
     }
 
     public ImageWrapper getImage(ImageSettingsRequest imageSettings, String region, String platform) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageService.java
@@ -154,10 +154,6 @@ public class ImageService {
         return imageRepository.save(imageEntity);
     }
 
-    public ImageEntity decorateImageWithUserDataForStack(Stack stack, String userdata) {
-        return userDataService.updateUserData(stack.getId(), userdata);
-    }
-
     public ImageWrapper getImage(ImageSettingsRequest imageSettings, String region, String platform) {
         return imageProviderFactory.getImageProvider(imageSettings.getCatalog())
                 .getImage(imageSettings, region, platform)

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/userdata/UserDataService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/userdata/UserDataService.java
@@ -94,7 +94,7 @@ public class UserDataService {
                 .replace("IS_CCM_V2_ENABLED", true)
                 .replace("IS_CCM_V2_JUMPGATE_ENABLED", true)
                 .getUserData();
-        updateUserData(stackId, userData);
+        createOrUpdateUserData(stackId, userData);
     }
 
     public void updateProxyConfig(Long stackId) {
@@ -102,10 +102,11 @@ public class UserDataService {
         Stack stack = getStack(stackId);
         ImageEntity image = imageService.getByStackId(stackId);
         String userData = proxyConfigUserDataReplacer.replaceProxyConfigInUserDataByEnvCrn(image.getUserdataWrapper(), stack.getEnvironmentCrn());
-        updateUserData(stackId, userData);
+        createOrUpdateUserData(stackId, userData);
     }
 
-    public ImageEntity updateUserData(Long stackId, String userdata) {
+    public ImageEntity createOrUpdateUserData(Long stackId, String userdata) {
+        LOGGER.debug("Updating user data for stack {}", stackId);
         ImageEntity image = imageService.getByStackId(stackId);
 
         String gatewayUserdataSecret = image.getGatewayUserdataSecret().getSecret();
@@ -136,7 +137,7 @@ public class UserDataService {
             Optional<ProxyConfig> proxyConfig = proxyConfigDtoService.getByEnvironmentCrn(stack.getEnvironmentCrn());
             String userData = userDataBuilder.buildUserData(stack.getAccountId(), environment, Platform.platform(stack.getCloudPlatform()),
                     cbSshKeyDer, sshUser, platformParameters, saltBootPassword, cbCert, ccmParameters, proxyConfig.orElse(null));
-            updateUserData(stack.getId(), userData);
+            createOrUpdateUserData(stack.getId(), userData);
         } catch (InterruptedException | ExecutionException e) {
             LOGGER.error("Failed to get Platform parameters", e);
             throw new GetCloudParameterException("Failed to get Platform parameters", e);

--- a/freeipa/src/main/resources/schema/app/20230227094552_CB-20943_Remove_the_secrets_from_the_userdata_script_which_are_stored_in_the_database.sql
+++ b/freeipa/src/main/resources/schema/app/20230227094552_CB-20943_Remove_the_secrets_from_the_userdata_script_which_are_stored_in_the_database.sql
@@ -1,0 +1,20 @@
+-- // CB-20943 Remove the secrets from the userdata script which are stored in the database
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE image ADD COLUMN IF NOT EXISTS gatewayuserdata TEXT;
+ALTER TABLE image ADD COLUMN IF NOT EXISTS accountid VARCHAR(255);
+
+ALTER TABLE image_history ADD COLUMN IF NOT EXISTS gatewayuserdata TEXT;
+ALTER TABLE image_history ADD COLUMN IF NOT EXISTS accountid VARCHAR(255);
+
+UPDATE image i SET accountid = s.accountid FROM stack s WHERE s.id = i.stack_id;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE image DROP COLUMN IF EXISTS gatewayuserdata;
+ALTER TABLE image DROP COLUMN IF EXISTS accountid;
+
+ALTER TABLE image_history DROP COLUMN IF EXISTS gatewayuserdata;
+ALTER TABLE image_history DROP COLUMN IF EXISTS accountid;
+

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverterTest.java
@@ -161,6 +161,8 @@ public class StackToCloudStackConverterTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null
         );
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/image/ImageToImageEntityConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/image/ImageToImageEntityConverterTest.java
@@ -17,7 +17,7 @@ class ImageToImageEntityConverterTest {
     void testConversion() {
         Image source = new Image(1L, "date", "", "arch", "1-2-a-b", Map.of(), "manjaro", Map.of("freeipa-ldap-agent", "1.2.3"), false);
 
-        ImageEntity result = underTest.convert(source);
+        ImageEntity result = underTest.convert("accountId", source);
 
         assertEquals(source.getUuid(), result.getImageId());
         assertEquals(source.getOs(), result.getOs());

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/verticalscale/handler/FreeIpaVerticalScaleHandlerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/verticalscale/handler/FreeIpaVerticalScaleHandlerTest.java
@@ -84,7 +84,7 @@ public class FreeIpaVerticalScaleHandlerTest {
         networkParameters.put("internetGatewayId", "igw-12345678");
         Network network = new Network(new Subnet(null), networkParameters);
         CloudStack cloudStack = new CloudStack(singletonList(group1), network, null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
 
         VerticalScaleRequest freeIPAVerticalScaleRequest = new VerticalScaleRequest();
         freeIPAVerticalScaleRequest.setGroup("master");
@@ -140,7 +140,7 @@ public class FreeIpaVerticalScaleHandlerTest {
         networkParameters.put("internetGatewayId", "igw-12345678");
         Network network = new Network(new Subnet(null), networkParameters);
         CloudStack cloudStack = new CloudStack(singletonList(group1), network, null, emptyMap(), emptyMap(), null,
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null, null, null);
 
         VerticalScaleRequest freeIPAVerticalScaleRequest = new VerticalScaleRequest();
         freeIPAVerticalScaleRequest.setGroup("master");

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/ImageServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/ImageServiceTest.java
@@ -168,7 +168,7 @@ public class ImageServiceTest {
                 .thenReturn(Optional.of(new ImageWrapper(image, IMAGE_CATALOG_URL, IMAGE_CATALOG)));
         when(image.getImageSetsByProvider()).thenReturn(Collections.singletonMap(DEFAULT_PLATFORM, Collections.singletonMap(DEFAULT_REGION, EXISTING_ID)));
         when(imageRepository.save(any(ImageEntity.class))).thenAnswer(invocation -> invocation.getArgument(0, ImageEntity.class));
-        when(imageConverter.convert(image)).thenReturn(new ImageEntity());
+        when(imageConverter.convert(any(), any())).thenReturn(new ImageEntity());
 
         ImageEntity imageEntity = underTest.create(stack, imageRequest);
 
@@ -190,7 +190,7 @@ public class ImageServiceTest {
         currentImage.setId(2L);
         when(imageRepository.findById(2L)).thenReturn(Optional.of(currentImage));
 
-        underTest.revertImageToRevision(2L, 3L);
+        underTest.revertImageToRevision("accountId", 2L, 3L);
 
         ArgumentCaptor<ImageEntity> captor = ArgumentCaptor.forClass(ImageEntity.class);
         verify(imageRepository).save(captor.capture());

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/userdata/UserDataServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/userdata/UserDataServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.core.task.AsyncTaskExecutor;
 
 import com.sequenceiq.cloudbreak.service.proxy.ProxyConfigDtoService;
 import com.sequenceiq.cloudbreak.service.proxy.ProxyConfigUserDataReplacer;
+import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
 import com.sequenceiq.freeipa.entity.ImageEntity;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.CredentialService;
@@ -72,6 +73,9 @@ class UserDataServiceTest {
     @Mock
     private Stack stack;
 
+    @Mock
+    private SecretService secretService;
+
     @BeforeEach
     void setUp() {
         lenient().when(stackService.getStackById(STACK_ID)).thenReturn(stack);
@@ -104,11 +108,12 @@ class UserDataServiceTest {
     private void setUserData(String userData) {
         ImageEntity image = new ImageEntity();
         image.setUserdata(userData);
+        image.setGatewayUserdata(userData);
         when(imageService.getByStackId(STACK_ID)).thenReturn(image);
     }
 
     private AbstractStringAssert<?> assertThatUserData() {
         verify(imageService).save(imageCaptor.capture());
-        return assertThat(imageCaptor.getValue().getUserdata());
+        return assertThat(imageCaptor.getValue().getGatewayUserdata());
     }
 }


### PR DESCRIPTION
Reverts hortonworks/cloudbreak#14498 which was a revert of hortonworks/cloudbreak#14383, so basically re-apply changes of hortonworks/cloudbreak#14383 with some enhancements and upgrade related fixes. Also fixed the CF based FreeIpa creation which was an issue with the previous PR.
Tested on GCP with DL upgrade also.