### PR TITLE
CB-20662 Downscale should be able to take exact instance id - extension

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/scale/DownscaleResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/scale/DownscaleResponse.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.scale;
 
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -10,8 +12,20 @@ import io.swagger.annotations.ApiModel;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DownscaleResponse extends ScaleResponseBase {
 
+    private Set<String> downscaleCandidates;
+
+    public Set<String> getDownscaleCandidates() {
+        return downscaleCandidates;
+    }
+
+    public void setDownscaleCandidates(Set<String> downscaleCandidates) {
+        this.downscaleCandidates = downscaleCandidates;
+    }
+
     @Override
     public String toString() {
-        return "DownscaleResponse{} " + super.toString();
+        return "DownscaleResponse{" +
+                "downscaleCandidates=" + downscaleCandidates +
+                "} " + super.toString();
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaScalingService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaScalingService.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.freeipa.api.v1.operation.model.OperationState.RUNNI
 import static com.sequenceiq.freeipa.flow.freeipa.verticalscale.event.FreeIpaVerticalScaleEvent.STACK_VERTICALSCALE_EVENT;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -152,6 +153,7 @@ public class FreeIpaScalingService {
             response.setOperationId(operation.getOperationId());
             response.setOriginalAvailabilityType(originalAvailabilityInfo.getAvailabilityType());
             response.setTargetAvailabilityType(targetAvailabilityType);
+            response.setDownscaleCandidates(new HashSet<>(downscaleCandidates));
             response.setFlowIdentifier(flowIdentifier);
             return response;
         } catch (Exception e) {


### PR DESCRIPTION
The previous commit with the same id made it possible to specify which freeipa nodes to downscale. The response, however should contain which nodes were then in fact removed. The current commit thus adds the field to the response which nodes were deleted during the downscale.

See detailed description in the commit message.