### PR TITLE
CB-21472 Create structuredevent index with sorting to prevent very sl…

### DIFF
--- a/core/src/main/resources/schema/app/20230418142012_CB-21472_create_structuredevent_index_with_sorting.sql
+++ b/core/src/main/resources/schema/app/20230418142012_CB-21472_create_structuredevent_index_with_sorting.sql
@@ -1,0 +1,9 @@
+-- // CB-21472 distrox audit event API very slow query "JDBC Execution Statement time warning (>1000ms): 4086ms"
+-- Migration SQL that makes the change goes here.
+
+CREATE INDEX IF NOT EXISTS idx_structuredevent_eventtype_resourcetype_resourceid_timestamp ON structuredevent (eventtype, resourcetype, resourceid, timestamp desc);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP INDEX IF EXISTS idx_structuredevent_eventtype_resourcetype_resourceid_timestamp;


### PR DESCRIPTION
…ow query "JDBC Execution Statement time warning (>1000ms): 4086ms"

[https://www.postgresql.org/docs/current/indexes-ordering.html](https://www.postgresql.org/docs/current/indexes-ordering.html)

Before:
`Limit  (cost=126.40..126.55 rows=60 width=2301) (actual time=0.333..0.352 rows=106 loops=1)
  ->  Sort  (cost=126.39..126.55 rows=65 width=2301) (actual time=0.331..0.341 rows=111 loops=1)
        Sort Key: "timestamp" DESC
        Sort Method: quicksort  Memory: 248kB
        ->  Index Scan using idx_structuredevent_eventtype_resourcetype_resourceid on structuredevent structured0_  (cost=0.28..124.43 rows=65 width=2301) (actual time=0.035..0.090 rows=111 loops=1)
              Index Cond: (((eventtype)::text = 'NOTIFICATION'::text) AND ((resourcetype)::text = 'datahub'::text) AND (resourceid = 164))
Planning Time: 0.157 ms
Execution Time: 0.475 ms`

After:
`Limit  (cost=9.83..124.43 rows=60 width=2301) (actual time=0.070..0.131 rows=106 loops=1)
  ->  Index Scan using idx_structuredevent_eventtype_resourcetype_resourceid_timestamp on structuredevent structured0_  (cost=0.28..124.43 rows=65 width=2301) (actual time=0.065..0.119 rows=111 loops=1)
        Index Cond: (((eventtype)::text = 'NOTIFICATION'::text) AND ((resourcetype)::text = 'datahub'::text) AND (resourceid = 164))
Planning Time: 0.160 ms
Execution Time: 0.178 ms`

See detailed description in the commit message.