### PR TITLE
CDPSDX-4024: Fixed faulty resize recovery for CCMv1 sdx clusters due to missing proxy service config reset.

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
@@ -684,7 +684,8 @@ public interface StackV4Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = RE_REGISTER_CLUSTER_PROXY_CONFIG, nickname = "reRegisterClusterProxyConfig")
     FlowIdentifier reRegisterClusterProxyConfig(@PathParam("workspaceId") Long workspaceId, @PathParam("crn") String crn,
-            @QueryParam("originalCrn") String originalCrn, @QueryParam("initiatorUserCrn") String initiatorUserCrn);
+            @QueryParam("skipFullReRegistration") @DefaultValue("false") boolean skipFullReRegistration, @QueryParam("originalCrn") String originalCrn,
+            @QueryParam("initiatorUserCrn") String initiatorUserCrn);
 
     @PUT
     @Path("internal/{name}/vertical_scaling")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -607,8 +607,10 @@ public class StackV4Controller extends NotificationController implements StackV4
 
     @Override
     @InternalOnly
-    public FlowIdentifier reRegisterClusterProxyConfig(Long workspaceId, String crn, String originalCrn, @InitiatorUserCrn String initiatorUserCrn) {
-        return stackOperationService.reRegisterClusterProxyConfig(NameOrCrn.ofCrn(crn), restRequestThreadLocalService.getAccountId(), originalCrn);
+    public FlowIdentifier reRegisterClusterProxyConfig(Long workspaceId, String crn, boolean skipFullReRegistration, String originalCrn,
+            @InitiatorUserCrn String initiatorUserCrn) {
+        return stackOperationService.reRegisterClusterProxyConfig(NameOrCrn.ofCrn(crn), restRequestThreadLocalService.getAccountId(),
+                skipFullReRegistration, originalCrn);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -438,9 +438,14 @@ public class ReactorFlowManager {
         return reactorNotifier.notify(stackId, selector, stackLoadBalancerUpdateTriggerEvent);
     }
 
-    public FlowIdentifier triggerClusterProxyConfigReRegistration(Long stackId, String originalCrn) {
-        String selector = ClusterProxyReRegistrationEvent.CLUSTER_PROXY_RE_REGISTRATION_EVENT.event();
-        return reactorNotifier.notify(stackId, selector, new ClusterProxyReRegistrationTriggerEvent(selector, stackId, originalCrn));
+    public FlowIdentifier triggerClusterProxyConfigReRegistration(Long stackId, boolean skipFullReRegistration, String originalCrn) {
+        String selector;
+        if (stackService.getById(stackId).getTunnel().useCcmV1()) {
+            selector = ClusterProxyReRegistrationEvent.CLUSTER_PROXY_CCMV1_REMAP_EVENT.event();
+        } else {
+            selector = ClusterProxyReRegistrationEvent.CLUSTER_PROXY_RE_REGISTRATION_EVENT.event();
+        }
+        return reactorNotifier.notify(stackId, selector, new ClusterProxyReRegistrationTriggerEvent(selector, stackId, skipFullReRegistration, originalCrn));
     }
 
     public void triggerDetermineDatalakeDataSizes(Long stackId, String operationId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/clusterproxy/reregister/ClusterProxyReRegistrationConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/clusterproxy/reregister/ClusterProxyReRegistrationConfig.java
@@ -1,9 +1,13 @@
 package com.sequenceiq.cloudbreak.core.flow2.stack.clusterproxy.reregister;
 
+import static com.sequenceiq.cloudbreak.core.flow2.stack.clusterproxy.reregister.ClusterProxyReRegistrationEvent.CLUSTER_PROXY_CCMV1_REMAP_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.stack.clusterproxy.reregister.ClusterProxyReRegistrationEvent.CLUSTER_PROXY_CCMV1_REMAP_FINISHED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.stack.clusterproxy.reregister.ClusterProxyReRegistrationEvent.CLUSTER_PROXY_CCMV1_REMAP_FINISHED_SKIP_RE_REGISTRATION_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.clusterproxy.reregister.ClusterProxyReRegistrationEvent.CLUSTER_PROXY_RE_REGISTRATION_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.clusterproxy.reregister.ClusterProxyReRegistrationEvent.CLUSTER_PROXY_RE_REGISTRATION_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.clusterproxy.reregister.ClusterProxyReRegistrationEvent.CLUSTER_PROXY_RE_REGISTRATION_FAIL_HANDLED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.clusterproxy.reregister.ClusterProxyReRegistrationEvent.CLUSTER_PROXY_RE_REGISTRATION_FINISHED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.stack.clusterproxy.reregister.ClusterProxyReRegistrationState.CLUSTER_PROXY_CCMV1_REMAP_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.clusterproxy.reregister.ClusterProxyReRegistrationState.CLUSTER_PROXY_RE_REGISTRATION_FAILED_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.clusterproxy.reregister.ClusterProxyReRegistrationState.CLUSTER_PROXY_RE_REGISTRATION_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.clusterproxy.reregister.ClusterProxyReRegistrationState.FINAL_STATE;
@@ -23,9 +27,33 @@ public class ClusterProxyReRegistrationConfig
         implements RetryableFlowConfiguration<ClusterProxyReRegistrationEvent> {
     private static final List<Transition<ClusterProxyReRegistrationState, ClusterProxyReRegistrationEvent>> TRANSITIONS =
             new Builder<ClusterProxyReRegistrationState, ClusterProxyReRegistrationEvent>()
-                    .from(INIT_STATE).to(CLUSTER_PROXY_RE_REGISTRATION_STATE).event(CLUSTER_PROXY_RE_REGISTRATION_EVENT).noFailureEvent()
-                    .from(CLUSTER_PROXY_RE_REGISTRATION_STATE).to(FINAL_STATE).event(CLUSTER_PROXY_RE_REGISTRATION_FINISHED_EVENT)
-                    .failureEvent(CLUSTER_PROXY_RE_REGISTRATION_FAILED_EVENT)
+                    .defaultFailureEvent(CLUSTER_PROXY_RE_REGISTRATION_FAILED_EVENT)
+
+                    .from(INIT_STATE)
+                    .to(CLUSTER_PROXY_RE_REGISTRATION_STATE)
+                    .event(CLUSTER_PROXY_RE_REGISTRATION_EVENT)
+                    .noFailureEvent()
+
+                    .from(INIT_STATE)
+                    .to(CLUSTER_PROXY_CCMV1_REMAP_STATE)
+                    .event(CLUSTER_PROXY_CCMV1_REMAP_EVENT)
+                    .noFailureEvent()
+
+                    .from(CLUSTER_PROXY_CCMV1_REMAP_STATE)
+                    .to(CLUSTER_PROXY_RE_REGISTRATION_STATE)
+                    .event(CLUSTER_PROXY_CCMV1_REMAP_FINISHED_EVENT)
+                    .defaultFailureEvent()
+
+                    .from(CLUSTER_PROXY_RE_REGISTRATION_STATE)
+                    .to(FINAL_STATE)
+                    .event(CLUSTER_PROXY_RE_REGISTRATION_FINISHED_EVENT)
+                    .defaultFailureEvent()
+
+                    .from(CLUSTER_PROXY_CCMV1_REMAP_STATE)
+                    .to(FINAL_STATE)
+                    .event(CLUSTER_PROXY_CCMV1_REMAP_FINISHED_SKIP_RE_REGISTRATION_EVENT)
+                    .defaultFailureEvent()
+
                     .build();
 
     private static final FlowEdgeConfig<ClusterProxyReRegistrationState, ClusterProxyReRegistrationEvent> EDGE_CONFIG =

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/clusterproxy/reregister/ClusterProxyReRegistrationContext.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/clusterproxy/reregister/ClusterProxyReRegistrationContext.java
@@ -7,16 +7,23 @@ import com.sequenceiq.flow.core.FlowParameters;
 public class ClusterProxyReRegistrationContext extends CommonContext {
     private final Stack stack;
 
+    private final boolean skipFullReRegistration;
+
     private final String originalCrn;
 
-    public ClusterProxyReRegistrationContext(FlowParameters flowParameters, Stack stack, String originalCrn) {
+    public ClusterProxyReRegistrationContext(FlowParameters flowParameters, Stack stack, boolean skipFullReRegistration, String originalCrn) {
         super(flowParameters);
         this.stack = stack;
+        this.skipFullReRegistration = skipFullReRegistration;
         this.originalCrn = originalCrn;
     }
 
     public Stack getStack() {
         return stack;
+    }
+
+    public boolean isSkipFullReRegistration() {
+        return skipFullReRegistration;
     }
 
     public String getOriginalCrn() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/clusterproxy/reregister/ClusterProxyReRegistrationEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/clusterproxy/reregister/ClusterProxyReRegistrationEvent.java
@@ -5,15 +5,22 @@ import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 
 public enum ClusterProxyReRegistrationEvent implements FlowEvent {
-    CLUSTER_PROXY_RE_REGISTRATION_EVENT("CLUSTER_PROXY_RE_REGISTRATION_EVENT"),
+    CLUSTER_PROXY_RE_REGISTRATION_EVENT,
+    CLUSTER_PROXY_CCMV1_REMAP_EVENT,
+    CLUSTER_PROXY_CCMV1_REMAP_FINISHED_EVENT,
+    CLUSTER_PROXY_CCMV1_REMAP_FINISHED_SKIP_RE_REGISTRATION_EVENT,
     CLUSTER_PROXY_RE_REGISTRATION_FINISHED_EVENT(EventSelectorUtil.selector(ClusterProxyReRegistrationResult.class)),
     CLUSTER_PROXY_RE_REGISTRATION_FAILED_EVENT(EventSelectorUtil.failureSelector(ClusterProxyReRegistrationResult.class)),
-    CLUSTER_PROXY_RE_REGISTRATION_FAIL_HANDLED_EVENT("CLUSTER_PROXY_RE_REGISTRATION_FAIL_HANDLED_EVENT");
+    CLUSTER_PROXY_RE_REGISTRATION_FAIL_HANDLED_EVENT;
 
     private final String event;
 
     ClusterProxyReRegistrationEvent(String event) {
         this.event = event;
+    }
+
+    ClusterProxyReRegistrationEvent() {
+        event = name();
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/clusterproxy/reregister/ClusterProxyReRegistrationState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/clusterproxy/reregister/ClusterProxyReRegistrationState.java
@@ -6,6 +6,7 @@ import com.sequenceiq.flow.core.RestartAction;
 
 public enum ClusterProxyReRegistrationState implements FlowState {
     INIT_STATE,
+    CLUSTER_PROXY_CCMV1_REMAP_STATE,
     CLUSTER_PROXY_RE_REGISTRATION_STATE,
     CLUSTER_PROXY_RE_REGISTRATION_FAILED_STATE,
     FINAL_STATE;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/clusterproxy/ClusterProxyReRegistrationTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/clusterproxy/ClusterProxyReRegistrationTriggerEvent.java
@@ -5,14 +5,22 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class ClusterProxyReRegistrationTriggerEvent extends StackEvent {
+    private final boolean skipFullReRegistration;
+
     private final String originalCrn;
 
     @JsonCreator
     public ClusterProxyReRegistrationTriggerEvent(@JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
+            @JsonProperty("skipFullReRegistration") boolean skipFullReRegistration,
             @JsonProperty("originalCrn") String originalCrn) {
         super(selector, stackId);
+        this.skipFullReRegistration = skipFullReRegistration;
         this.originalCrn = originalCrn;
+    }
+
+    public boolean isSkipFullReRegistration() {
+        return skipFullReRegistration;
     }
 
     public String getOriginalCrn() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -455,9 +455,9 @@ public class StackOperationService {
         eventService.fireCloudbreakEvent(stack.getId(), STOP_REQUESTED.name(), STACK_STOP_REQUESTED);
     }
 
-    public FlowIdentifier reRegisterClusterProxyConfig(@NotNull NameOrCrn nameOrCrn, String accountId, String originalCrn) {
+    public FlowIdentifier reRegisterClusterProxyConfig(@NotNull NameOrCrn nameOrCrn, String accountId, boolean skipFullReRegistration, String originalCrn) {
         StackView stack = stackDtoService.getStackViewByNameOrCrn(nameOrCrn, accountId);
-        return flowManager.triggerClusterProxyConfigReRegistration(stack.getId(), originalCrn);
+        return flowManager.triggerClusterProxyConfigReRegistration(stack.getId(), skipFullReRegistration, originalCrn);
     }
 
     public FlowIdentifier rotateSaltPassword(@NotNull NameOrCrn nameOrCrn, String accountId, RotateSaltPasswordReason reason) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
@@ -54,6 +54,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordTyp
 import com.sequenceiq.cloudbreak.service.image.ImageChangeDto;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stack.repair.UnhealthyInstances;
+import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.flow.core.model.FlowAcceptResult;
 import com.sequenceiq.flow.service.FlowCancelService;
 
@@ -94,6 +95,7 @@ public class ReactorFlowManagerTest {
         reset(reactorNotifier);
         stack = TestUtil.stack();
         stack.setCluster(TestUtil.cluster());
+        stack.setTunnel(Tunnel.CCMV2_JUMPGATE);
         ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
         when(asyncTaskExecutor.submit(captor.capture())).then(invocation -> {
             captor.getValue().run();
@@ -115,6 +117,7 @@ public class ReactorFlowManagerTest {
 
         when(stackService.getPlatformVariantByStackId(STACK_ID)).thenReturn(cloudPlatformVariant);
         when(cloudPlatformVariant.getVariant()).thenReturn(Variant.variant("AWS"));
+        when(stackService.getById(STACK_ID)).thenReturn(stack);
 
         underTest.triggerProvisioning(STACK_ID);
         underTest.triggerClusterInstall(STACK_ID);
@@ -162,7 +165,7 @@ public class ReactorFlowManagerTest {
         underTest.triggerStopStartStackUpscale(STACK_ID, instanceGroupAdjustment, true);
         underTest.triggerStopStartStackDownscale(STACK_ID, instanceIdsByHostgroup, false);
         underTest.triggerClusterServicesRestart(STACK_ID);
-        underTest.triggerClusterProxyConfigReRegistration(STACK_ID, "");
+        underTest.triggerClusterProxyConfigReRegistration(STACK_ID, false, "");
         underTest.triggerRdsUpgrade(STACK_ID, TargetMajorVersion.VERSION_11, null, null);
         underTest.triggerRotateSaltPassword(STACK_ID, RotateSaltPasswordReason.MANUAL, RotateSaltPasswordType.FALLBACK);
         underTest.triggerModifyProxyConfig(STACK_ID, null);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/SdxDetachActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/SdxDetachActions.java
@@ -228,7 +228,7 @@ public class SdxDetachActions {
                     SdxCluster reattached = sdxAttachService.reattachCluster(detached);
                     sdxAttachService.reattachStack(reattached, detachedName);
                     if (cloudbreakStackService.getStack(detached).getTunnel().useCcmV1()) {
-                        sdxAttachService.reRegisterClusterProxyConfig(reattached, detachedCrn);
+                        sdxAttachService.reRegisterClusterProxyConfig(reattached, true, detachedCrn);
                     }
 
                     LOGGER.info("Successfully restored detached SDX with ID {} which failed to detach its external database.",

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/attach/SdxAttachDetachUtils.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/attach/SdxAttachDetachUtils.java
@@ -82,12 +82,12 @@ public class SdxAttachDetachUtils {
         );
     }
 
-    public void reRegisterClusterProxyConfig(SdxCluster cluster, String originalCrn) {
+    public void reRegisterClusterProxyConfig(SdxCluster cluster, boolean skipFullReRegistration, String originalCrn) {
         LOGGER.info("Attempting to re-register the cluster proxy config for SDX cluster with ID: {}", cluster.getId());
         String initiatorUserCrn = ThreadBasedUserCrnProvider.getUserCrn();
         FlowIdentifier flowId = ThreadBasedUserCrnProvider.doAsInternalActor(
                 regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(),
-                () -> stackV4Endpoint.reRegisterClusterProxyConfig(0L, cluster.getCrn(), originalCrn, initiatorUserCrn)
+                () -> stackV4Endpoint.reRegisterClusterProxyConfig(0L, cluster.getCrn(), skipFullReRegistration, originalCrn, initiatorUserCrn)
         );
         PollingConfig pollingConfig = new PollingConfig(
                 reRegisterClusterProxyConfigSleepTimeInSec, TimeUnit.SECONDS,

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/attach/SdxAttachService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/attach/SdxAttachService.java
@@ -66,7 +66,7 @@ public class SdxAttachService {
             if (clusterToReattach.hasExternalDatabase()) {
                 reattachExternalDatabase(reattached, detachedCrn);
             }
-            reRegisterClusterProxyConfig(reattached, detachedCrn);
+            reRegisterClusterProxyConfig(reattached, false, detachedCrn);
             return reattached;
         } catch (Exception e) {
             LOGGER.error("Failed to reattach SDX cluster with CRN '" + detachedCrn +
@@ -127,9 +127,9 @@ public class SdxAttachService {
      * This explicitly occurs during recovery due to the resized DL being deleted.
      * Note that this method has no undesired side effects and is safe to call even if not necessarily required.
      */
-    public void reRegisterClusterProxyConfig(SdxCluster cluster, String detachedCrn) {
+    public void reRegisterClusterProxyConfig(SdxCluster cluster, boolean skipFullReRegistration, String detachedCrn) {
         LOGGER.info("Started re-registering cluster proxy config for SDX cluster with ID: {}", cluster.getId());
-        sdxAttachDetachUtils.reRegisterClusterProxyConfig(cluster, detachedCrn);
+        sdxAttachDetachUtils.reRegisterClusterProxyConfig(cluster, skipFullReRegistration, detachedCrn);
         LOGGER.info("Finished re-registering cluster proxy config for SDX cluster with ID: {}. Now has crn: {}.",
                 cluster.getId(), cluster.getCrn());
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/attach/SdxDetachService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/attach/SdxDetachService.java
@@ -83,7 +83,7 @@ public class SdxDetachService {
 
     public void detachCCMv1ClusterProxyMapping(SdxCluster cluster) {
             LOGGER.info("Started detaching CCMv1 cluster proxy mapping of SDX cluster with ID: {}.", cluster.getId());
-            sdxAttachDetachUtils.reRegisterClusterProxyConfig(cluster, cluster.getOriginalCrn());
+            sdxAttachDetachUtils.reRegisterClusterProxyConfig(cluster, true, cluster.getOriginalCrn());
             LOGGER.info("Finished detaching CCMv1 cluster proxy mapping of SDX cluster with ID: {}.", cluster.getId());
     }
 


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CDPSDX-4024

We determined that the reason for this failure was that the proxy service was not having its config updated, resulting in it using stale keys (the instance IDs of the medium duty DL which was deleted). 

This change reformats some logic but the main change which solves the issue is that we now run the proxy re registration twice for CCMv1, once with the logic used to remap the MinaSSHd tunneling keys for CCMv1, and the second time for the full re-registration of the proxy service configs.

Due to local issues with CCMv1 port forwarding, I am and will be unable to test this locally. However due to the importance of this fix, and the fact that the issue is causing L0 promotion test failures, I believe we can move forward with the change and test on mow-dev. 