### PR TITLE
CDPSDX-4057: Changing the scalable shape enum from SCALABLE to ENTERPRISE. This change only affects the enum.

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterShape.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterShape.java
@@ -4,7 +4,7 @@ public enum SdxClusterShape {
     CUSTOM(Boolean.FALSE),
     LIGHT_DUTY(Boolean.FALSE),
     MEDIUM_DUTY_HA(Boolean.TRUE),
-    SCALABLE(Boolean.TRUE),
+    ENTERPRISE(Boolean.TRUE),
     MICRO_DUTY(Boolean.FALSE);
 
     private final boolean multiAzEnabledByDefault;


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CDPSDX-4057

This is meant to modify the name of the new DL shape without breaking the backwards compatibility tests ran on these enum classes. This is why this is pointed at the prod branch.