### PR TITLE
CB-19860,CB-14228 - Validation of terms and permissions at launch

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/exception/CloudPlatformValidationWarningException.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/exception/CloudPlatformValidationWarningException.java
@@ -2,6 +2,10 @@ package com.sequenceiq.cloudbreak.cloud.exception;
 
 public class CloudPlatformValidationWarningException extends RuntimeException {
 
+    public CloudPlatformValidationWarningException(String message) {
+        super(message);
+    }
+
     public CloudPlatformValidationWarningException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/marketplace/AzureImageTermStatus.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/marketplace/AzureImageTermStatus.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image.marketplace;
+
+public enum AzureImageTermStatus {
+
+    ACCEPTED,
+    NOT_ACCEPTED,
+    NON_READABLE;
+
+    public static AzureImageTermStatus parseFromBoolean(boolean value) {
+        return value ? ACCEPTED : NOT_ACCEPTED;
+    }
+
+    public boolean getAsBoolean() {
+        return this == AzureImageTermStatus.ACCEPTED;
+    }
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureImageFormatValidator.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureImageFormatValidator.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.azure.validator;
 
+import static com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts.ACCEPTANCE_POLICY_PARAMETER;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -14,11 +16,13 @@ import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.Validator;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureImageTermStatus;
 import com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureImageTermsSignerService;
 import com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureMarketplaceImage;
 import com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureMarketplaceImageProviderService;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudPlatformValidationWarningException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 
@@ -50,35 +54,87 @@ public class AzureImageFormatValidator implements Validator {
         String imageUri = image.getImageName();
 
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        boolean onlyMarketplaceImagesEnabled = entitlementService.azureOnlyMarketplaceImagesEnabled(accountId);
+
         if (isVhdImageFormat(image)) {
-            checkEntitlement("Checking presence of 'Only Azure Marketplace Images Enabled' entitlement for VHD image {}",
-                    imageUri,
-                    entitlementService.azureOnlyMarketplaceImagesEnabled(accountId),
-                    "Your image %s seems to be a VHD image, but only Azure Marketplace images allowed in your account! ");
-            LOGGER.debug("Image {} seems to be a valid VHD image", imageUri);
+            validateVhdPermitted(imageUri, onlyMarketplaceImagesEnabled);
         } else if (isMarketplaceImageFormat(image)) {
-            checkEntitlement("Checking presence of Azure Marketplace entitlement for Marketplace image {}",
-                    imageUri,
-                    !entitlementService.azureMarketplaceImagesEnabled(accountId),
-                    "Your image %s seems to be an Azure Marketplace image! ");
-            LOGGER.debug("Checking if Terms and Conditions for your Azure Marketplace image {} are accepted", imageUri);
+            boolean marketplaceImagesEnabled = entitlementService.azureMarketplaceImagesEnabled(accountId);
+            validateMarketplacePermitted(imageUri, marketplaceImagesEnabled);
             AzureMarketplaceImage azureMarketplaceImage = azureMarketplaceImageProviderService.get(image);
-            if (isAutomaticTermsSignerDisabled() && areTermsNotSigned(ac, azureMarketplaceImage)) {
-                String errorMessage = String.format("Your image %s seems to be an Azure Marketplace image, "
-                        + "however its Terms and Conditions are not accepted! Please accept them and retry the provisioning or upgrade. " +
-                        "On how to accept the Terms and Conditions of the image please refer to azure documentation " +
-                        "at https://docs.microsoft.com/en-us/cli/azure/vm/image/terms?view=azure-cli-latest.", imageUri);
-                LOGGER.warn(errorMessage);
-                throw new CloudConnectorException(errorMessage);
+            AzureImageTermStatus termsStatus = getTermsStatus(ac, azureMarketplaceImage);
+            if (isAutomaticTermsSignerDisabled() || !isAutomaticTermsSignerAccepted(cloudStack)) {
+                switch (termsStatus) {
+                    case NOT_ACCEPTED:
+                        handleTermsNotAccepted(imageUri, onlyMarketplaceImagesEnabled);
+                        break;
+
+                    case NON_READABLE:
+                        handleTermsNonReadable(imageUri, onlyMarketplaceImagesEnabled);
+                        break;
+
+                    default:
+                        LOGGER.debug("Image terms are already accepted for image {}, there is nothing to do here", imageUri);
+                }
+
             } else {
                 LOGGER.debug("The Terms and Conditions are accepted for Azure Marketplace image {} or the automatic signer is enabled.", imageUri);
             }
 
         } else {
-            String errorMessage = String.format("Your image name %s is invalid. Please check the desired format in the documentation!", imageUri);
-            LOGGER.warn(errorMessage);
-            throw new CloudConnectorException(errorMessage);
+            handleUnknownFormat(imageUri);
         }
+    }
+
+    private void handleTermsNonReadable(String imageUri, boolean onlyMarketplaceImagesEnabled) {
+        if (onlyMarketplaceImagesEnabled) {
+            String warningMessage = String.format("Cloudera Management Console does not have sufficient permissions to read if "
+                    + "Terms and Conditions are accepted for the Azure Marketplace image %s. "
+                    + "Please either enable automatic consent or ensure that the terms are already accepted!", imageUri);
+            LOGGER.info(warningMessage);
+            throw new CloudPlatformValidationWarningException(warningMessage);
+        } else {
+            LOGGER.debug("Terms for %s are non readable but we proceed without warn assuming at least VHD would work.");
+        }
+    }
+
+    private void handleTermsNotAccepted(String imageUri, boolean onlyMarketplaceImagesEnabled) {
+        if (onlyMarketplaceImagesEnabled) {
+            String errorMessage = String.format("Your image %s seems to be an Azure Marketplace image, "
+                    + "however its Terms and Conditions are not accepted! "
+                    + "Please either enable automatic consent or accept the terms manually and initiate the provisioning or upgrade again. " +
+                    "On how to accept the Terms and Conditions of the image please refer to azure documentation " +
+                    "at https://docs.microsoft.com/en-us/cli/azure/vm/image/terms?view=azure-cli-latest.", imageUri);
+            LOGGER.info(errorMessage);
+
+            throw new CloudConnectorException(errorMessage);
+        } else {
+            String warningMessage = String.format("Your image %s seems to be an Azure Marketplace image, "
+                    + "however its Terms and Conditions are not accepted! We will use VHD images for the deployment."
+                    + "If you would like to use Marketplace images instead, please either enable automatic consent "
+                    + "or accept the terms manually and initiate the provisioning or upgrade again. " +
+                    "On how to accept the Terms and Conditions of the image please refer to azure documentation " +
+                    "at https://docs.microsoft.com/en-us/cli/azure/vm/image/terms?view=azure-cli-latest.", imageUri);
+            LOGGER.info(warningMessage);
+            throw new CloudPlatformValidationWarningException(warningMessage);
+        }
+    }
+
+    private void validateMarketplacePermitted(String imageUri, boolean azureMarketplaceImagesEnabled) {
+        checkEntitlement("Checking presence of Azure Marketplace entitlement for Marketplace image {}",
+                imageUri,
+                !azureMarketplaceImagesEnabled,
+                "Your image %s seems to be an Azure Marketplace image! "
+                        + "If you would like to use it please open Cloudera support ticket to enable this capability!");
+        LOGGER.debug("Checking if Terms and Conditions for your Azure Marketplace image {} are accepted", imageUri);
+    }
+
+    private void validateVhdPermitted(String imageUri, boolean azureOnlyMarketplaceImagesEnabled) {
+        checkEntitlement("Checking presence of 'Only Azure Marketplace Images Enabled' entitlement for VHD image {}",
+                imageUri,
+                azureOnlyMarketplaceImagesEnabled,
+                "Your image %s seems to be a VHD image, but only Azure Marketplace images allowed in your account! ");
+        LOGGER.debug("Image {} seems to be a valid VHD image", imageUri);
     }
 
     private void checkEntitlement(String logMessage, String imageUri, boolean entitlement, String error) {
@@ -94,9 +150,8 @@ public class AzureImageFormatValidator implements Validator {
         return !enableAzureImageTermsAutomaticSigner;
     }
 
-    private boolean areTermsNotSigned(AuthenticatedContext ac, AzureMarketplaceImage azureMarketplaceImage) {
-        AzureClient azureClient = ac.getParameter(AzureClient.class);
-        return !azureImageTermsSignerService.isSigned(azureClient.getCurrentSubscription().subscriptionId(), azureMarketplaceImage, azureClient);
+    private boolean isAutomaticTermsSignerAccepted(CloudStack stack) {
+        return Boolean.parseBoolean(stack.getParameters().get(ACCEPTANCE_POLICY_PARAMETER));
     }
 
     public boolean isMarketplaceImageFormat(Image image) {
@@ -121,5 +176,16 @@ public class AzureImageFormatValidator implements Validator {
             LOGGER.debug("Image with name {} is not a valid VHD based image", imageUri);
             return false;
         }
+    }
+
+    private AzureImageTermStatus getTermsStatus(AuthenticatedContext ac, AzureMarketplaceImage azureMarketplaceImage) {
+        AzureClient azureClient = ac.getParameter(AzureClient.class);
+        return azureImageTermsSignerService.getImageTermStatus(azureClient.getCurrentSubscription().subscriptionId(), azureMarketplaceImage, azureClient);
+    }
+
+    private void handleUnknownFormat(String imageUri) {
+        String errorMessage = String.format("Your image name %s is invalid. Please check the desired format in the documentation!", imageUri);
+        LOGGER.warn(errorMessage);
+        throw new CloudConnectorException(errorMessage);
     }
 }

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/ProvisionValidationHandlerTest.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/ProvisionValidationHandlerTest.java
@@ -81,7 +81,7 @@ public class ProvisionValidationHandlerTest {
         ValidationRequest request = createValidationRequest();
         CloudContext cloudContext = request.getCloudContext();
         mockCloudConnector(request, cloudContext);
-        doThrow(new CloudPlatformValidationWarningException(WARNING_MESSAGE, new Exception()))
+        doThrow(new CloudPlatformValidationWarningException(WARNING_MESSAGE))
                 .when(validator).validate(ac, request.getCloudStack());
 
         underTest.accept(new Event<>(request));


### PR DESCRIPTION
This commit validates for the following 3 unhappy cases, marked with "!!":

```
if (CDP_AZURE_IMAGE_MARKETPLACE_ONLY)
  if (non-auto)
    if (non-accepted)
      !!failhard
    elif (unknown)
      !!warn
    else
      proceed
  if (auto)
    if (non-accepted|unknown)
      accept
    else
      proceed
elif (CDP_AZURE_IMAGE_MARKETPLACE)
  if (non-auto)
    if (non-accepted)
      !!fallback to vhd --> warn
    elif (unknown)
      proceed and fallback if error
    else
      proceed
  if (auto)
    if (non-accepted|unknown)
      accept
    else
      proceed
```

Fallback clause does not work due to an independent bug: [CB-21442](https://jira.cloudera.com/browse/CB-21442)
