### PR TITLE
CB-21391 FMS doesn't put instance metadata status to FAILED state on …

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/failure/UpscaleStackResultToUpscaleFailureEventConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/failure/UpscaleStackResultToUpscaleFailureEventConverter.java
@@ -18,9 +18,8 @@ public class UpscaleStackResultToUpscaleFailureEventConverter implements Payload
     @Override
     public UpscaleFailureEvent convert(Object payload) {
         UpscaleStackResult result = (UpscaleStackResult) payload;
-        UpscaleFailureEvent event = new UpscaleFailureEvent(result.getResourceId(), "Adding instances", Set.of(),
+        return new UpscaleFailureEvent(result.getResourceId(), "Adding instances", Set.of(),
                 StringUtils.isNotEmpty(result.getStatusReason()) ? Map.of("statusReason", result.getStatusReason()) : Map.of(),
                 new Exception("Payload failed: " + payload));
-        return event;
     }
 }


### PR DESCRIPTION
…upscale failure, instead it remains in REQUESTED state

When handling upscale failure, instance put to terminated if there is no instance id available and put to `FAILED` if it's still in requested state or it's missing the IP or FQDN.

See detailed description in the commit message.