### PR TITLE
CB-21320 Change vm.supportedJavaVersions property format

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/vm/VirtualMachineConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/vm/VirtualMachineConfiguration.java
@@ -1,21 +1,27 @@
 package com.sequenceiq.cloudbreak.vm;
 
-import java.util.List;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConfigurationProperties("vm")
 public class VirtualMachineConfiguration {
 
-    private List<Integer> supportedJavaVersions;
+    private final Set<Integer> supportedJavaVersions;
 
-    public List<Integer> getSupportedJavaVersions() {
-        return supportedJavaVersions;
+    public VirtualMachineConfiguration(@Value("${vm.supportedJavaVersions}") String supportedJavaVersions) {
+        this.supportedJavaVersions = Arrays.stream(supportedJavaVersions.split(","))
+                .map(String::trim)
+                .filter(Predicate.not(String::isEmpty))
+                .map(Integer::parseInt)
+                .collect(Collectors.toSet());
     }
 
-    public void setSupportedJavaVersions(List<Integer> supportedJavaVersions) {
-        this.supportedJavaVersions = supportedJavaVersions;
+    public Set<Integer> getSupportedJavaVersions() {
+        return supportedJavaVersions;
     }
 }

--- a/common/src/main/resources/common-config.yml
+++ b/common/src/main/resources/common-config.yml
@@ -157,6 +157,4 @@ hikari:
       down-if-pool-is-full: false
 
 vm:
-  supportedJavaVersions:
-  - 8
-  - 11
+  supportedJavaVersions: 8,11

--- a/common/src/test/java/com/sequenceiq/cloudbreak/vm/VirtualMachineConfigurationTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/vm/VirtualMachineConfigurationTest.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.cloudbreak.vm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class VirtualMachineConfigurationTest {
+
+    @ParameterizedTest(name = "[{index}] \"{0}\" is parsed to {1}")
+    @MethodSource("supportedJavaVersionsArguments")
+    void supportedJavaVersions(String property, Set<Integer> expected) {
+        Set<Integer> result = new VirtualMachineConfiguration(property).getSupportedJavaVersions();
+        assertThat(result).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> supportedJavaVersionsArguments() {
+        return Stream.of(
+                Arguments.of("", Set.of()),
+                Arguments.of(" ", Set.of()),
+                Arguments.of("8", Set.of(8)),
+                Arguments.of("8 ", Set.of(8)),
+                Arguments.of("8,11", Set.of(8, 11)),
+                Arguments.of("8,11,", Set.of(8, 11))
+        );
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/JavaVersionValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/JavaVersionValidatorTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,7 +41,7 @@ class JavaVersionValidatorTest {
 
     @Test
     public void shouldNotFailInCaseOfImageSupportsJavaVersion() {
-        when(virtualMachineConfiguration.getSupportedJavaVersions()).thenReturn(List.of(JAVA_VERSION_11));
+        when(virtualMachineConfiguration.getSupportedJavaVersions()).thenReturn(Set.of(JAVA_VERSION_11));
         when(image.getPackageVersions()).thenReturn(Map.of(String.format("java%d", JAVA_VERSION_11), "anyvalue"));
 
         victim.validateImage(image, JAVA_VERSION_11, ACCOUNT_ID);
@@ -49,7 +49,7 @@ class JavaVersionValidatorTest {
 
     @Test
     public void shouldFailInCaseOfJavaVersionNotSupportedByTheVirtualMachineConfiguration() {
-        when(virtualMachineConfiguration.getSupportedJavaVersions()).thenReturn(List.of());
+        when(virtualMachineConfiguration.getSupportedJavaVersions()).thenReturn(Set.of());
 
         BadRequestException exception = assertThrows(BadRequestException.class,
                 () -> victim.validateImage(image, JAVA_VERSION_11, ACCOUNT_ID));
@@ -59,7 +59,7 @@ class JavaVersionValidatorTest {
 
     @Test
     public void shoudlFailOnJavaVersionIsNotSupportedByTheImage() {
-        when(virtualMachineConfiguration.getSupportedJavaVersions()).thenReturn(List.of(JAVA_VERSION_11));
+        when(virtualMachineConfiguration.getSupportedJavaVersions()).thenReturn(Set.of(JAVA_VERSION_11));
         when(image.getPackageVersions()).thenReturn(Collections.emptyMap());
         when(image.getUuid()).thenReturn("imageuuid");
 

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
@@ -680,7 +680,7 @@ class SdxServiceTest {
         when(transactionService.required(isA(Supplier.class))).thenAnswer(invocation -> invocation.getArgument(0, Supplier.class).get());
         String lightDutyJson = FileReaderUtils.readFileFromClasspath("/duties/7.1.0/aws/light_duty.json");
         when(cdpConfigService.getConfigForKey(any())).thenReturn(JsonUtil.readValue(lightDutyJson, StackV4Request.class));
-        when(virtualMachineConfiguration.getSupportedJavaVersions()).thenReturn(List.of(11));
+        when(virtualMachineConfiguration.getSupportedJavaVersions()).thenReturn(Set.of(11));
 
         SdxClusterRequest sdxClusterRequest = createSdxClusterRequest(null, LIGHT_DUTY);
         sdxClusterRequest.setJavaVersion(11);
@@ -1891,7 +1891,7 @@ class SdxServiceTest {
 
         when(sdxClusterRepository.findByAccountIdAndEnvNameAndDeletedIsNullAndDetachedIsFalse(
                 anyString(), anyString())).thenReturn(Collections.emptyList());
-        when(virtualMachineConfiguration.getSupportedJavaVersions()).thenReturn(Collections.emptyList());
+        when(virtualMachineConfiguration.getSupportedJavaVersions()).thenReturn(Collections.emptySet());
 
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->


### PR DESCRIPTION
We can not pass list values from dps-k8s so the property format was changed to a comma separated list that is parsed in the VirtualMachineConfiguration class.

See detailed description in the commit message.