### PR TITLE
CB-21385 We can allow ECDSA only on GOV envs

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak.auth.altus;
 
-import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.ACCESS_KEY_ECDSA;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.AUDIT_ARCHIVING_GCP;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_ALLOW_DIFFERENT_DATAHUB_VERSION_THAN_DATALAKE;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_ALLOW_HA_REPAIR;
@@ -575,10 +574,6 @@ public class EntitlementService {
 
     public boolean isUpgradeAttachedDatahubsCheckSkipped(String accountId) {
         return isEntitlementRegistered(accountId, CDP_UPGRADE_SKIP_ATTACHED_DATAHUBS_CHECK);
-    }
-
-    public boolean isECDSABasedAccessKeyEnabled(String accountId) {
-        return isEntitlementRegistered(accountId, ACCESS_KEY_ECDSA);
     }
 
     public boolean isEditProxyConfigEnabled(String accountId) {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsEnsureMachineUserHandlerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsEnsureMachineUserHandlerTest.java
@@ -23,10 +23,8 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.thunderhead.service.common.usage.UsageProto;
-import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.eventbus.Event;
-import com.sequenceiq.cloudbreak.telemetry.TelemetryFeatureService;
 import com.sequenceiq.common.api.telemetry.model.DataBusCredential;
 import com.sequenceiq.common.api.telemetry.model.DiagnosticsDestination;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
@@ -37,6 +35,7 @@ import com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollecti
 import com.sequenceiq.freeipa.service.AltusMachineUserService;
 import com.sequenceiq.freeipa.service.image.ImageService;
 import com.sequenceiq.freeipa.service.stack.StackService;
+import com.sequenceiq.freeipa.service.telemetry.TelemetryConfigService;
 
 @ExtendWith(MockitoExtension.class)
 public class DiagnosticsEnsureMachineUserHandlerTest {
@@ -56,10 +55,7 @@ public class DiagnosticsEnsureMachineUserHandlerTest {
     private AltusMachineUserService altusMachineUserService;
 
     @Mock
-    private EntitlementService entitlementService;
-
-    @Mock
-    private TelemetryFeatureService telemetryFeatureService;
+    private TelemetryConfigService telemetryConfigService;
 
     @BeforeEach
     public void setUp() {
@@ -83,6 +79,7 @@ public class DiagnosticsEnsureMachineUserHandlerTest {
         underTest.doAccept(new HandlerEvent<>(new Event<>(event)));
         // THEN
         verify(altusMachineUserService, times(1)).getOrCreateDataBusCredentialIfNeeded(anyLong(), any());
+        verify(telemetryConfigService, times(1)).getCdpAccessKeyType(stack);
     }
 
     @Test


### PR DESCRIPTION
"We should make the key type selection based on which type of deployment we have.
 On gov environments we can only allow ECDSA.
 On commercial clouds we can only support RSA since some components(e.g. telemetry-publisher) can't accept ECDSA.

 We should remove the entitlement and substitute it with either a deployment config or we could also check on the crn partition to decide if we are on a gov deployment or not. Or any reliable way to tell if it's a gov env or not will suffice."