### PR TITLE
CB-21417 Fix `GeneralClusterConfigs.variant`

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
@@ -242,6 +242,7 @@ public class StackToTemplatePreparationObjectConverter {
 
             Builder builder = Builder.builder()
                     .withCloudPlatform(CloudPlatform.valueOf(source.getCloudPlatform()))
+                    .withPlatformVariant(source.getPlatformVariant())
                     .withRdsViews(rdsViews)
                     .withRdsSslCertificateFilePath(sslCertsFilePath)
                     .withGateway(gateway, gatewaySignKey, exposedServiceCollector.getAllKnoxExposed(version))

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToTemplatePreparationObjectConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToTemplatePreparationObjectConverter.java
@@ -176,6 +176,7 @@ public class StackV4RequestToTemplatePreparationObjectConverter {
 
             Builder builder = Builder.builder()
                     .withCloudPlatform(source.getCloudPlatform())
+                    .withPlatformVariant(source.getVariant())
                     .withRdsViews(rdsConfigs)
                     .withHostgroupViews(hostgroupViews)
                     .withGateway(gateway, gatewaySignKey, exposedServiceCollector.getAllKnoxExposed(version))

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
@@ -123,6 +123,8 @@ public class StackToTemplatePreparationObjectConverterTest {
 
     private static final String TEST_CLOUD_PLATFORM = "AWS";
 
+    private static final String TEST_PLATFORM_VARIANT = "AWS_VARIANT";
+
     private static final String ADMIN_GROUP_NAME = "mockAdmins";
 
     private static final Map<String, String> MOCK_GROUP_MAPPINGS = Map.of(ADMIN_GROUP_NAME, "mockGroupRole");
@@ -290,6 +292,7 @@ public class StackToTemplatePreparationObjectConverterTest {
         when(stackMock.getEnvironmentCrn()).thenReturn("env");
         when(stackMock.getCloudPlatform()).thenReturn(TEST_CLOUD_PLATFORM);
         when(stackMock.cloudPlatform()).thenReturn(TEST_CLOUD_PLATFORM);
+        when(stackMock.getPlatformVariant()).thenReturn(TEST_PLATFORM_VARIANT);
         when(stackMock.getType()).thenReturn(StackType.DATALAKE);
         when(stackMock.getRegion()).thenReturn(REGION);
         when(stackMock.getAvailabilityZone()).thenReturn(AVAILABILITY_ZONE);
@@ -602,13 +605,14 @@ public class StackToTemplatePreparationObjectConverterTest {
     }
 
     @Test
-    public void testConvertCloudPlatformMatches() {
+    public void testConvertCloudPlatformAndVariantMatch() {
         when(blueprintViewProvider.getBlueprintView(any())).thenReturn(getBlueprintView());
         when(stackMock.getStack()).thenReturn(stackMock);
 
         TemplatePreparationObject result = underTest.convert(stackMock);
 
         assertThat(result.getCloudPlatform()).isEqualTo(CloudPlatform.AWS);
+        assertThat(result.getPlatformVariant()).isEqualTo(TEST_PLATFORM_VARIANT);
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackV4RequestToTemplatePreparationObjectConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackV4RequestToTemplatePreparationObjectConverterTest.java
@@ -1,10 +1,11 @@
 package com.sequenceiq.cloudbreak.converter.v2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -21,11 +22,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
@@ -89,7 +93,11 @@ import com.sequenceiq.environment.api.v1.credential.model.response.CredentialRes
 import com.sequenceiq.environment.api.v1.environment.model.base.IdBrokerMappingSource;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class StackV4RequestToTemplatePreparationObjectConverterTest {
+
+    private static final String TEST_PLATFORM_VARIANT = "AWS_VARIANT";
 
     private static final String TEST_CREDENTIAL_NAME = "testCred";
 
@@ -219,13 +227,13 @@ public class StackV4RequestToTemplatePreparationObjectConverterTest {
     @Mock
     private RdsViewProvider rdsViewProvider;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
         when(restRequestThreadLocalService.getCloudbreakUser()).thenReturn(cloudbreakUser);
         when(source.getEnvironmentCrn()).thenReturn(TEST_ENVIRONMENT_CRN);
         when(source.getCluster()).thenReturn(cluster);
         when(source.getCloudPlatform()).thenReturn(CloudPlatform.AWS);
+        when(source.getVariant()).thenReturn(TEST_PLATFORM_VARIANT);
         when(source.getType()).thenReturn(StackType.DATALAKE);
         when(source.getPlacement()).thenReturn(placementSettings);
         when(source.getName()).thenReturn(TEST_CLUSTER_NAME);
@@ -317,9 +325,8 @@ public class StackV4RequestToTemplatePreparationObjectConverterTest {
 
     @Test
     public void testConvertWhenProvidingDataThenBlueprintWithExpectedDataShouldBeStored() {
-        String stackVersion = TEST_VERSION;
         String stackType = "HDP";
-        when(blueprintStackInfo.getVersion()).thenReturn(stackVersion);
+        when(blueprintStackInfo.getVersion()).thenReturn(TEST_VERSION);
         when(blueprintStackInfo.getType()).thenReturn(stackType);
         BlueprintView expected = mock(BlueprintView.class);
         when(blueprintViewProvider.getBlueprintView(blueprint)).thenReturn(expected);
@@ -370,9 +377,11 @@ public class StackV4RequestToTemplatePreparationObjectConverterTest {
     }
 
     @Test
-    public void testConvertCloudPlatformMatches() {
+    public void testConvertCloudPlatformAndVariantMatch() {
         TemplatePreparationObject result = underTest.convert(source);
+
         assertEquals(CloudPlatform.AWS, result.getCloudPlatform());
+        assertThat(result.getPlatformVariant()).isEqualTo(TEST_PLATFORM_VARIANT);
     }
 
     @Test
@@ -465,7 +474,7 @@ public class StackV4RequestToTemplatePreparationObjectConverterTest {
         for (int i = 0; i < GENERAL_TEST_QUANTITY; i++) {
             InstanceGroupV4Request instanceGroup = new InstanceGroupV4Request();
             InstanceTemplateV4Request template = new InstanceTemplateV4Request();
-            template.setAttachedVolumes(Collections.EMPTY_SET);
+            template.setAttachedVolumes(Collections.emptySet());
             instanceGroup.setName(String.format("group-%d", i));
             instanceGroup.setTemplate(template);
             instanceGroup.setType(InstanceGroupType.CORE);

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveKnoxConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveKnoxConfigProvider.java
@@ -30,14 +30,14 @@ public class HiveKnoxConfigProvider implements CmTemplateComponentConfigProvider
         if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_1_0)) {
             serviceConfigs.add(config(HIVE_SERVICE_CONFIG_SAFETY_VALVE, filePerEvent));
         } else {
-            KerberosConfig kerberosConfigOpt = templatePreparationObject.getKerberosConfig().get();
-            String realm = kerberosConfigOpt.getRealm();
+            KerberosConfig kerberosConfig = templatePreparationObject.getKerberosConfig().get();
+            String realm = kerberosConfig.getRealm();
             String principal = ConfigUtils.getSafetyValveProperty("hive.server2.authentication.spnego.principal", "HTTP/_HOST@" + realm);
             String keytab = ConfigUtils.getSafetyValveProperty("hive.server2.authentication.spnego.keytab", "hive.keytab");
             serviceConfigs.add(config(HIVE_SERVICE_CONFIG_SAFETY_VALVE, principal + keytab + filePerEvent));
         }
         if (CMRepositoryVersionUtil.isS3SslChannelModeSupported(cdhVersion, templatePreparationObject.getCloudPlatform(),
-                templatePreparationObject.getGeneralClusterConfigs().getVariant())) {
+                templatePreparationObject.getPlatformVariant())) {
             String sslChannelMode = ConfigUtils.getSafetyValveProperty("fs.s3a.ssl.channel.mode", "openssl");
             serviceConfigs.add(config(HIVE_SERVICE_CONFIG_SAFETY_VALVE, sslChannelMode));
         }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/spark/Spark3OnYarnRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/spark/Spark3OnYarnRoleConfigProvider.java
@@ -37,7 +37,7 @@ public class Spark3OnYarnRoleConfigProvider extends AbstractRoleConfigProvider {
                             SPARK3_YARN_ACCESS_DIR_PARAM + ConfigUtils.getBasePathFromStorageLocation(storageLocationView.get().getValue())));
                 }
                 if (CMRepositoryVersionUtil.isS3SslChannelModeSupported(source.getBlueprintView()
-                        .getProcessor().getVersion().orElse(""), source.getCloudPlatform(), source.getGeneralClusterConfigs().getVariant())) {
+                        .getProcessor().getVersion().orElse(""), source.getCloudPlatform(), source.getPlatformVariant())) {
                     roleConfigs.add(config(SPARK3_CONF_CLIENT_SAFETY_VALVE, SPARK3_HADOOP_S3_SSL_CHANNEL_MODE));
                 }
                 return roleConfigs;

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/spark/SparkOnYarnRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/spark/SparkOnYarnRoleConfigProvider.java
@@ -37,7 +37,7 @@ public class SparkOnYarnRoleConfigProvider extends AbstractRoleConfigProvider {
                             SPARK_YARN_ACCESS_DIR_PARAM + ConfigUtils.getBasePathFromStorageLocation(storageLocationView.get().getValue())));
                 }
                 if (CMRepositoryVersionUtil.isS3SslChannelModeSupported(source.getBlueprintView()
-                        .getProcessor().getVersion().orElse(""), source.getCloudPlatform(), source.getGeneralClusterConfigs().getVariant())) {
+                        .getProcessor().getVersion().orElse(""), source.getCloudPlatform(), source.getPlatformVariant())) {
                     roleConfigs.add(config(SPARK_CONF_CLIENT_SAFETY_VALVE, SPARK_HADOOP_S3_SSL_CHANNEL_MODE));
                 }
                 return roleConfigs;

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/general/GeneralClusterConfigsProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/general/GeneralClusterConfigsProvider.java
@@ -44,7 +44,7 @@ public class GeneralClusterConfigsProvider {
         generalClusterConfigs.setCloudbreakAmbariPassword(cluster.getCloudbreakAmbariPassword());
         generalClusterConfigs.setNodeCount(stack.getFullNodeCount().intValue());
         generalClusterConfigs.setPrimaryGatewayInstanceDiscoveryFQDN(Optional.ofNullable(stack.getPrimaryGatewayInstance().getDiscoveryFQDN()));
-        generalClusterConfigs.setVariant(stack.getPlatformVariant());
+        generalClusterConfigs.setVariant(cluster.getVariant());
         generalClusterConfigs.setAutoTlsEnabled(cluster.getAutoTlsEnabled());
         boolean userFacingCertHasBeenGenerated = StringUtils.isNotEmpty(stack.getSecurityConfig().getUserFacingKey())
                 && StringUtils.isNotEmpty(stack.getSecurityConfig().getUserFacingCert());

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveKnoxConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveKnoxConfigProviderTest.java
@@ -25,7 +25,6 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.dto.KerberosConfig;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
-import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
 
 @ExtendWith(MockitoExtension.class)
 class HiveKnoxConfigProviderTest {
@@ -78,14 +77,12 @@ class HiveKnoxConfigProviderTest {
     }
 
     private static TemplatePreparationObject createTemplatePreparationObject(String platformVariant) {
-        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
-        generalClusterConfigs.setVariant(platformVariant);
         return Builder.builder()
                 .withKerberosConfig(KerberosConfig.KerberosConfigBuilder.aKerberosConfig()
                         .withRealm("EXAMPLE.COM")
                         .build())
                 .withCloudPlatform(CloudPlatform.AWS)
-                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withPlatformVariant(platformVariant)
                 .build();
     }
 

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/spark/Spark3OnYarnRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/spark/Spark3OnYarnRoleConfigProviderTest.java
@@ -1,15 +1,15 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.spark;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
@@ -19,14 +19,13 @@ import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
 import com.sequenceiq.cloudbreak.template.filesystem.StorageLocationView;
 import com.sequenceiq.cloudbreak.template.filesystem.s3.S3FileSystemConfigurationsView;
-import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
 import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 import com.sequenceiq.common.api.filesystem.S3FileSystem;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class Spark3OnYarnRoleConfigProviderTest {
 
     private final Spark3OnYarnRoleConfigProvider underTest = new Spark3OnYarnRoleConfigProvider();
@@ -102,15 +101,12 @@ public class Spark3OnYarnRoleConfigProviderTest {
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
         cmTemplateProcessor.setCdhVersion("7.2.16");
 
-        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
-        generalClusterConfigs.setVariant(platformVariant);
-
         return Builder.builder()
                 .withFileSystemConfigurationView(fileSystemConfigurationsView)
                 .withHostgroupViews(Set.of(master, worker))
                 .withBlueprintView(new BlueprintView(null, null, null, cmTemplateProcessor))
                 .withCloudPlatform(cloudPlatform)
-                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withPlatformVariant(platformVariant)
                 .build();
     }
 

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/spark/SparkOnYarnRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/spark/SparkOnYarnRoleConfigProviderTest.java
@@ -1,15 +1,15 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.spark;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
@@ -19,14 +19,13 @@ import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
 import com.sequenceiq.cloudbreak.template.filesystem.StorageLocationView;
 import com.sequenceiq.cloudbreak.template.filesystem.s3.S3FileSystemConfigurationsView;
-import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
 import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 import com.sequenceiq.common.api.filesystem.S3FileSystem;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SparkOnYarnRoleConfigProviderTest {
 
     private final SparkOnYarnRoleConfigProvider underTest = new SparkOnYarnRoleConfigProvider();
@@ -105,15 +104,12 @@ public class SparkOnYarnRoleConfigProviderTest {
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
         cmTemplateProcessor.setCdhVersion("7.2.16");
 
-        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
-        generalClusterConfigs.setVariant(platformVariant);
-
         return Builder.builder()
                 .withFileSystemConfigurationView(fileSystemConfigurationsView)
                 .withHostgroupViews(Set.of(master, worker))
                 .withBlueprintView(new BlueprintView(null, null, null, cmTemplateProcessor))
                 .withCloudPlatform(cloudPlatform)
-                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withPlatformVariant(platformVariant)
                 .build();
     }
 

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/general/GeneralClusterConfigsProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/general/GeneralClusterConfigsProviderTest.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.cloudbreak.cmtemplate.general;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ClusterV4Request;
+import com.sequenceiq.cloudbreak.domain.SecurityConfig;
+import com.sequenceiq.cloudbreak.dto.StackDtoDelegate;
+import com.sequenceiq.cloudbreak.dto.credential.Credential;
+import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
+import com.sequenceiq.cloudbreak.view.ClusterView;
+import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
+import com.sequenceiq.cloudbreak.workspace.model.User;
+
+@ExtendWith(MockitoExtension.class)
+class GeneralClusterConfigsProviderTest {
+
+    public static final String CLUSTER_MANAGER_VARIANT = "clusterManagerVariant";
+
+    @InjectMocks
+    private GeneralClusterConfigsProvider underTest;
+
+    @Mock
+    private StackDtoDelegate stack;
+
+    @Mock
+    private ClusterView cluster;
+
+    @Mock
+    private InstanceMetadataView primaryGatewayInstance;
+
+    @Mock
+    private SecurityConfig securityConfig;
+
+    @Test
+    void generalClusterConfigsTestVariantWhenStackDtoDelegate() {
+        when(stack.getCluster()).thenReturn(cluster);
+        when(stack.getPrimaryGatewayInstance()).thenReturn(primaryGatewayInstance);
+        when(stack.getSecurityConfig()).thenReturn(securityConfig);
+        when(stack.getCreator()).thenReturn(new User());
+
+        when(cluster.getVariant()).thenReturn(CLUSTER_MANAGER_VARIANT);
+
+        GeneralClusterConfigs generalClusterConfigs = underTest.generalClusterConfigs(stack, Credential.builder().build());
+
+        assertThat(generalClusterConfigs.getVariant()).isEqualTo(CLUSTER_MANAGER_VARIANT);
+    }
+
+    @Test
+    void generalClusterConfigsTestVariantWhenStackV4Request() {
+        StackV4Request stackRequest = new StackV4Request();
+        ClusterV4Request clusterRequest = new ClusterV4Request();
+        stackRequest.setCluster(clusterRequest);
+
+        GeneralClusterConfigs generalClusterConfigs = underTest.generalClusterConfigs(stackRequest, Credential.builder().build(), null,
+                CLUSTER_MANAGER_VARIANT);
+
+        assertThat(generalClusterConfigs.getVariant()).isEqualTo(CLUSTER_MANAGER_VARIANT);
+    }
+
+}

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
@@ -48,6 +48,8 @@ public class TemplatePreparationObject {
 
     private final CloudPlatform cloudPlatform;
 
+    private final String platformVariant;
+
     private final GatewayView gatewayView;
 
     private final GeneralClusterConfigs generalClusterConfigs;
@@ -96,6 +98,7 @@ public class TemplatePreparationObject {
 
     private TemplatePreparationObject(Builder builder) {
         cloudPlatform = builder.cloudPlatform;
+        platformVariant = builder.platformVariant;
         rdsViews = builder.rdsViews.stream().collect(Collectors.toMap(
                 rdsConfig -> rdsConfig.getType().toLowerCase(),
                 Function.identity()
@@ -133,6 +136,10 @@ public class TemplatePreparationObject {
 
     public CloudPlatform getCloudPlatform() {
         return cloudPlatform;
+    }
+
+    public String getPlatformVariant() {
+        return platformVariant;
     }
 
     public Optional<CustomConfigurationsView> getCustomConfigurationsView() {
@@ -235,6 +242,8 @@ public class TemplatePreparationObject {
 
         private CloudPlatform cloudPlatform;
 
+        private String platformVariant;
+
         private Set<RdsView> rdsViews = new HashSet<>();
 
         private String rdsSslCertificateFilePath;
@@ -287,6 +296,11 @@ public class TemplatePreparationObject {
 
         public Builder withCloudPlatform(CloudPlatform cloudPlatform) {
             this.cloudPlatform = cloudPlatform;
+            return this;
+        }
+
+        public Builder withPlatformVariant(String platformVariant) {
+            this.platformVariant = platformVariant;
             return this;
         }
 

--- a/template-manager-core/src/test/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObjectTest.java
+++ b/template-manager-core/src/test/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObjectTest.java
@@ -8,6 +8,8 @@ class TemplatePreparationObjectTest {
 
     private static final String SSL_CERTS_FILE_PATH = "/foo/bar.pem";
 
+    private static final String TEST_PLATFORM_VARIANT = "AWS_VARIANT";
+
     @Test
     void getRdsSslCertificateFilePathTestWhenFilePathAbsent() {
         TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
@@ -23,6 +25,15 @@ class TemplatePreparationObjectTest {
                 .build();
 
         assertThat(tpo.getRdsSslCertificateFilePath()).isEqualTo(SSL_CERTS_FILE_PATH);
+    }
+
+    @Test
+    void getPlatformVariantTest() {
+        TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
+                .withPlatformVariant(TEST_PLATFORM_VARIANT)
+                .build();
+
+        assertThat(tpo.getPlatformVariant()).isEqualTo(TEST_PLATFORM_VARIANT);
     }
 
 }


### PR DESCRIPTION
* Partially reverts 79215c7b434115564660b61d73700fd7c818d726 / #14667.
  * `GeneralClusterConfigs.variant` is restored to its former meaning, i.e. cluster manager variant.
* Introduce `TemplatePreparationObject.platformVariant`.
  * Populated in the respective converters.
  * Utilized in config providers when invoking `CMRepositoryVersionUtil.isS3SslChannelModeSupported()`.
* Testing: Added new UT & adapted existing ones, migrating all JUnit 4 ones to JUnit 5.
