### PR TITLE
CB-21088 add 8 digit hash to the end of the vm names on Azure

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudInstance.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudInstance.java
@@ -3,15 +3,18 @@ package com.sequenceiq.cloudbreak.cloud.model;
 import java.util.Map;
 import java.util.Objects;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.model.generic.DynamicModel;
 
 /**
  * A common, abstract representation of a virtual machine in a cloud provider.
- *
+ * <p>
  * For example, this class can be used to represent an AWS EC2 instance, Azure virtual machine, or GCP virtual machine instance.
- *
+ * <p>
  * This is a <em>minimal</em> representation, containing the unique (cloud vendor specific) instance ID, template used to create the
  * instance, and necessary information to authenticate and connect to the instance.
  *
@@ -26,6 +29,10 @@ public class CloudInstance extends DynamicModel {
 
     public static final String FQDN = "FQDN";
 
+    public static final String ID = "ID";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudInstance.class);
+
     private final String instanceId;
 
     private String subnetId;
@@ -37,10 +44,10 @@ public class CloudInstance extends DynamicModel {
     private final InstanceAuthentication authentication;
 
     public CloudInstance(String instanceId,
-        InstanceTemplate template,
-        InstanceAuthentication authentication,
-        String subnetId,
-        String availabilityZone) {
+            InstanceTemplate template,
+            InstanceAuthentication authentication,
+            String subnetId,
+            String availabilityZone) {
         this.instanceId = instanceId;
         this.template = template;
         this.authentication = authentication;
@@ -89,6 +96,16 @@ public class CloudInstance extends DynamicModel {
 
     public void setAvailabilityZone(String availabilityZone) {
         this.availabilityZone = availabilityZone;
+    }
+
+    public String getDbIdOrDefaultIfNotExists() {
+        Long dbId = getParameter(CloudInstance.ID, Long.class);
+        if (dbId != null) {
+            return Long.toString(dbId);
+        } else {
+            LOGGER.info("DB id not found, return with 'not_found' instead");
+            return "not_found";
+        }
     }
 
     @Override

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCloudResourceService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCloudResourceService.java
@@ -187,10 +187,11 @@ public class AzureCloudResourceService {
                                 .stream()
                                 .filter(cloudInstance -> cloudInstance.getTemplate().getStatus().equals(InstanceStatus.CREATE_REQUESTED))
                                 .filter(cloudInstance -> instance.getName().equalsIgnoreCase(
-                                        azureUtils.getPrivateInstanceId(stackName,
+                                        azureUtils.getFullInstanceId(stackName,
                                                 cloudInstance.getTemplate().getGroupName(),
-                                                Long.toString(cloudInstance.getTemplate().getPrivateId()))))
-                                .peek(cloudInstance -> LOGGER.debug("The following resource is categorized as VM instance {}", cloudInstance.toString()))
+                                                Long.toString(cloudInstance.getTemplate().getPrivateId()),
+                                                cloudInstance.getDbIdOrDefaultIfNotExists())))
+                                .peek(cloudInstance -> LOGGER.debug("The following resource is categorized as VM instance {}", cloudInstance))
                                 .forEach(filteredInstance ->
                                         vmResourceList.add(buildVm(instance, filteredInstance.getTemplate().getPrivateId(),
                                                 filteredInstance.getTemplate().getGroupName(), resourceGroupName))

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollector.java
@@ -129,9 +129,8 @@ public class AzureMetadataCollector implements MetadataCollector {
     }
 
     private Map<String, InstanceTemplate> getTemplateMap(List<CloudInstance> vms, AuthenticatedContext authenticatedContext) {
-        List<InstanceTemplate> templates = vms.stream().map(CloudInstance::getTemplate).collect(Collectors.toList());
         String stackName = azureUtils.getStackName(authenticatedContext.getCloudContext());
-        return templates.stream()
+        return vms.stream()
                 .collect(Collectors.toMap(
                         template -> azureUtils.getPrivateInstanceId(stackName, template.getGroupName(), Long.toString(template.getPrivateId())),
                         template -> template));

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
+import org.springframework.util.DigestUtils;
 
 import com.azure.core.management.exception.AdditionalInfo;
 import com.azure.core.management.exception.ManagementError;
@@ -89,6 +90,8 @@ public class AzureUtils {
     private static final int NETWORKINTERFACE_DETACH_CHECKING_MAXATTEMPT = 5;
 
     private static final int MAX_DISK_ENCRYPTION_SET_NAME_LENGTH = 80;
+
+    private static final int INSTANCE_NAME_HASH_LENGTH = 8;
 
     private static final String AUTHORIZATION_FAILED_CODE = "AuthorizationFailed";
 
@@ -146,8 +149,17 @@ public class AzureUtils {
         sb.delete(j, sb.length());
     }
 
-    public String getPrivateInstanceId(String stackName, String groupName, String privateId) {
-        return String.format("%s%s%s", stackName, getGroupName(groupName), privateId);
+    public String getFullInstanceId(String stackName, String groupName, String privateId, String dbId) {
+        return stackName + getInstanceIdWithoutStackName(groupName, privateId, dbId);
+    }
+
+    public static String getInstanceIdWithoutStackName(String groupName, String privateId, String dbId) {
+        if (dbId != null) {
+            return String.format("%s%s-%s", getGroupName(groupName), privateId,
+                    DigestUtils.md5DigestAsHex(dbId.getBytes()).substring(0, INSTANCE_NAME_HASH_LENGTH));
+        } else {
+            return String.format("%s%s", getGroupName(groupName), privateId);
+        }
     }
 
     public String getStackName(CloudContext cloudContext) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureInstanceView.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureInstanceView.java
@@ -113,7 +113,8 @@ public class AzureInstanceView {
     }
 
     public String getInstanceId() {
-        return AzureUtils.getGroupName(instanceTemplate.getGroupName()) + instanceTemplate.getPrivateId();
+        String id = instance.getDbIdOrDefaultIfNotExists();
+        return AzureUtils.getInstanceIdWithoutStackName(instanceTemplate.getGroupName(), instanceTemplate.getPrivateId().toString(), id);
     }
 
     public long getPrivateId() {

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCloudResourceServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCloudResourceServiceTest.java
@@ -2,10 +2,10 @@ package com.sequenceiq.cloudbreak.cloud.azure;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -32,6 +31,7 @@ import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceAuthentication;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.common.api.type.CommonStatus;
@@ -76,9 +76,9 @@ public class AzureCloudResourceServiceTest {
         TargetResource t = new TargetResource();
         t.withResourceType(MICROSOFT_COMPUTE_VIRTUAL_MACHINES);
         t.withResourceName(VM_NAME);
-        PagedIterable<DeploymentOperation> operationList = Mockito.mock(PagedIterable.class);
-        DeploymentOperations operations = Mockito.mock(DeploymentOperations.class);
-        DeploymentOperation operation = Mockito.mock(DeploymentOperation.class);
+        PagedIterable<DeploymentOperation> operationList = mock(PagedIterable.class);
+        DeploymentOperations operations = mock(DeploymentOperations.class);
+        DeploymentOperation operation = mock(DeploymentOperation.class);
         when(operationList.stream()).thenReturn(Stream.of(operation));
 
         when(deployment.deploymentOperations()).thenReturn(operations);
@@ -99,9 +99,9 @@ public class AzureCloudResourceServiceTest {
         TargetResource t = new TargetResource();
         t.withResourceType(MICROSOFT_COMPUTE_VIRTUAL_MACHINES);
         t.withResourceName(VM_NAME);
-        PagedIterable<DeploymentOperation> operationList = Mockito.mock(PagedIterable.class);
-        DeploymentOperations operations = Mockito.mock(DeploymentOperations.class);
-        DeploymentOperation operation = Mockito.mock(DeploymentOperation.class);
+        PagedIterable<DeploymentOperation> operationList = mock(PagedIterable.class);
+        DeploymentOperations operations = mock(DeploymentOperations.class);
+        DeploymentOperation operation = mock(DeploymentOperation.class);
         when(operationList.stream()).thenReturn(Stream.of(operation));
 
         when(deployment.deploymentOperations()).thenReturn(operations);
@@ -122,9 +122,9 @@ public class AzureCloudResourceServiceTest {
         TargetResource t = new TargetResource();
         t.withResourceType("unknown");
         t.withResourceName(VM_NAME);
-        PagedIterable<DeploymentOperation> operationList = Mockito.mock(PagedIterable.class);
-        DeploymentOperations operations = Mockito.mock(DeploymentOperations.class);
-        DeploymentOperation operation = Mockito.mock(DeploymentOperation.class);
+        PagedIterable<DeploymentOperation> operationList = mock(PagedIterable.class);
+        DeploymentOperations operations = mock(DeploymentOperations.class);
+        DeploymentOperation operation = mock(DeploymentOperation.class);
         when(operationList.stream()).thenReturn(Stream.of(operation));
 
         when(deployment.deploymentOperations()).thenReturn(operations);
@@ -141,9 +141,9 @@ public class AzureCloudResourceServiceTest {
     public void getInstanceCloudResourcesInstancesFound() {
 
         List<Group> groupList = new ArrayList<>();
-        Group group = Mockito.mock(Group.class);
-        CloudInstance instance = Mockito.mock(CloudInstance.class);
-        InstanceTemplate instanceTemplate = Mockito.mock(InstanceTemplate.class);
+        Group group = mock(Group.class);
+        InstanceTemplate instanceTemplate = mock(InstanceTemplate.class);
+        CloudInstance instance = new CloudInstance("i-1", instanceTemplate, mock(InstanceAuthentication.class), "subnet-1", "az-1");
         CloudResource vm1 = createCloudResource(INSTANCE_1, ResourceType.AZURE_INSTANCE);
         CloudResource vm2 = createCloudResource(INSTANCE_2, ResourceType.AZURE_INSTANCE);
         CloudResource vm3 = createCloudResource(INSTANCE_3, ResourceType.AZURE_INSTANCE);
@@ -151,10 +151,8 @@ public class AzureCloudResourceServiceTest {
         CloudResource ip1 = createCloudResource(IP_1, ResourceType.AZURE_PUBLIC_IP);
         List<CloudResource> cloudResourceList = List.of(vm1, vm2, vm3, storage1, ip1);
 
-        when(instance.getTemplate()).thenReturn(instanceTemplate);
-        when(instance.getTemplate().getPrivateId()).thenReturn(1L);
         when(instance.getTemplate().getStatus()).thenReturn(InstanceStatus.CREATE_REQUESTED);
-        when(azureUtils.getPrivateInstanceId(any(), any(), any()))
+        when(azureUtils.getFullInstanceId(any(), any(), any(), any()))
                 .thenReturn(INSTANCE_1)
                 .thenReturn(INSTANCE_2)
                 .thenReturn(INSTANCE_3);
@@ -174,11 +172,11 @@ public class AzureCloudResourceServiceTest {
         CloudResource vm1 = createCloudResource(INSTANCE_1, ResourceType.AZURE_INSTANCE);
         CloudResource vm2 = createCloudResource(INSTANCE_2, ResourceType.AZURE_INSTANCE);
         CloudResource vm3 = createCloudResource(INSTANCE_3, ResourceType.AZURE_INSTANCE);
-        AzureListResult<VirtualMachine> virtualMachines = Mockito.mock(AzureListResult.class);
-        VirtualMachine vm = Mockito.mock(VirtualMachine.class);
-        StorageProfile storageProfile = Mockito.mock(StorageProfile.class);
-        OSDisk osDisk = Mockito.mock(OSDisk.class);
-        ManagedDiskParameters managedDiskParameters = Mockito.mock(ManagedDiskParameters.class);
+        AzureListResult<VirtualMachine> virtualMachines = mock(AzureListResult.class);
+        VirtualMachine vm = mock(VirtualMachine.class);
+        StorageProfile storageProfile = mock(StorageProfile.class);
+        OSDisk osDisk = mock(OSDisk.class);
+        ManagedDiskParameters managedDiskParameters = mock(ManagedDiskParameters.class);
         when(virtualMachines.getStream()).thenAnswer(invocation -> Stream.of(vm));
 
         when(vm.name()).thenReturn(INSTANCE_1);
@@ -208,7 +206,6 @@ public class AzureCloudResourceServiceTest {
                 .withStatus(status)
                 .withType(resourceType)
                 .withInstanceId(instanceId)
-                .withParameters(Collections.emptyMap())
                 .build();
     }
 

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollectorTest.java
@@ -180,15 +180,16 @@ class AzureMetadataCollectorTest {
 
     private List<CloudInstance> createVms() {
         return List.of(
-                createCloudInstance(INSTANCE_1, PRIVATE_ID_1),
-                createCloudInstance(INSTANCE_2, PRIVATE_ID_2),
-                createCloudInstance(INSTANCE_3, PRIVATE_ID_3));
+                createCloudInstance(INSTANCE_1, PRIVATE_ID_1, 1L),
+                createCloudInstance(INSTANCE_2, PRIVATE_ID_2, 2L),
+                createCloudInstance(INSTANCE_3, PRIVATE_ID_3, 3L));
     }
 
-    private CloudInstance createCloudInstance(String instanceId, Long privateId) {
+    private CloudInstance createCloudInstance(String instanceId, Long privateId, Long id) {
         InstanceTemplate instanceTemplate = new InstanceTemplate(null, INSTANCE_GROUP_NAME, privateId, Collections.emptyList(), null, Collections.emptyMap(),
                 null, null, TemporaryStorage.ATTACHED_VOLUMES, 0L);
-        return new CloudInstance(instanceId, instanceTemplate, null, "subnet-1", "az1");
+        return new CloudInstance(instanceId, instanceTemplate, null, "subnet-1", "az1",
+                Collections.singletonMap(CloudInstance.ID, id));
     }
 
     private CloudResource createCloudResource() {

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStackViewProviderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStackViewProviderTest.java
@@ -114,7 +114,7 @@ public class AzureStackViewProviderTest {
 
         AzureStackView actual = underTest.getAzureStack(azureCredentialView, cloudStack, client, ac);
 
-        assertEquals("i1", actual.getInstancesByGroupType().get(InstanceGroupType.CORE.name()).get(0).getInstanceId());
+        assertEquals("i1-c4ca4238", actual.getInstancesByGroupType().get(InstanceGroupType.CORE.name()).get(0).getInstanceId());
         assertEquals(GROUP_NAME, actual.getInstanceGroups().get(0).getName());
         assertEquals(imageId, actual.getInstancesByGroupType().get(InstanceGroupType.CORE.name()).get(0).getCustomImageId());
 
@@ -143,7 +143,8 @@ public class AzureStackViewProviderTest {
     }
 
     private CloudInstance createCloudInstance() {
-        return new CloudInstance(INSTANCE_ID, createInstanceTemplate(), null, "subnet-1", "az1");
+        return new CloudInstance(INSTANCE_ID, createInstanceTemplate(), null, "subnet-1", "az1",
+                Collections.singletonMap(CloudInstance.ID, 1L));
     }
 
     private InstanceTemplate createInstanceTemplate() {

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
@@ -224,6 +224,7 @@ public class AzureTemplateBuilderTest {
                 new HashMap<>(), 0L, "cb-centos66-amb200-2015-05-25", TemporaryStorage.ATTACHED_VOLUMES, 0L);
         Map<String, Object> params = new HashMap<>();
         params.put(NetworkConstants.SUBNET_ID, "existingSubnet");
+        params.put(CloudInstance.ID, 1L);
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         instance = new CloudInstance("SOME_ID", instanceTemplate, instanceAuthentication, "existingSubnet", "az1", params);
         List<SecurityRule> rules = Collections.singletonList(new SecurityRule("0.0.0.0/0",
@@ -702,13 +703,13 @@ public class AzureTemplateBuilderTest {
         String lbGroupExpectedBlob =
                 "\"tags\":{},\"sku\":{\"name\":\"Standard\",\"tier\":\"Regional\"},\"properties\":{\"publicIPAllocationM" +
                         "ethod\":\"Static\"}},{\"apiVersion\":\"2016-09-01\",\"type\":\"Microsoft.Network/networkInterfa" +
-                        "ces\",\"name\":\"[concat(parameters('nicNamePrefix'),'m0')]\",\"location\":\"[parameters('regio" +
+                        "ces\",\"name\":\"[concat(parameters('nicNamePrefix'),'m0-c4ca4238')]\",\"location\":\"[parameters('regio" +
                         "n')]\",\"tags\":{},\"dependsOn\":[\"[concat('Microsoft.Network/networkSecurityGroups/',variable" +
                         "s('gateway-groupsecGroupName'))]\"";
         String nonLbGroupExpectedBlob =
                 "\"tags\":{},\"properties\":{\"publicIPAllocationMethod\":\"Dynamic\"}},{\"apiVersion\":\"2016-09-01\",\"" +
                         "type\":\"Microsoft.Network/networkInterfaces\",\"name\":\"[concat(parameters('nicNamePrefix'),'" +
-                        "m0')]\",\"location\":\"[parameters('region')]\",\"tags\":{},\"dependsOn\":[\"[concat('Microsoft" +
+                        "m0-c4ca4238')]\",\"location\":\"[parameters('region')]\",\"tags\":{},\"dependsOn\":[\"[concat('Microsoft" +
                         ".Network/networkSecurityGroups/',variables('core-groupsecGroupName'))]\"";
 
         Network network = new Network(new Subnet(SUBNET_CIDR));
@@ -1285,8 +1286,8 @@ public class AzureTemplateBuilderTest {
                         AzureInstanceTemplateOperation.PROVISION, azureMarketplaceImage);
         //THEN
         gson.fromJson(templateString, Map.class);
-        assertThat(templateString).contains("[concat('datadisk', 'm0', '0')]");
-        assertThat(templateString).contains("[concat('datadisk', 'm0', '1')]");
+        assertThat(templateString).contains("[concat('datadisk', 'm0-c4ca4238', '0')]");
+        assertThat(templateString).contains("[concat('datadisk', 'm0-c4ca4238', '1')]");
     }
 
     @ParameterizedTest(name = "buildTestDisksOnAllVersionsAndVerifyOsDisks {0}")
@@ -1322,7 +1323,7 @@ public class AzureTemplateBuilderTest {
                         AzureInstanceTemplateOperation.PROVISION, azureMarketplaceImage);
         //THEN
         gson.fromJson(templateString, Map.class);
-        assertTrue(templateString.contains("[concat(parameters('vmNamePrefix'),'-osDisk', 'm0')]"));
+        assertTrue(templateString.contains("[concat(parameters('vmNamePrefix'),'-osDisk', 'm0-c4ca4238')]"));
     }
 
     @ParameterizedTest(name = "buildTestDisksWhenTheVersion210OrGreater {0}")
@@ -1360,7 +1361,7 @@ public class AzureTemplateBuilderTest {
                         AzureInstanceTemplateOperation.PROVISION, azureMarketplaceImage);
         //THEN
         gson.fromJson(templateString, Map.class);
-        assertTrue(templateString.contains("[concat(parameters('vmNamePrefix'),'-osDisk', 'm0')]"));
+        assertTrue(templateString.contains("[concat(parameters('vmNamePrefix'),'-osDisk', 'm0-c4ca4238')]"));
         assertFalse(templateString.contains("[concat('datadisk', 'm0', '1')]"));
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
@@ -536,6 +536,7 @@ public class StackToCloudStackConverter {
     public Map<String, Object> buildCloudInstanceParameters(DetailedEnvironmentResponse environment,
             InstanceMetadataView instanceMetaData, CloudPlatform platform, Template template) {
         Map<String, Object> params = new HashMap<>();
+        putIfPresent(params, CloudInstance.ID, getIfNotNull(instanceMetaData, InstanceMetadataView::getId));
         putIfPresent(params, CloudInstance.DISCOVERY_NAME, getIfNotNull(instanceMetaData, InstanceMetadataView::getShortHostname));
         putIfPresent(params, SUBNET_ID, getIfNotNull(instanceMetaData, InstanceMetadataView::getSubnetId));
         putIfPresent(params, CloudInstance.INSTANCE_NAME, getIfNotNull(instanceMetaData, InstanceMetadataView::getInstanceName));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
@@ -858,9 +858,10 @@ public class StackToCloudStackConverterTest {
 
         Map<String, Object> result = underTest.buildCloudInstanceParameters(environment, instanceMetaData, CloudPlatform.AWS, null);
 
-        assertThat(result).hasSize(4);
+        assertThat(result).hasSize(5);
         assertThat(result).doesNotContainKey(RESOURCE_GROUP_NAME_PARAMETER);
         assertThat(result).doesNotContainKey(RESOURCE_GROUP_USAGE_PARAMETER);
+        assertThat(result.get(CloudInstance.ID)).isEqualTo(1L);
         assertThat(result.get(CloudInstance.FQDN)).isEqualTo(DISCOVERY_FQDN);
         assertThat(result.get(CloudInstance.DISCOVERY_NAME)).isEqualTo(DISCOVERY_NAME);
         assertThat(result.get(NetworkConstants.SUBNET_ID)).isEqualTo(SUBNET_ID);
@@ -874,7 +875,8 @@ public class StackToCloudStackConverterTest {
 
         Map<String, Object> result = underTest.buildCloudInstanceParameters(environment, instanceMetaData, CloudPlatform.AWS, null);
 
-        assertThat(result).isEmpty();
+        assertEquals(1, result.size());
+        assertThat(result.get(CloudInstance.ID)).isEqualTo(1L);
     }
 
     @Test
@@ -906,7 +908,8 @@ public class StackToCloudStackConverterTest {
 
         assertEquals(RESOURCE_GROUP, result.get(RESOURCE_GROUP_NAME_PARAMETER).toString());
         assertEquals(ResourceGroupUsage.SINGLE.name(), result.get(RESOURCE_GROUP_USAGE_PARAMETER).toString());
-        assertEquals(7, result.size());
+        assertEquals(8, result.size());
+        assertThat(result.get(CloudInstance.ID)).isEqualTo(1L);
         assertThat(result.get(CloudInstance.FQDN)).isEqualTo(DISCOVERY_FQDN);
         assertThat(result.get(CloudInstance.DISCOVERY_NAME)).isEqualTo(DISCOVERY_NAME);
         assertThat(result.get(NetworkConstants.SUBNET_ID)).isEqualTo(SUBNET_ID);
@@ -936,7 +939,8 @@ public class StackToCloudStackConverterTest {
         assertFalse(result.containsKey(RESOURCE_GROUP_NAME_PARAMETER));
         assertFalse(result.containsKey(RESOURCE_GROUP_USAGE_PARAMETER));
 
-        assertEquals(5, result.size());
+        assertEquals(6, result.size());
+        assertThat(result.get(CloudInstance.ID)).isEqualTo(1L);
         assertThat(result.get(CloudInstance.FQDN)).isEqualTo(DISCOVERY_FQDN);
         assertThat(result.get(CloudInstance.DISCOVERY_NAME)).isEqualTo(DISCOVERY_NAME);
         assertThat(result.get(NetworkConstants.SUBNET_ID)).isEqualTo(SUBNET_ID);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
@@ -9,6 +9,8 @@ import static com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.CREATE_REQUES
 import static com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.DELETE_REQUESTED;
 import static com.sequenceiq.cloudbreak.common.network.NetworkConstants.SUBNET_ID;
 import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
+import static com.sequenceiq.cloudbreak.util.NullUtil.getIfNotNull;
+import static com.sequenceiq.cloudbreak.util.NullUtil.putIfPresent;
 import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus.REQUESTED;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -459,6 +461,7 @@ public class StackToCloudStackConverter implements Converter<Stack, CloudStack> 
         String subnetId = instanceMetaData == null ? null : instanceMetaData.getSubnetId();
         String instanceName = instanceMetaData == null ? null : instanceMetaData.getInstanceName();
         Map<String, Object> params = new HashMap<>();
+        putIfPresent(params, CloudInstance.ID, getIfNotNull(instanceMetaData, InstanceMetaData::getId));
         if (hostName != null) {
             hostName = getFreeIpaHostname(instanceMetaData, hostName);
             LOGGER.debug("Setting FreeIPA hostname to {}", hostName);


### PR DESCRIPTION
error scenario at the moment:

we have worker4 with FQDN perdos-az-dist5-env2-worker4.perdos-a.xcu2-8y8x.wl.cloudera.site, it has perdos-az-dist5-env2120w13 instance id, 13 is the private ID. Delete this worker
wair 1 month, instance metadata archiver job deletes the terminated instance from instancemetadata table upscale with 1 node. It will have perdos-az-dist5-env2120w13 because we create private id based on the biggest private id from instancemetadata table for the stack. It is 12, so the next private id is 13. in /srv/salt/agent-tls-tokens we have token with name perdos-az-dist5-env2-worker4.perdos-a.xcu2-8y8x.wl.cloudera.site-perdos-az-dist5-env2120w13 and this is the same for the new node highstate fails, because we will never copy the token to the new node.

solution provided by this commit:
Add a cropped hash of instancemetadata ID, which is a generated ID by postgres, to the end of the instance ID for every Azure VM

See detailed description in the commit message.