### PR TITLE
CDPSDX-3896 move CM MGMT services to AUXILIARY host in case of Enterprise DL

### DIFF
--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/util/BlueprintUtilsTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/util/BlueprintUtilsTest.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.cloudbreak.cmtemplate.util;
+
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sequenceiq.cloudbreak.cmtemplate.utils.BlueprintUtils;
+import com.sequenceiq.cloudbreak.json.JsonHelper;
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class BlueprintUtilsTest {
+
+    @Spy
+    private JsonHelper jsonHelper;
+
+    @InjectMocks
+    private BlueprintUtils underTest;
+
+    @Test
+    public void descriptionTest() throws IOException {
+        validateDescription("7.2.17", "cdp-sdx-medium-ha", "Medium SDX template");
+        validateDescription("7.2.17", "cdp-sdx-enterprise", "Enterprise SDX template");
+        validateDescription("7.2.18", "cdp-sdx-medium-ha", "Medium SDX template");
+        validateDescription("7.2.18", "cdp-sdx-enterprise", "Enterprise SDX template");
+        validateDescription("7.2.19", "cdp-sdx-medium-ha", "Medium SDX template");
+        validateDescription("7.2.19", "cdp-sdx-enterprise", "Enterprise SDX template");
+        validateDescription("7.2.20", "cdp-sdx-medium-ha", "Medium SDX template");
+        validateDescription("7.2.20", "cdp-sdx-enterprise", "Enterprise SDX template");
+    }
+
+    private void validateDescription(String version, String template, String descriptionSubStr) throws IOException {
+        try {
+            JsonNode jsonNode = underTest.convertStringToJsonNode(
+                    FileReaderUtils.readFileFromPath(Path.of(
+                            String.format("../core/src/main/resources/defaults/blueprints/%s/%s.bp", version, template))));
+            JsonNode description = jsonNode.get("description");
+            Assert.assertTrue(description.asText().contains(descriptionSubStr));
+        } catch (NoSuchFileException noSuchFileException) {
+
+        }
+    }
+}


### PR DESCRIPTION
[CDPSDX-3896](https://jira.cloudera.com/browse/CDPSDX-3896) Move CM MGMT services to AUXILIARY host in case of Enterprise DL. These changes are required to remove the overallocation of the Gateway host groups. This action is harmless based on the CM MGMT services are backend services that will not be hit directly by the services. In other words: the CM and the CM MGMT decouple is harmless because we do not move the CM; therefore, the CM has the required load balancer (s). Tested locally by Enterprise Datalake. The CM MGMT services were deployed to the AUXILIARY host group. The CM was reachable. Also, the SMON and HMON metrics were shown on CM UI. Sidenote: CM and the CM MGMT are not HA. Therefore we do not lose HA capability by this action. Also, this action is not on their roadmap, date: 2023-APR-13.