### PR TITLE
CB-21467 extends the topology to populate ranger and ranger UI URLs

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-enterprise.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-enterprise.bp
@@ -32,7 +32,6 @@
           "ranger-RANGER_USERSYNC-BASE",
           "ranger-RANGER_TAGSYNC-BASE",
           "hive-HIVEMETASTORE-BASE",
-          "ranger-RANGER_ADMIN-BASE",
           "knox-KNOX_GATEWAY-BASE",
           "solr-GATEWAY-BASE",
           "hdfs-GATEWAY-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.18/cdp-sdx-enterprise.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.18/cdp-sdx-enterprise.bp
@@ -32,7 +32,6 @@
           "ranger-RANGER_USERSYNC-BASE",
           "ranger-RANGER_TAGSYNC-BASE",
           "hive-HIVEMETASTORE-BASE",
-          "ranger-RANGER_ADMIN-BASE",
           "knox-KNOX_GATEWAY-BASE",
           "solr-GATEWAY-BASE",
           "hdfs-GATEWAY-BASE",

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -283,7 +283,7 @@
                  <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000;enableStickySession=false;noFallback=false;enableLoadBalancing=true</value>
              </param>
              {%- endif %}
-             {% if 'RANGER' in exposed and 'RANGER_ADMIN' in salt['pillar.get']('gateway:location') -%}
+             {% if 'RANGER_ADMIN' in salt['pillar.get']('gateway:location') or 'RANGER_ADMIN' in salt['pillar.get']('master:location') -%}
              <param>
                  <name>RANGER</name>
                  <value>enableStickySession=true;noFallback=false;enableLoadBalancing=true</value>
@@ -496,6 +496,31 @@
     <service>
         <role>RANGERUI</role>
         {% for hostloc in salt['pillar.get']('gateway:location')['RANGER_ADMIN'] -%}
+        <url>{{ protocol }}://{{ hostloc }}:{{ ports['RANGER'] }}</url>
+        {%- endfor %}
+        <param>
+             <name>replayBufferSize</name>
+             <value>128</value>
+        </param>
+    </service>
+    {%- endif %}
+    {%- endif %}
+
+    {% if 'RANGER_ADMIN' in salt['pillar.get']('master:location') -%}
+    {% if 'RANGER' in exposed -%}
+    <service>
+        <role>RANGER</role>
+        {% for hostloc in salt['pillar.get']('master:location')['RANGER_ADMIN'] -%}
+        <url>{{ protocol }}://{{ hostloc }}:{{ ports['RANGER'] }}</url>
+        {%- endfor %}
+        <param>
+            <name>replayBufferSize</name>
+            <value>128</value>
+        </param>
+    </service>
+    <service>
+        <role>RANGERUI</role>
+        {% for hostloc in salt['pillar.get']('master:location')['RANGER_ADMIN'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['RANGER'] }}</url>
         {%- endfor %}
         <param>

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -435,6 +435,21 @@
     {%- endif %}
     {%- endif %}
 
+    {% if 'RANGER_ADMIN' in salt['pillar.get']('master:location') -%}
+        {% if 'RANGER' in exposed -%}
+        <service>
+            <role>RANGER</role>
+            {% for hostloc in salt['pillar.get']('master:location')['RANGER_ADMIN'] -%}
+            <url>{{ protocol }}://{{ hostloc }}:{{ ports['RANGER'] }}</url>
+            {%- endfor %}
+            <param>
+                <name>replayBufferSize</name>
+                <value>128</value>
+            </param>
+        </service>
+        {%- endif %}
+        {%- endif %}
+
     {% if 'RANGER_RAZ_SERVER' in salt['pillar.get']('gateway:location') -%}
     {% if 'RANGERRAZ' in exposed -%}
     <service>

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_token.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_token.xml.j2
@@ -218,6 +218,12 @@
                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
             </param>
             {%- endif %}
+            {% if 'RANGER' in exposed and 'RANGER_ADMIN' in salt['pillar.get']('master:location') -%}
+                        <param>
+                            <name>RANGER</name>
+                            <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                        </param>
+            {%- endif %}
             {% if 'YARNUIV2' in exposed and 'RESOURCEMANAGER' in salt['pillar.get']('gateway:location') -%}
             <param>
                 <name>RESOURCEMANAGER</name>


### PR DESCRIPTION
CB-21467 extends the topology to populate ranger and ranger UI URLs when the ranger is running on the master node. In the case of EDL, we moved the Ranger from the GATEWAY node to the MASTER node. But the salt searched it in the GATEWAY host, which means it's not loading the ranger URLs into the cdp-proxy topology;

To unblock EDL promotion we added Ranger in Gateway along with Master node as well. This PR fixes it correctly.

Tested.
The Datalake Ranger UI loaded.
The Ranger API call was successful.

The content of  `/var/lib/knox/gateway/data/deployments/cdp-proxy.topo.18795723142/META-INF/topology.xml`

```
  <service>
      <role>RANGER</role>
      <url>https://irokolya-env-04-18-001-gateway0.irokolya.xcu2-8y8x.wl.cloudera.site:6182</url>
      <url>https://irokolya-env-04-18-001-gateway1.irokolya.xcu2-8y8x.wl.cloudera.site:6182</url>
      <param>
         <name>replayBufferSize</name>
         <value>128</value>
      </param>
   </service>
   <service>
      <role>RANGERUI</role>
      <url>https://irokolya-env-04-18-001-gateway0.irokolya.xcu2-8y8x.wl.cloudera.site:6182</url>
      <url>https://irokolya-env-04-18-001-gateway1.irokolya.xcu2-8y8x.wl.cloudera.site:6182</url>
      <param>
         <name>replayBufferSize</name>
         <value>128</value>
      </param>
   </service>

```

