### PR TITLE
CB-21403 Content size validation limit increase

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/validation/ContentSizeProvider.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/validation/ContentSizeProvider.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.cloudbreak.validation;
+
+public interface ContentSizeProvider {
+
+    int getMaxSizeInBytes();
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/validation/DefaultContentSizeProvider.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/validation/DefaultContentSizeProvider.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.cloudbreak.validation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DefaultContentSizeProvider implements ContentSizeProvider {
+
+    private static final String ENV_MAX_SIZE_IN_BYTES = "cb.validation.max.content.size";
+
+    private static final Integer DEFAULT_MAX_SIZE_IN_BYTES = 6 * 1024 * 1024;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultContentSizeProvider.class);
+
+    private int maxContentSizeInBytes;
+
+    public DefaultContentSizeProvider(Environment environment) {
+        this.maxContentSizeInBytes = initMaxContentSizeInBytes(environment);
+    }
+
+    private int initMaxContentSizeInBytes(Environment environment) {
+        if (!environment.containsProperty(ENV_MAX_SIZE_IN_BYTES)) {
+            LOGGER.debug("{} property is not set. Defaulting its value to 6 MB.", ENV_MAX_SIZE_IN_BYTES);
+        }
+        return Integer.valueOf(environment.getProperty(ENV_MAX_SIZE_IN_BYTES, DEFAULT_MAX_SIZE_IN_BYTES.toString()));
+    }
+
+    @Override
+    public int getMaxSizeInBytes() {
+        return maxContentSizeInBytes;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/HttpContentSizeValidator.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/HttpContentSizeValidator.java
@@ -1,21 +1,22 @@
 package com.sequenceiq.cloudbreak.validation;
 
+import javax.inject.Inject;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import javax.ws.rs.core.Response.Status.Family;
 import javax.ws.rs.core.Response.StatusType;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.helper.HttpHelper;
 
+@Component
 public class HttpContentSizeValidator implements ConstraintValidator<ValidHttpContentSize, String> {
-
-    public static final int MAX_SIZE = 5;
-
-    public static final int MAX_IN_BYTES = 5 * 1024 * 1024;
 
     public static final String FAILED_TO_GET_BY_FAMILY_TYPE = "Failed to get response by the specified URL '%s' due to: '%s'!";
 
@@ -23,17 +24,19 @@ public class HttpContentSizeValidator implements ConstraintValidator<ValidHttpCo
 
     public static final String FAILED_TO_GET_WITH_EXCEPTION = "Failed to get response by the specified URL!";
 
+    public static final String MESSAGE_VARIABLE = "contentLimit";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpContentSizeValidator.class);
+
+    @Inject
+    private ContentSizeProvider contentSizeProvider;
 
     private HttpHelper httpHelper = HttpHelper.getInstance();
 
     @Override
-    public void initialize(ValidHttpContentSize constraintAnnotation) {
-    }
-
-    @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
         LOGGER.info("content size validation was called. Value: {}", value);
+
         if (value == null) {
             return true;
         } else if (!value.startsWith("http")) {
@@ -47,7 +50,14 @@ public class HttpContentSizeValidator implements ConstraintValidator<ValidHttpCo
                 context.buildConstraintViolationWithTemplate(msg).addConstraintViolation();
                 return false;
             }
-            return contentLength.getValue() > 0 && contentLength.getValue() <= MAX_IN_BYTES;
+            int maxSizeInBytes = contentSizeProvider.getMaxSizeInBytes();
+            boolean valid = contentLength.getValue() > 0 && contentLength.getValue() <= maxSizeInBytes;
+            if (!valid) {
+                context.unwrap(HibernateConstraintValidatorContext.class)
+                        .addMessageParameter(MESSAGE_VARIABLE, FileUtils.byteCountToDisplaySize(maxSizeInBytes));
+            }
+
+            return valid;
         } catch (Throwable throwable) {
             LOGGER.info("content size validation failed.", throwable);
             context.buildConstraintViolationWithTemplate(FAILED_TO_GET_WITH_EXCEPTION).addConstraintViolation();

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ImageCatalogValidator.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ImageCatalogValidator.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.validation;
 
 import java.util.Map;
 
+import javax.inject.Inject;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import javax.ws.rs.core.Response.Status.Family;
@@ -10,6 +11,7 @@ import javax.ws.rs.core.Response.StatusType;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -18,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sequenceiq.cloudbreak.api.helper.HttpHelper;
 
+@Component
 public class ImageCatalogValidator implements ConstraintValidator<ValidImageCatalog, String> {
 
     public static final String FAILED_TO_GET_BY_FAMILY_TYPE = "Failed to get response by the specified URL '%s' due to: '%s'!";
@@ -32,9 +35,10 @@ public class ImageCatalogValidator implements ConstraintValidator<ValidImageCata
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    private static final HttpContentSizeValidator HTTP_CONTENT_SIZE_VALIDATOR = new HttpContentSizeValidator();
-
     private static final HttpHelper HTTP_HELPER = HttpHelper.getInstance();
+
+    @Inject
+    private HttpContentSizeValidator httpContentSizeValidator;
 
     @Override
     public void initialize(ValidImageCatalog constraintAnnotation) {
@@ -44,7 +48,7 @@ public class ImageCatalogValidator implements ConstraintValidator<ValidImageCata
     public boolean isValid(String value, ConstraintValidatorContext context) {
         LOGGER.info("Image Catalog validation was called: {}", value);
         try {
-            if (value == null || !HTTP_CONTENT_SIZE_VALIDATOR.isValid(value, context)) {
+            if (value == null || !httpContentSizeValidator.isValid(value, context)) {
                 return false;
             }
             Pair<StatusType, String> content = HTTP_HELPER.getContent(value);

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ValidHttpContentSize.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ValidHttpContentSize.java
@@ -15,7 +15,7 @@ import javax.validation.Payload;
 @Constraint(validatedBy = HttpContentSizeValidator.class)
 public @interface ValidHttpContentSize {
 
-    String message() default "The content of the given URL must be less than " + HttpContentSizeValidator.MAX_SIZE + " Mb";
+    String message() default "The content of the given URL must be less than {" + HttpContentSizeValidator.MESSAGE_VARIABLE + "}.";
 
     Class<?>[] groups() default {};
 

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/api/model/imagecatalog/ValidatorTestHelper.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/api/model/imagecatalog/ValidatorTestHelper.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.cloudbreak.api.model.imagecatalog;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.sequenceiq.common.model.annotations.IgnorePojoValidation;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { ValidatorTestHelperConfiguration.class })
+@IgnorePojoValidation
+public class ValidatorTestHelper {
+
+    @Autowired
+    private Validator validator;
+
+    protected List<String> getPropertyPaths(Set<? extends ConstraintViolation<?>> violations) {
+        return violations.stream().map(ConstraintViolation::getPropertyPath).map(Object::toString).collect(Collectors.toList());
+    }
+
+    protected List<String> getMessageTemplate(Set<? extends ConstraintViolation<?>> violations) {
+        return violations.stream().map(ConstraintViolation::getMessageTemplate).map(msg -> msg.replaceAll("([{}])", ""))
+                .collect(Collectors.toList());
+    }
+
+    public Validator getValidator() {
+        return validator;
+    }
+}

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/api/model/imagecatalog/ValidatorTestHelperConfiguration.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/api/model/imagecatalog/ValidatorTestHelperConfiguration.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.cloudbreak.api.model.imagecatalog;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+@Configuration
+public class ValidatorTestHelperConfiguration {
+
+    @Bean
+    public LocalValidatorFactoryBean validator() {
+        return new LocalValidatorFactoryBean();
+    }
+}

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -836,7 +836,8 @@ cb:
       maxAttempts: 5
       backOffDelay: 2000
       backOffMultiplier: 2
-
+  validation:
+    max.content.size: 6291456
 
 
 cluster:


### PR DESCRIPTION
The image catalogs are reaching the original 5 MB limit of our validators. Refactored the limit to an environment variable and increased it to 6 MB.
