### PR TITLE
CB-21393 FMS status syncer modifications for unusable instances

### DIFF
--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsDownscaleService.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsDownscaleService.java
@@ -58,6 +58,8 @@ public class AwsDownscaleService {
 
     private static final int MAX_DETACH_INSTANCE_SIZE = 20;
 
+    private static final String INVALID_INSTANCE_ID_MALFORMED_CODE = "InvalidInstanceID.Malformed";
+
     @Inject
     private AwsComputeResourceService awsComputeResourceService;
 
@@ -235,7 +237,8 @@ public class AwsDownscaleService {
                 return existingInstances;
             } catch (AwsServiceException e) {
                 LOGGER.info("Termination failed, lets check if it is failed because instance was not found", e);
-                if (!INSTANCE_NOT_FOUND_ERROR_CODE.equals(e.awsErrorDetails().errorCode())) {
+                if (!INSTANCE_NOT_FOUND_ERROR_CODE.equals(e.awsErrorDetails().errorCode())
+                        && !INVALID_INSTANCE_ID_MALFORMED_CODE.equals(e.awsErrorDetails().errorCode())) {
                     throw e;
                 } else {
                     LOGGER.info("Instance was not found, lets filter out the non existing instances");

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/repair/RepairInstancesRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/repair/RepairInstancesRequest.java
@@ -1,8 +1,11 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.repair;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotEmpty;
+
+import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -46,7 +49,7 @@ public class RepairInstancesRequest {
     }
 
     public List<String> getInstanceIds() {
-        return instanceIds;
+        return instanceIds == null ? instanceIds : instanceIds.stream().filter(StringUtils::isNotBlank).collect(Collectors.toList());
     }
 
     public void setInstanceIds(List<String> instanceIds) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaStackHealthDetailsService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaStackHealthDetailsService.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -40,7 +41,7 @@ public class FreeIpaStackHealthDetailsService {
         List<InstanceMetaData> instances = stack.getAllInstanceMetaDataList();
 
         HealthDetailsFreeIpaResponse response = new HealthDetailsFreeIpaResponse();
-        for (InstanceMetaData instance: instances) {
+        for (InstanceMetaData instance : instances) {
             NodeHealthDetails nodeResponse;
             if (shouldRunHealthCheck(instance)) {
                 nodeResponse = healthDetailsService.getInstanceHealthDetails(stack, instance);
@@ -91,8 +92,10 @@ public class FreeIpaStackHealthDetailsService {
 
     private void updateResponseWithInstanceIds(HealthDetailsFreeIpaResponse response, Stack stack) {
         Map<String, String> nameIdMap = getNameIdMap(stack);
-        for (NodeHealthDetails node: response.getNodeHealthDetails()) {
-            node.setInstanceId(nameIdMap.get(node.getName()));
+        for (NodeHealthDetails node : response.getNodeHealthDetails()) {
+            if (nameIdMap.containsKey(node.getName()) && StringUtils.isNotBlank(nameIdMap.get(node.getName()))) {
+                node.setInstanceId(nameIdMap.get(node.getName()));
+            }
         }
     }
 


### PR DESCRIPTION
An instance is unusable if it's missing FQDN or private IP, as this is a bare minimum to have a functional instance. If the instance:
- has instance ID, but lack any of FQDN or IP then the state is set to `FAILED`, FreeIPA will be `UNHEALTHY`
- has no instance ID, no FQDN or IP then it's set to TERMINATED, and if everything else is fine FreeIPA will be `HEALTHY`

The `FAILED` isntance is removable with the repair functionality by providing the instance id. To handle the edge case where the instance id is malformed, this error is handled the same way during downscale as if the instance is non existing on AWS side.

Added filtering to `RepairInstancesRequest` to filter out blank instance IDs, as during testing CLI sent in one empty string in the list.

See detailed description in the commit message.