### PR TITLE
CB-21356 Handle OS Upgrade Order for Enterprise DL

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/type/InstanceGroupName.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/InstanceGroupName.java
@@ -6,7 +6,13 @@ public enum InstanceGroupName {
     IDBROKER("idbroker"),
     GATEWAY("gateway"),
     AUXILIARY("auxiliary"),
-    CORE("core");
+    CORE("core"),
+    SOLRHG("solrhg"),
+    STORAGEHG("storagehg"),
+    KAFKAHG("kafkahg"),
+    RAZHG("razhg"),
+    ATLASHG("atlashg"),
+    HMSHG("hmshg");
 
     private final String name;
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/OrderedOSUpgradeRequestProvider.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/OrderedOSUpgradeRequestProvider.java
@@ -1,15 +1,23 @@
 package com.sequenceiq.datalake.service.upgrade;
 
+import static com.sequenceiq.common.api.type.InstanceGroupName.ATLASHG;
 import static com.sequenceiq.common.api.type.InstanceGroupName.AUXILIARY;
 import static com.sequenceiq.common.api.type.InstanceGroupName.CORE;
 import static com.sequenceiq.common.api.type.InstanceGroupName.GATEWAY;
+import static com.sequenceiq.common.api.type.InstanceGroupName.HMSHG;
 import static com.sequenceiq.common.api.type.InstanceGroupName.IDBROKER;
+import static com.sequenceiq.common.api.type.InstanceGroupName.KAFKAHG;
 import static com.sequenceiq.common.api.type.InstanceGroupName.MASTER;
+import static com.sequenceiq.common.api.type.InstanceGroupName.RAZHG;
+import static com.sequenceiq.common.api.type.InstanceGroupName.SOLRHG;
+import static com.sequenceiq.common.api.type.InstanceGroupName.STORAGEHG;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -35,23 +43,26 @@ public class OrderedOSUpgradeRequestProvider {
         Map<String, List<String>> instanceIdsByInstanceGroup = getInstanceIdsByInstanceGroup(instanceMetaDataByInstanceGroup);
         LOGGER.debug("Instance ids by instance group: {}", instanceIdsByInstanceGroup);
 
+        int order = 0;
         List<OrderedOSUpgradeSet> osUpgradeByUpgradeSets = new ArrayList<>();
-        osUpgradeByUpgradeSets.add(new OrderedOSUpgradeSet(0, Set.of(
+        osUpgradeByUpgradeSets.add(new OrderedOSUpgradeSet(order++, Set.of(
                 getInstanceId(instanceIdsByInstanceGroup, MASTER),
                 getInstanceId(instanceIdsByInstanceGroup, CORE),
                 getInstanceId(instanceIdsByInstanceGroup, AUXILIARY),
                 getInstanceId(instanceIdsByInstanceGroup, IDBROKER)
         )));
-        osUpgradeByUpgradeSets.add(new OrderedOSUpgradeSet(1, Set.of(
+        osUpgradeByUpgradeSets.add(new OrderedOSUpgradeSet(order++, Set.of(
                 getInstanceId(instanceIdsByInstanceGroup, MASTER),
                 getInstanceId(instanceIdsByInstanceGroup, CORE),
                 getInstanceId(instanceIdsByInstanceGroup, GATEWAY),
                 getInstanceId(instanceIdsByInstanceGroup, IDBROKER)
         )));
-        osUpgradeByUpgradeSets.add(new OrderedOSUpgradeSet(2, Set.of(
+        osUpgradeByUpgradeSets.add(new OrderedOSUpgradeSet(order++, Set.of(
                 getInstanceId(instanceIdsByInstanceGroup, CORE),
                 getInstanceId(instanceIdsByInstanceGroup, GATEWAY)
         )));
+        addServiceHostGroupsToOrderedOSUpgradeSet(instanceIdsByInstanceGroup, order, osUpgradeByUpgradeSets);
+
         validateThatEveryInstanceIsPresentInTheConfig(instanceIdsByInstanceGroup);
         OrderedOSUpgradeSetRequest request = new OrderedOSUpgradeSetRequest();
         request.setOrderedOsUpgradeSets(osUpgradeByUpgradeSets);
@@ -69,7 +80,7 @@ public class OrderedOSUpgradeRequestProvider {
     private Map<String, List<String>> getInstanceIdsByInstanceGroup(Map<String, List<InstanceMetaDataV4Response>> instanceMetaDataByInstanceGroup) {
         return instanceMetaDataByInstanceGroup.entrySet().stream()
                 .collect(Collectors.toMap(
-                        Map.Entry::getKey,
+                        Entry::getKey,
                         entry -> entry.getValue().stream()
                                 .map(InstanceMetaDataV4Response::getInstanceId)
                                 .collect(Collectors.toList())));
@@ -94,6 +105,35 @@ public class OrderedOSUpgradeRequestProvider {
         if (!instancesFromInstanceGroups.isEmpty()) {
             throw new CloudbreakServiceException(
                     String.format("The following instances are missing from the ordered OS upgrade request: %s", instancesFromInstanceGroups));
+        }
+    }
+
+    private void addServiceHostGroupsToOrderedOSUpgradeSet(Map<String, List<String>> instanceIdsByInstanceGroup, int order,
+            List<OrderedOSUpgradeSet> osUpgradeByUpgradeSets) {
+        Set<String> instanceIds = null;
+        do {
+            if (instanceIds != null) {
+                osUpgradeByUpgradeSets.add(new OrderedOSUpgradeSet(order++, instanceIds));
+            }
+            instanceIds = getServicesHostGroupIds(instanceIdsByInstanceGroup);
+        } while (!instanceIds.isEmpty());
+    }
+
+    private Set<String> getServicesHostGroupIds(Map<String, List<String>> instanceIdsByInstanceGroup) {
+        Set<String> instanceIds = new HashSet<>();
+        addInstanceId(instanceIdsByInstanceGroup, SOLRHG, instanceIds);
+        addInstanceId(instanceIdsByInstanceGroup, STORAGEHG, instanceIds);
+        addInstanceId(instanceIdsByInstanceGroup, KAFKAHG, instanceIds);
+        addInstanceId(instanceIdsByInstanceGroup, RAZHG, instanceIds);
+        addInstanceId(instanceIdsByInstanceGroup, ATLASHG, instanceIds);
+        addInstanceId(instanceIdsByInstanceGroup, HMSHG, instanceIds);
+        return instanceIds;
+    }
+
+    private void addInstanceId(Map<String, List<String>> instanceIdsByInstanceGroup, InstanceGroupName instanceGroupName, Set<String> instanceIds) {
+        if (instanceIdsByInstanceGroup.containsKey(instanceGroupName.getName()) &&
+                !instanceIdsByInstanceGroup.get(instanceGroupName.getName()).isEmpty()) {
+            instanceIds.add(instanceIdsByInstanceGroup.get(instanceGroupName.getName()).remove(0));
         }
     }
 }

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/OrderedOSUpgradeRequestProviderTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/OrderedOSUpgradeRequestProviderTest.java
@@ -1,10 +1,16 @@
 package com.sequenceiq.datalake.service.upgrade;
 
+import static com.sequenceiq.common.api.type.InstanceGroupName.ATLASHG;
 import static com.sequenceiq.common.api.type.InstanceGroupName.AUXILIARY;
 import static com.sequenceiq.common.api.type.InstanceGroupName.CORE;
 import static com.sequenceiq.common.api.type.InstanceGroupName.GATEWAY;
+import static com.sequenceiq.common.api.type.InstanceGroupName.HMSHG;
 import static com.sequenceiq.common.api.type.InstanceGroupName.IDBROKER;
+import static com.sequenceiq.common.api.type.InstanceGroupName.KAFKAHG;
 import static com.sequenceiq.common.api.type.InstanceGroupName.MASTER;
+import static com.sequenceiq.common.api.type.InstanceGroupName.RAZHG;
+import static com.sequenceiq.common.api.type.InstanceGroupName.SOLRHG;
+import static com.sequenceiq.common.api.type.InstanceGroupName.STORAGEHG;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -56,6 +62,27 @@ class OrderedOSUpgradeRequestProviderTest {
                 createInstanceMetadata(GATEWAY, 1)
         )));
         instanceGroups.add(createInstanceGroup(Set.of(createInstanceMetadata(AUXILIARY, 0))));
+        instanceGroups.add(createInstanceGroup(Set.of(createInstanceMetadata(SOLRHG, 3))));
+        instanceGroups.add(createInstanceGroup(Set.of(createInstanceMetadata(STORAGEHG, 3))));
+        instanceGroups.add(createInstanceGroup(Set.of(
+                createInstanceMetadata(KAFKAHG, 3),
+                createInstanceMetadata(KAFKAHG, 4)
+        )));
+        instanceGroups.add(createInstanceGroup(Set.of(
+                createInstanceMetadata(RAZHG, 3),
+                createInstanceMetadata(RAZHG, 4),
+                createInstanceMetadata(RAZHG, 5)
+        )));
+        instanceGroups.add(createInstanceGroup(Set.of(
+                createInstanceMetadata(ATLASHG, 3),
+                createInstanceMetadata(ATLASHG, 4),
+                createInstanceMetadata(ATLASHG, 5),
+                createInstanceMetadata(ATLASHG, 6)
+        )));
+        instanceGroups.add(createInstanceGroup(Set.of(
+                createInstanceMetadata(HMSHG, 3),
+                createInstanceMetadata(HMSHG, 4)
+        )));
 
         OrderedOSUpgradeSetRequest actual = underTest.createMediumDutyOrderedOSUpgradeSetRequest(createStackV4Response(instanceGroups), TARGET_IMAGE_ID);
 
@@ -63,12 +90,25 @@ class OrderedOSUpgradeRequestProviderTest {
         assertEquals(0, actual.getOrderedOsUpgradeSets().get(0).getOrder());
         assertEquals(1, actual.getOrderedOsUpgradeSets().get(1).getOrder());
         assertEquals(2, actual.getOrderedOsUpgradeSets().get(2).getOrder());
+        assertEquals(3, actual.getOrderedOsUpgradeSets().get(3).getOrder());
+        assertEquals(4, actual.getOrderedOsUpgradeSets().get(4).getOrder());
+        assertEquals(5, actual.getOrderedOsUpgradeSets().get(5).getOrder());
+        assertEquals(6, actual.getOrderedOsUpgradeSets().get(6).getOrder());
+
         assertThat(actual.getOrderedOsUpgradeSets().get(0).getInstanceIds(),
                 containsInAnyOrder(Arrays.asList("i-master0", "i-core0", "i-auxiliary0", "i-idbroker0").toArray()));
         assertThat(actual.getOrderedOsUpgradeSets().get(1).getInstanceIds(),
                 containsInAnyOrder(Set.of("i-master1", "i-core1", "i-gateway0", "i-idbroker1").toArray()));
         assertThat(actual.getOrderedOsUpgradeSets().get(2).getInstanceIds(),
                 containsInAnyOrder(Set.of("i-core2", "i-gateway1").toArray()));
+        assertThat(actual.getOrderedOsUpgradeSets().get(3).getInstanceIds(),
+                containsInAnyOrder(Set.of("i-solrhg3", "i-storagehg3", "i-kafkahg3", "i-razhg3", "i-atlashg3", "i-hmshg3").toArray()));
+        assertThat(actual.getOrderedOsUpgradeSets().get(4).getInstanceIds(),
+                containsInAnyOrder(Set.of("i-kafkahg4", "i-razhg4", "i-atlashg4", "i-hmshg4").toArray()));
+        assertThat(actual.getOrderedOsUpgradeSets().get(5).getInstanceIds(),
+                containsInAnyOrder(Set.of("i-razhg5", "i-atlashg5").toArray()));
+        assertThat(actual.getOrderedOsUpgradeSets().get(6).getInstanceIds(),
+                containsInAnyOrder(Set.of("i-atlashg6").toArray()));
     }
 
     @Test


### PR DESCRIPTION
Context: Enterprise DL has service host groups that should be added to the OS upgrade request when they are present in the stack.
The order of upgrade for these services will be a group of 1 service of each type (SOLRHG, STORAGEHG, KAFKAHG, RAZHG, ATLASHG, HMSHG) at a time.

Test:
Enterprise shape only exists in 7.2.17, to test the upgrade I had to change the checkUpgrade code to force the return of the same image as a candidate to upgrade the OS. 
The service instances were upgraded following the described order.