### PR TITLE
CB-21467 add Ranger to the Gatway Host group in enterprise DL

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-enterprise.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-enterprise.bp
@@ -32,6 +32,7 @@
           "ranger-RANGER_USERSYNC-BASE",
           "ranger-RANGER_TAGSYNC-BASE",
           "hive-HIVEMETASTORE-BASE",
+          "ranger-RANGER_ADMIN-BASE",
           "knox-KNOX_GATEWAY-BASE",
           "solr-GATEWAY-BASE",
           "hdfs-GATEWAY-BASE",


### PR DESCRIPTION
CB-21467 add Ranger to the Gateway Host group to make sure that the topology.xml will be populated with the Ranger URL.

We will also explore ways to have separate topology.xml defined for the new shape. This will be a separate PR.