### PR TITLE
CB-21567: Enforce new validations when upgrading to 7.2.16.3 or above

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/catalog/ImagePackageVersion.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/catalog/ImagePackageVersion.java
@@ -16,7 +16,8 @@ public enum ImagePackageVersion {
     SALT_BOOTSTRAP("salt-bootstrap"),
     SPARK3("spark3", "Spark 3"),
     STACK("stack"),
-    CDP_LOGGING_AGENT("cdp-logging-agent");
+    CDP_LOGGING_AGENT("cdp-logging-agent"),
+    PYTHON38("python38", "Python 3.8");
 
     private final String key;
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/ClusterUpgradeValidationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/ClusterUpgradeValidationActions.java
@@ -281,7 +281,9 @@ public class ClusterUpgradeValidationActions {
                 LOGGER.info("Starting to validate services.");
                 boolean lockComponents = (Boolean) variables.get(LOCK_COMPONENTS);
                 String targetRuntime = (String) variables.get(TARGET_RUNTIME);
-                ClusterUpgradeServiceValidationEvent event = new ClusterUpgradeServiceValidationEvent(payload.getResourceId(), lockComponents, targetRuntime);
+                UpgradeImageInfo imageInfo = (UpgradeImageInfo) variables.get(UPGRADE_IMAGE_INFO);
+                ClusterUpgradeServiceValidationEvent event = new ClusterUpgradeServiceValidationEvent(payload.getResourceId(), lockComponents, targetRuntime,
+                        imageInfo);
                 sendEvent(context, event.selector(), event);
             }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeServiceValidationEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeServiceValidationEvent.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.cloudbreak.service.upgrade.UpgradeImageInfo;
 
 public class ClusterUpgradeServiceValidationEvent extends StackEvent {
 
@@ -10,14 +11,18 @@ public class ClusterUpgradeServiceValidationEvent extends StackEvent {
 
     private final String targetRuntime;
 
+    private final UpgradeImageInfo upgradeImageInfo;
+
     @JsonCreator
     public ClusterUpgradeServiceValidationEvent(
             @JsonProperty("resourceId") Long resourceId,
             @JsonProperty("lockComponents") boolean lockComponents,
-            @JsonProperty("targetRuntime") String targetRuntime) {
+            @JsonProperty("targetRuntime") String targetRuntime,
+            @JsonProperty("upgradeImageInfo") UpgradeImageInfo upgradeImageInfo) {
         super(ClusterUpgradeValidationHandlerSelectors.VALIDATE_SERVICES_EVENT.name(), resourceId);
         this.lockComponents = lockComponents;
         this.targetRuntime = targetRuntime;
+        this.upgradeImageInfo = upgradeImageInfo;
     }
 
     public boolean isLockComponents() {
@@ -28,11 +33,16 @@ public class ClusterUpgradeServiceValidationEvent extends StackEvent {
         return targetRuntime;
     }
 
+    public UpgradeImageInfo getUpgradeImageInfo() {
+        return upgradeImageInfo;
+    }
+
     @Override
     public String toString() {
         return "ClusterUpgradeServiceValidationEvent{" +
                 "lockComponents=" + lockComponents +
                 "targetRuntime=" + targetRuntime +
+                "upgradeImageInfo=" + upgradeImageInfo +
                 "} " + super.toString();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/CurrentImagePackageProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/CurrentImagePackageProvider.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.cloudbreak.service.image;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.ImagePackageVersion;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
+
+@Component
+public class CurrentImagePackageProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CurrentImagePackageProvider.class);
+
+    @Inject
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Inject
+    private ImageConverter imageConverter;
+
+    public boolean currentInstancesContainsPackage(Long stackId, List<Image> cdhImagesFromCatalog, ImagePackageVersion packageVersion) {
+        Map<String, String> imagesByInstance = getImagesByInstance(stackId);
+        LOGGER.debug("The available packages on instances: {}", imagesByInstance);
+        return imagesByInstance.entrySet().stream().allMatch(entry -> cdhImagesFromCatalog.stream().anyMatch(
+                imageFromCatalog -> currentImageContainsPackage(packageVersion, entry, imageFromCatalog)));
+    }
+
+    private Map<String, String> getImagesByInstance(Long stackId) {
+        return instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(stackId)
+                .stream()
+                .filter(instanceMetaData -> !instanceMetaData.getImage().getMap().isEmpty())
+                .collect(Collectors.toMap(InstanceMetaData::getInstanceId,
+                        instanceMetaData -> convertJsonToImage(instanceMetaData.getImage())));
+    }
+
+    private String convertJsonToImage(Json image) {
+        return imageConverter.convertJsonToImage(image).getImageId();
+    }
+
+    private boolean currentImageContainsPackage(ImagePackageVersion packageVersion, Map.Entry<String, String> entry, Image imageFromCatalog) {
+        return imageFromCatalog.getUuid().equals(entry.getValue()) && imageFromCatalog.getPackageVersions().containsKey(packageVersion.getKey());
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/CurrentImageUsageCondition.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/CurrentImageUsageCondition.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.cloudbreak.service.image;
 
-import java.util.Set;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
@@ -26,28 +25,19 @@ public class CurrentImageUsageCondition {
     private ImageConverter imageConverter;
 
     public boolean currentImageUsedOnInstances(Long stackId, String currentImageId) {
-        Set<Image> imagesFromInstances = getImagesFromInstanceMetadata(stackId);
-        LOGGER.debug("The current image of the stack: {}. The available images on instances: {}", currentImageId, getImageIds(imagesFromInstances));
-        return imagesFromInstances.stream()
-                .anyMatch(image -> !image.getImageId().equals(currentImageId));
+        Map<String, String> imageByInstances = getImagesByInstance(stackId);
+        LOGGER.debug("The current image of the stack: {}. The available images on instances: {}", currentImageId, imageByInstances);
+        return !imageByInstances.isEmpty() && imageByInstances.values().stream().allMatch(imageIdOnInstance -> imageIdOnInstance.equals(currentImageId));
     }
 
-    private Set<Image> getImagesFromInstanceMetadata(Long stackId) {
+    private Map<String, String> getImagesByInstance(Long stackId) {
         return instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(stackId)
                 .stream()
-                .map(InstanceMetaData::getImage)
-                .filter(json -> !json.getMap().isEmpty())
-                .map(this::convertJsonToImage)
-                .collect(Collectors.toSet());
+                .filter(instanceMetaData -> !instanceMetaData.getImage().getMap().isEmpty())
+                .collect(Collectors.toMap(InstanceMetaData::getInstanceId, instanceMetaData -> convertJsonToImage(instanceMetaData.getImage())));
     }
 
-    private Image convertJsonToImage(Json imageJson) {
-        return imageConverter.convertJsonToImage(imageJson);
-    }
-
-    private Set<String> getImageIds(Set<Image> imagesFromInstances) {
-        return imagesFromInstances.stream()
-                .map(Image::getImageId)
-                .collect(Collectors.toSet());
+    private String convertJsonToImage(Json image) {
+        return imageConverter.convertJsonToImage(image).getImageId();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageConverter.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.cloudbreak.service.image;
 
-import java.io.IOException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -18,7 +16,7 @@ public class ImageConverter {
     public Image convertJsonToImage(Json imageJson) {
         try {
             return imageJson.get(Image.class);
-        } catch (IOException e) {
+        } catch (Exception e) {
             String message = "Failed to convert Json to Image";
             LOGGER.error(message, e);
             throw new CloudbreakRuntimeException(message, e);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityService.java
@@ -35,6 +35,7 @@ import com.sequenceiq.cloudbreak.service.cluster.model.RepairValidation;
 import com.sequenceiq.cloudbreak.service.cluster.model.Result;
 import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
+import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.upgrade.image.ClusterUpgradeImageFilter;
 import com.sequenceiq.cloudbreak.service.upgrade.image.ImageFilterParams;
@@ -143,13 +144,13 @@ public class ClusterUpgradeAvailabilityService {
             LOGGER.info(String.format("Retrieving images for upgrading stack %s", stack.getName()));
             com.sequenceiq.cloudbreak.cloud.model.Image currentImage = getImage(stack);
             Long workspaceId = stack.getWorkspace().getId();
-            Image image = imageCatalogService
-                    .getImage(workspaceId, currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), currentImage.getImageId())
-                    .getImage();
+            StatedImage image = imageCatalogService
+                    .getImage(workspaceId, currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), currentImage.getImageId());
             ImageFilterParams imageFilterParams = imageFilterParamsFactory.create(image, lockComponents, stack, internalUpgradeSettings, getAllImages);
             ImageFilterResult imageFilterResult = filterImages(accountId, workspaceId, currentImage.getImageCatalogName(), imageFilterParams);
             LOGGER.info(String.format("%d possible image found for stack upgrade.", imageFilterResult.getImages().size()));
-            upgradeOptions = createResponse(image, imageFilterResult, stack.getCloudPlatform(), stack.getRegion(), currentImage.getImageCatalogName());
+            upgradeOptions = createResponse(image.getImage(), imageFilterResult, stack.getCloudPlatform(), stack.getRegion(),
+                    currentImage.getImageCatalogName());
         } catch (CloudbreakImageNotFoundException | CloudbreakImageCatalogException | NotFoundException e) {
             LOGGER.warn("Failed to get images", e);
             upgradeOptions.setReason(String.format("Failed to retrieve image due to %s", e.getMessage()));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactory.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.InternalUpgradeSettings;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
-import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cluster.service.ClouderaManagerProductsProvider;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.service.PlatformStringTransformer;
@@ -20,6 +19,7 @@ import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.view.ClusterComponentView;
 import com.sequenceiq.cloudbreak.dto.StackDtoDelegate;
+import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.service.parcel.ParcelService;
 import com.sequenceiq.cloudbreak.service.upgrade.image.ImageFilterParams;
 
@@ -37,8 +37,9 @@ public class ImageFilterParamsFactory {
     @Inject
     private PlatformStringTransformer platformStringTransformer;
 
-    public ImageFilterParams create(Image image, boolean lockComponents, Stack stack, InternalUpgradeSettings internalUpgradeSettings, boolean getAllImages) {
-        return new ImageFilterParams(image, lockComponents, getStackRelatedParcels(stack), stack.getType(),
+    public ImageFilterParams create(StatedImage image, boolean lockComponents, Stack stack, InternalUpgradeSettings internalUpgradeSettings,
+            boolean getAllImages) {
+        return new ImageFilterParams(image.getImage(), image.getImageCatalogName(), lockComponents, getStackRelatedParcels(stack), stack.getType(),
                 getBlueprint(stack), stack.getId(), internalUpgradeSettings, platformStringTransformer.getPlatformStringForImageCatalog(stack.cloudPlatform(),
                 stack.getPlatformVariant()), stack.cloudPlatform(), stack.getRegion(), getAllImages);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradeImageInfo.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradeImageInfo.java
@@ -1,23 +1,26 @@
 package com.sequenceiq.cloudbreak.service.upgrade;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.service.image.StatedImage;
 
 public class UpgradeImageInfo {
 
-    private Image currentImage;
+    private final Image currentImage;
 
-    private StatedImage currentStatedImage;
+    private final StatedImage currentStatedImage;
 
-    private StatedImage targetStatedImage;
+    private final StatedImage targetStatedImage;
 
-    public UpgradeImageInfo(Image currentImage, StatedImage currentStatedImage, StatedImage targetStatedImage) {
+    @JsonCreator
+    public UpgradeImageInfo(
+            @JsonProperty("currentImage") Image currentImage,
+            @JsonProperty("currentStatedImage") StatedImage currentStatedImage,
+            @JsonProperty("targetStatedImage") StatedImage targetStatedImage) {
         this.currentImage = currentImage;
         this.currentStatedImage = currentStatedImage;
         this.targetStatedImage = targetStatedImage;
-    }
-
-    public UpgradeImageInfo() {
     }
 
     public Image getCurrentImage() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ImageFilterParams.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ImageFilterParams.java
@@ -13,6 +13,8 @@ public class ImageFilterParams {
 
     private final Image currentImage;
 
+    private final String imageCatalogName;
+
     private final boolean lockComponents;
 
     private final Map<String, String> stackRelatedParcels;
@@ -33,10 +35,11 @@ public class ImageFilterParams {
 
     private final boolean getAllImages;
 
-    public ImageFilterParams(Image currentImage, boolean lockComponents, Map<String, String> stackRelatedParcels, StackType stackType, Blueprint blueprint,
-            Long stackId, InternalUpgradeSettings internalUpgradeSettings, ImageCatalogPlatform imageCatalogPlatform, String cloudPlatform, String region,
-            boolean getAllImages) {
+    public ImageFilterParams(Image currentImage, String imageCatalogName, boolean lockComponents, Map<String, String> stackRelatedParcels, StackType stackType,
+            Blueprint blueprint, Long stackId, InternalUpgradeSettings internalUpgradeSettings, ImageCatalogPlatform imageCatalogPlatform, String cloudPlatform,
+            String region, boolean getAllImages) {
         this.currentImage = currentImage;
+        this.imageCatalogName = imageCatalogName;
         this.lockComponents = lockComponents;
         this.stackRelatedParcels = stackRelatedParcels;
         this.stackType = stackType;
@@ -51,6 +54,10 @@ public class ImageFilterParams {
 
     public Image getCurrentImage() {
         return currentImage;
+    }
+
+    public String getImageCatalogName() {
+        return imageCatalogName;
     }
 
     public boolean isLockComponents() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/CurrentImageUpgradeImageFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/CurrentImageUpgradeImageFilter.java
@@ -53,13 +53,17 @@ public class CurrentImageUpgradeImageFilter implements UpgradeImageFilter {
     private Predicate<Image> filterCurrentImage(ImageFilterParams imageFilterParams) {
         return image -> {
             String currentImageId = imageFilterParams.getCurrentImage().getUuid();
-            if (!(image.getUuid().equals(currentImageId) && !isCurrentImageUsedOnInstances(imageFilterParams, currentImageId))) {
+            if (!isCurrentImage(image, currentImageId) || !isCurrentImageUsedOnInstances(imageFilterParams, currentImageId)) {
                 return true;
             } else {
                 LOGGER.debug("The current image was removed from the upgrade candidates.");
                 return false;
             }
         };
+    }
+
+    private boolean isCurrentImage(Image image, String currentImageId) {
+        return image.getUuid().equals(currentImageId);
     }
 
     private boolean isCurrentImageUsedOnInstances(ImageFilterParams imageFilterParams, String currentImageId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/RuntimeDependencyBasedUpgradeImageFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/RuntimeDependencyBasedUpgradeImageFilter.java
@@ -1,0 +1,77 @@
+package com.sequenceiq.cloudbreak.service.upgrade.image.filter;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
+import com.sequenceiq.cloudbreak.service.upgrade.image.ImageFilterParams;
+import com.sequenceiq.cloudbreak.service.upgrade.image.ImageFilterResult;
+import com.sequenceiq.cloudbreak.service.upgrade.validation.PythonVersionBasedRuntimeVersionValidator;
+import com.sequenceiq.cloudbreak.service.upgrade.validation.service.PythonVersionValidator;
+
+@Component
+public class RuntimeDependencyBasedUpgradeImageFilter implements UpgradeImageFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RuntimeDependencyBasedUpgradeImageFilter.class);
+
+    private static final int ORDER_NUMBER = 10;
+
+    @Inject
+    private PythonVersionBasedRuntimeVersionValidator pythonVersionBasedRuntimeVersionValidator;
+
+    @Inject
+    private StackDtoService stackDtoService;
+
+    @Inject
+    private ImageCatalogService imageCatalogService;
+
+    @Override
+    public ImageFilterResult filter(ImageFilterResult imageFilterResult, ImageFilterParams imageFilterParams) {
+        List<Image> filteredImages = filterImages(imageFilterResult, imageFilterParams);
+        LOGGER.debug("After the filtering {} image left.", filteredImages.size());
+        return new ImageFilterResult(filteredImages, getReason(filteredImages, imageFilterParams));
+    }
+
+    @Override
+    public String getMessage(ImageFilterParams imageFilterParams) {
+        return PythonVersionValidator.ERROR_MESSAGE;
+    }
+
+    @Override
+    public Integer getFilterOrderNumber() {
+        return ORDER_NUMBER;
+    }
+
+    private List<Image> filterImages(ImageFilterResult imageFilterResult, ImageFilterParams imageFilterParams) {
+        StackDto stack = stackDtoService.getById(imageFilterParams.getStackId());
+        List<Image> allCdhImages = getAllCdhImagesFromCatalog(imageFilterParams, stack);
+        return imageFilterResult.getImages()
+                .stream()
+                .filter(image -> pythonVersionBasedRuntimeVersionValidator.isUpgradePermittedForRuntime(stack, allCdhImages,
+                        imageFilterParams.getCurrentImage(), image))
+                .collect(Collectors.toList());
+    }
+
+    private List<Image> getAllCdhImagesFromCatalog(ImageFilterParams imageFilterParams, StackDto stack) {
+        try {
+            return imageCatalogService.getAllCdhImages(ThreadBasedUserCrnProvider.getUserCrn(), stack.getWorkspaceId(),
+                    imageFilterParams.getImageCatalogName(), Set.of(imageFilterParams.getImageCatalogPlatform()));
+        } catch (CloudbreakImageCatalogException e) {
+            LOGGER.error("Failed to retrieve images from catalog {}", imageFilterParams.getImageCatalogName(), e);
+            throw new CloudbreakServiceException(e);
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/locked/LockedComponentService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/locked/LockedComponentService.java
@@ -40,13 +40,18 @@ public class LockedComponentService {
             com.sequenceiq.cloudbreak.cloud.model.catalog.Image targetCatalogImage = imageCatalogService
                     .getImage(workspaceId, currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), targetImageId)
                     .getImage();
-            LOGGER.info("Determining that the stack {} component versions are the same on the current image {} and the target image {}", stack.getName(),
-                    currentCatalogImage.getUuid(), targetCatalogImage.getUuid());
-            return lockedComponentChecker.isUpgradePermitted(currentCatalogImage, targetCatalogImage, imageFilterParamsFactory.getStackRelatedParcels(stack));
+            return isComponentsLocked(stack, currentCatalogImage, targetCatalogImage);
         } catch (Exception ex) {
             String msg = "Exception during determining the lockComponents parameter.";
             LOGGER.warn(msg, ex);
             throw new CloudbreakRuntimeException(msg, ex);
         }
+    }
+
+    public boolean isComponentsLocked(StackDto stack, com.sequenceiq.cloudbreak.cloud.model.catalog.Image currentCatalogImage,
+            com.sequenceiq.cloudbreak.cloud.model.catalog.Image targetCatalogImage) {
+        LOGGER.debug("Determining that the stack {} component versions are the same on the current image {} and the target image {}", stack.getName(),
+                currentCatalogImage.getUuid(), targetCatalogImage.getUuid());
+        return lockedComponentChecker.isUpgradePermitted(currentCatalogImage, targetCatalogImage, imageFilterParamsFactory.getStackRelatedParcels(stack));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/PythonVersionBasedRuntimeVersionValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/PythonVersionBasedRuntimeVersionValidator.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.cloudbreak.service.upgrade.validation;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.ImagePackageVersion;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.service.image.CurrentImagePackageProvider;
+import com.sequenceiq.cloudbreak.service.upgrade.image.locked.LockedComponentService;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
+
+@Component
+public class PythonVersionBasedRuntimeVersionValidator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PythonVersionBasedRuntimeVersionValidator.class);
+
+    private static final String MINIMUM_RUNTIME_VERSION = "7.2.16";
+
+    @Inject
+    private LockedComponentService lockedComponentService;
+
+    @Inject
+    private CurrentImagePackageProvider currentImagePackageProvider;
+
+    public boolean isUpgradePermittedForRuntime(StackDto stack, List<Image> cdhImagesFromCatalog, Image currentImage, Image targetImage) {
+        String targetImageId = targetImage.getUuid();
+        if (isDataHubCluster(stack) && isTargetImageRequiresPython38(targetImage)) {
+            if (isCurrentImageContainsPython38(stack, cdhImagesFromCatalog, currentImage) || isOsUpgrade(stack, currentImage, targetImage)) {
+                LOGGER.debug("Permitting upgrade for image {} because the required Python version is present on the current image {}", targetImageId,
+                        currentImage.getUuid());
+                return true;
+            } else {
+                LOGGER.debug("The upgrade is not possible for image {} because the target runtime requires Python 3.8 dependency", targetImageId);
+                return false;
+            }
+        }
+        LOGGER.debug("Permitting upgrade because the target image {} does not require Python 3.8 dependency", targetImageId);
+        return true;
+    }
+
+    private boolean isDataHubCluster(StackDto stack) {
+        return stack.getType().equals(StackType.WORKLOAD);
+    }
+
+    private boolean isOsUpgrade(StackDto stack, Image currentImage, Image targetImage) {
+        return currentImage.getStackDetails().getVersion().equals(targetImage.getStackDetails().getVersion()) &&
+                lockedComponentService.isComponentsLocked(stack, currentImage, targetImage);
+    }
+
+    private boolean isTargetImageRequiresPython38(Image targetImage) {
+        return isTargetRuntimeRequiresPython38(targetImage.getStackDetails().getVersion());
+    }
+
+    private boolean isTargetRuntimeRequiresPython38(String targetRuntimeVersion) {
+        return new VersionComparator().compare(() -> targetRuntimeVersion, () -> MINIMUM_RUNTIME_VERSION) >= 0;
+    }
+
+    private boolean isCurrentImageContainsPython38(StackDto stack, List<Image> cdhImagesFromCatalog, Image currentImage) {
+        return currentImage.getPackageVersions().containsKey(ImagePackageVersion.PYTHON38.getKey())
+                && currentImagePackageProvider.currentInstancesContainsPackage(stack.getId(), cdhImagesFromCatalog, ImagePackageVersion.PYTHON38);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/FlinkUpgradeValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/FlinkUpgradeValidator.java
@@ -11,7 +11,7 @@ import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
 import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateService;
 import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 
 @Component
@@ -32,7 +32,7 @@ public class FlinkUpgradeValidator implements ServiceUpgradeValidator {
     @Override
     public void validate(ServiceUpgradeValidationRequest validationRequest) {
         String targetRuntime = validationRequest.getTargetRuntime();
-        Stack stack = validationRequest.getStack();
+        StackDto stack = validationRequest.getStack();
         if (!StringUtils.hasText(targetRuntime)) {
             LOGGER.debug("Skipping Flink service validation due to missing or invalid: target runtime version: [{}]", targetRuntime);
         } else if (!CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited(targetRuntime, CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_16)) {
@@ -52,11 +52,11 @@ public class FlinkUpgradeValidator implements ServiceUpgradeValidator {
         }
     }
 
-    private boolean isFLinkServicePresent(Stack stack) {
+    private boolean isFLinkServicePresent(StackDto stack) {
         return cmTemplateService.isServiceTypePresent(FLINK_SERVICE_TYPE, getBlueprintText(stack));
     }
 
-    private String getBlueprintText(Stack stack) {
-        return stack.getCluster().getBlueprint().getBlueprintText();
+    private String getBlueprintText(StackDto stack) {
+        return stack.getBlueprint().getBlueprintText();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/NifiUpgradeValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/NifiUpgradeValidator.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateService;
 import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.template.VolumeUtils;
 
@@ -37,19 +37,19 @@ public class NifiUpgradeValidator implements ServiceUpgradeValidator {
         if (validationRequest.isLockComponents() && isNifiServicePresent(validationRequest.getStack())) {
             validateNifiWorkingDirectory(validationRequest.getStack());
         } else {
-            LOGGER.debug("Skipping Nifi service validation because  it's not OS upgrade or Nifi not present in the cluster.");
+            LOGGER.debug("Skipping Nifi service validation because it's not OS upgrade or Nifi not present in the cluster.");
         }
     }
 
-    private boolean isNifiServicePresent(Stack stack) {
+    private boolean isNifiServicePresent(StackDto stack) {
         return cmTemplateService.isServiceTypePresent(NIFI_SERVICE_TYPE, getBlueprintText(stack));
     }
 
-    private String getBlueprintText(Stack stack) {
-        return stack.getCluster().getBlueprint().getBlueprintText();
+    private String getBlueprintText(StackDto stack) {
+        return stack.getBlueprint().getBlueprintText();
     }
 
-    private void validateNifiWorkingDirectory(Stack stack) {
+    private void validateNifiWorkingDirectory(StackDto stack) {
         ClusterApi connector = clusterApiConnectors.getConnector(stack);
         Optional<String> nifiWorkingDirectory = connector.getRoleConfigValueByServiceType(stack.getCluster().getName(), ROLE_TYPE, NIFI_SERVICE_TYPE,
                 NIFI_WORKING_DIRECTORY);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/PythonVersionValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/PythonVersionValidator.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.cloudbreak.service.upgrade.validation.service;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
+import com.sequenceiq.cloudbreak.common.service.PlatformStringTransformer;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
+import com.sequenceiq.cloudbreak.service.upgrade.UpgradeImageInfo;
+import com.sequenceiq.cloudbreak.service.upgrade.validation.PythonVersionBasedRuntimeVersionValidator;
+
+@Component
+public class PythonVersionValidator implements ServiceUpgradeValidator {
+
+    public static final String ERROR_MESSAGE =
+            "You are not eligible to upgrade to the selected runtime because an additional dependency must be present on your image. "
+                    + "Please run an OS upgrade or upgrade to the latest service pack for your current runtime version first. "
+                    + "This will automatically add the required dependency. "
+                    + "After this you will be able to launch another upgrade to the more recent runtime.";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PythonVersionValidator.class);
+
+    @Inject
+    private PythonVersionBasedRuntimeVersionValidator pythonVersionBasedRuntimeVersionValidator;
+
+    @Inject
+    private ImageCatalogService imageCatalogService;
+
+    @Inject
+    private PlatformStringTransformer platformStringTransformer;
+
+    @Override
+    public void validate(ServiceUpgradeValidationRequest validationRequest) {
+        UpgradeImageInfo upgradeImageInfo = validationRequest.getUpgradeImageInfo();
+        Image currentImage = upgradeImageInfo.getCurrentStatedImage().getImage();
+        Image targetImage = upgradeImageInfo.getTargetStatedImage().getImage();
+        if (isUpgradeDeniedForRuntime(validationRequest.getStack(), validationRequest.getUpgradeImageInfo().getCurrentStatedImage().getImageCatalogName(),
+                currentImage, targetImage)) {
+            LOGGER.debug("Upgrade validation failed because the current image {} does not contains Python 3.8 and it's required for upgrade to the target"
+                    + "image {}", currentImage.getUuid(), targetImage.getUuid());
+            throw new UpgradeValidationFailedException(ERROR_MESSAGE);
+        }
+    }
+
+    private boolean isUpgradeDeniedForRuntime(StackDto stack, String imageCatalogName, Image currentImage, Image targetImage) {
+        List<Image> cdhImagesFromCatalog = getAllCdhImagesFromCatalog(stack, imageCatalogName);
+        return !pythonVersionBasedRuntimeVersionValidator.isUpgradePermittedForRuntime(stack, cdhImagesFromCatalog, currentImage, targetImage);
+    }
+
+    private List<Image> getAllCdhImagesFromCatalog(StackDto stack, String imageCatalogName) {
+        try {
+            return imageCatalogService.getAllCdhImages(ThreadBasedUserCrnProvider.getUserCrn(), stack.getWorkspaceId(),
+                    imageCatalogName, platformStringTransformer.getPlatformStringForImageCatalogSet(stack.getCloudPlatform(), stack.getPlatformVariant()));
+        } catch (CloudbreakImageCatalogException e) {
+            LOGGER.error("Failed to retrieve images from catalog {}", imageCatalogName, e);
+            throw new CloudbreakServiceException(e);
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/ServiceUpgradeValidationRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/ServiceUpgradeValidationRequest.java
@@ -1,22 +1,26 @@
 package com.sequenceiq.cloudbreak.service.upgrade.validation.service;
 
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.service.upgrade.UpgradeImageInfo;
 
 public class ServiceUpgradeValidationRequest {
 
-    private final Stack stack;
+    private final StackDto stack;
 
     private final boolean lockComponents;
 
     private final String targetRuntime;
 
-    public ServiceUpgradeValidationRequest(Stack stack, boolean lockComponents, String targetRuntime) {
+    private final UpgradeImageInfo upgradeImageInfo;
+
+    public ServiceUpgradeValidationRequest(StackDto stack, boolean lockComponents, String targetRuntime, UpgradeImageInfo upgradeImageInfo) {
         this.stack = stack;
         this.lockComponents = lockComponents;
         this.targetRuntime = targetRuntime;
+        this.upgradeImageInfo = upgradeImageInfo;
     }
 
-    public Stack getStack() {
+    public StackDto getStack() {
         return stack;
     }
 
@@ -26,5 +30,9 @@ public class ServiceUpgradeValidationRequest {
 
     public String getTargetRuntime() {
         return targetRuntime;
+    }
+
+    public UpgradeImageInfo getUpgradeImageInfo() {
+        return upgradeImageInfo;
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CurrentImagePackageProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CurrentImagePackageProviderTest.java
@@ -1,0 +1,89 @@
+package com.sequenceiq.cloudbreak.service.image;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.ImagePackageVersion;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
+
+@ExtendWith(MockitoExtension.class)
+class CurrentImagePackageProviderTest {
+
+    private static final long STACK_ID = 1L;
+
+    private static final ImagePackageVersion REQUIRED_PACKAGE = ImagePackageVersion.PYTHON38;
+
+    private static final String CURRENT_IMAGE_ID = "current-image";
+
+    @InjectMocks
+    private CurrentImagePackageProvider underTest;
+
+    @Mock
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Spy
+    private ImageConverter imageConverter;
+
+    @Test
+    void testShouldReturnTrueWhenAllInstanceContainsTheRequiredPackage() {
+        when(instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(STACK_ID)).thenReturn(createInstanceMetadataSet());
+        List<Image> cdhImagesFromCatalog = List.of(createImage("image-1", true), createImage("image-2", true), createImage(CURRENT_IMAGE_ID, true));
+        assertTrue(underTest.currentInstancesContainsPackage(STACK_ID, cdhImagesFromCatalog, REQUIRED_PACKAGE));
+    }
+
+    @Test
+    void testShouldReturnFalseWhenInstancesDoesNotContainsTheRequiredPackage() {
+        when(instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(STACK_ID)).thenReturn(createInstanceMetadataSet());
+        List<Image> cdhImagesFromCatalog = List.of(createImage("image-1", true), createImage("image-2", false), createImage(CURRENT_IMAGE_ID, false));
+        assertFalse(underTest.currentInstancesContainsPackage(STACK_ID, cdhImagesFromCatalog, REQUIRED_PACKAGE));
+    }
+
+    @Test
+    void testShouldReturnFalseWhenTheImagesFromCatalogIsEmpty() {
+        when(instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(STACK_ID)).thenReturn(createInstanceMetadataSet());
+        List<Image> cdhImagesFromCatalog = Collections.emptyList();
+        assertFalse(underTest.currentInstancesContainsPackage(STACK_ID, cdhImagesFromCatalog, REQUIRED_PACKAGE));
+    }
+
+    private Image createImage(String imageId, boolean containsPackage) {
+        return ImageTestBuilder.builder()
+                .withUuid(imageId)
+                .withPackageVersions(containsPackage ? Map.of(REQUIRED_PACKAGE.getKey(), "3.8") : Collections.emptyMap())
+                .build();
+    }
+
+    private Set<InstanceMetaData> createInstanceMetadataSet() {
+        return Set.of(
+                createInstanceMetadata("instance-1", CURRENT_IMAGE_ID),
+                createInstanceMetadata("instance-2", CURRENT_IMAGE_ID),
+                createInstanceMetadata("instance-3", CURRENT_IMAGE_ID)
+        );
+    }
+
+    private InstanceMetaData createInstanceMetadata(String instanceId, String imageId) {
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setInstanceId(instanceId);
+        instanceMetaData.setImage(new Json(createImage(imageId)));
+        return instanceMetaData;
+    }
+
+    private com.sequenceiq.cloudbreak.cloud.model.Image createImage(String imageId) {
+        return new com.sequenceiq.cloudbreak.cloud.model.Image(null, null, null, null, null, null, imageId, null);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageTestBuilder.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageTestBuilder.java
@@ -1,0 +1,170 @@
+package com.sequenceiq.cloudbreak.service.image;
+
+import java.util.List;
+import java.util.Map;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.ImageStackDetails;
+
+public class ImageTestBuilder {
+
+    private String date;
+
+    private Long created;
+
+    private Long published;
+
+    private String description;
+
+    private String os;
+
+    private String osType;
+
+    private String uuid;
+
+    private String version;
+
+    private Map<String, String> repo;
+
+    private Map<String, Map<String, String>> imageSetsByProvider;
+
+    private ImageStackDetails stackDetails;
+
+    private boolean defaultImage;
+
+    private Map<String, String> packageVersions;
+
+    private List<List<String>> preWarmParcels;
+
+    private List<String> preWarmCsd;
+
+    private String cmBuildNumber;
+
+    private boolean advertised;
+
+    private String baseParcelUrl;
+
+    private String sourceImageId;
+
+    public static ImageTestBuilder builder() {
+        return new ImageTestBuilder();
+    }
+
+    public ImageTestBuilder withDate(String date) {
+        this.date = date;
+        return this;
+    }
+
+    public ImageTestBuilder withCreated(Long created) {
+        this.created = created;
+        return this;
+    }
+
+    public ImageTestBuilder withPublished(Long published) {
+        this.published = published;
+        return this;
+    }
+
+    public ImageTestBuilder withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public ImageTestBuilder withOs(String os) {
+        this.os = os;
+        return this;
+    }
+
+    public ImageTestBuilder withOsType(String osType) {
+        this.osType = osType;
+        return this;
+    }
+
+    public ImageTestBuilder withUuid(String uuid) {
+        this.uuid = uuid;
+        return this;
+    }
+
+    public ImageTestBuilder withVersion(String version) {
+        this.version = version;
+        return this;
+    }
+
+    public ImageTestBuilder withRepo(Map<String, String> repo) {
+        this.repo = repo;
+        return this;
+    }
+
+    public ImageTestBuilder withImageSetsByProvider(Map<String, Map<String, String>> imageSetsByProvider) {
+        this.imageSetsByProvider = imageSetsByProvider;
+        return this;
+    }
+
+    public ImageTestBuilder withStackDetails(ImageStackDetails stackDetails) {
+        this.stackDetails = stackDetails;
+        return this;
+    }
+
+    public ImageTestBuilder withDefaultImage(boolean defaultImage) {
+        this.defaultImage = defaultImage;
+        return this;
+    }
+
+    public ImageTestBuilder withPackageVersions(Map<String, String> packageVersions) {
+        this.packageVersions = packageVersions;
+        return this;
+    }
+
+    public ImageTestBuilder withPreWarmParcels(List<List<String>> preWarmParcels) {
+        this.preWarmParcels = preWarmParcels;
+        return this;
+    }
+
+    public ImageTestBuilder withPreWarmCsd(List<String> preWarmCsd) {
+        this.preWarmCsd = preWarmCsd;
+        return this;
+    }
+
+    public ImageTestBuilder withCmBuildNumber(String cmBuildNumber) {
+        this.cmBuildNumber = cmBuildNumber;
+        return this;
+    }
+
+    public ImageTestBuilder withAdvertised(boolean advertised) {
+        this.advertised = advertised;
+        return this;
+    }
+
+    public ImageTestBuilder withBaseParcelUrl(String baseParcelUrl) {
+        this.baseParcelUrl = baseParcelUrl;
+        return this;
+    }
+
+    public ImageTestBuilder withSourceImageId(String sourceImageId) {
+        this.sourceImageId = sourceImageId;
+        return this;
+    }
+
+    public Image build() {
+        return new Image(
+                date,
+                created,
+                published,
+                description,
+                os,
+                uuid,
+                version,
+                repo,
+                imageSetsByProvider,
+                stackDetails,
+                osType,
+                packageVersions,
+                preWarmParcels,
+                preWarmCsd,
+                cmBuildNumber,
+                advertised,
+                baseParcelUrl,
+                sourceImageId
+        );
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityServiceTest.java
@@ -138,11 +138,12 @@ public class ClusterUpgradeAvailabilityServiceTest {
         Image properImage = mock(com.sequenceiq.cloudbreak.cloud.model.catalog.Image.class);
         ImageFilterParams imageFilterParams = createImageFilterParams(stack, currentImageFromCatalog);
         UpgradeV4Response response = new UpgradeV4Response();
+        StatedImage statedImage = StatedImage.statedImage(currentImageFromCatalog, CATALOG_URL, CATALOG_NAME);
 
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(statedImage, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
         when(imageCatalogService.getImage(WORKSPACE_ID, currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), currentImage.getImageId()))
-                .thenReturn(StatedImage.statedImage(currentImageFromCatalog, CATALOG_URL, CATALOG_NAME));
+                .thenReturn(statedImage);
         ImageFilterResult filteredImages = createFilteredImages(properImage);
         when(clusterUpgradeImageFilter.filter(ACCOUNT_ID, WORKSPACE_ID, CATALOG_NAME, imageFilterParams)).thenReturn(filteredImages);
         when(upgradeOptionsResponseFactory.createV4Response(currentImageFromCatalog, filteredImages, stack.getCloudPlatform(), stack.getRegion(),
@@ -165,13 +166,14 @@ public class ClusterUpgradeAvailabilityServiceTest {
         Image properImage = mock(com.sequenceiq.cloudbreak.cloud.model.catalog.Image.class);
         ImageFilterParams imageFilterParams = createImageFilterParams(stack, currentImageFromCatalog);
         UpgradeV4Response response = new UpgradeV4Response();
+        StatedImage statedImage = StatedImage.statedImage(currentImageFromCatalog, CATALOG_URL, CATALOG_NAME);
 
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(statedImage, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
         when(clusterRepairService.repairWithDryRun(stack.getId())).thenReturn(result);
         when(result.isError()).thenReturn(false);
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
         when(imageCatalogService.getImage(WORKSPACE_ID, currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), currentImage.getImageId()))
-                .thenReturn(StatedImage.statedImage(currentImageFromCatalog, CATALOG_URL, CATALOG_NAME));
+                .thenReturn(statedImage);
         ImageFilterResult filteredImages = createFilteredImages(properImage);
         when(clusterUpgradeImageFilter.filter(ACCOUNT_ID, WORKSPACE_ID, CATALOG_NAME, imageFilterParams)).thenReturn(filteredImages);
         when(upgradeOptionsResponseFactory.createV4Response(currentImageFromCatalog, filteredImages, stack.getCloudPlatform(), stack.getRegion(),
@@ -193,13 +195,14 @@ public class ClusterUpgradeAvailabilityServiceTest {
         Image properImage = mock(com.sequenceiq.cloudbreak.cloud.model.catalog.Image.class);
         ImageFilterParams imageFilterParams = createImageFilterParams(stack, currentImageFromCatalog);
         UpgradeV4Response response = new UpgradeV4Response();
+        StatedImage statedImage = StatedImage.statedImage(currentImageFromCatalog, CATALOG_URL, CATALOG_NAME);
 
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(statedImage, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
         when(clusterRepairService.repairWithDryRun(stack.getId())).thenReturn(result);
         when(result.isError()).thenReturn(false);
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
         when(imageCatalogService.getImage(WORKSPACE_ID, currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), currentImage.getImageId()))
-                .thenReturn(StatedImage.statedImage(currentImageFromCatalog, CATALOG_URL, CATALOG_NAME));
+                .thenReturn(statedImage);
         ImageFilterResult filteredImages = createFilteredImages(properImage);
         when(clusterUpgradeImageFilter.filter(ACCOUNT_ID, WORKSPACE_ID, CATALOG_NAME, imageFilterParams)).thenReturn(filteredImages);
         when(upgradeOptionsResponseFactory.createV4Response(currentImageFromCatalog, filteredImages, stack.getCloudPlatform(), stack.getRegion(),
@@ -219,13 +222,14 @@ public class ClusterUpgradeAvailabilityServiceTest {
         Image currentImageFromCatalog = mock(com.sequenceiq.cloudbreak.cloud.model.catalog.Image.class);
         Image properImage = mock(com.sequenceiq.cloudbreak.cloud.model.catalog.Image.class);
         UpgradeV4Response response = new UpgradeV4Response();
+        StatedImage statedImage = StatedImage.statedImage(currentImageFromCatalog, CATALOG_URL, CATALOG_NAME);
 
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
         when(imageCatalogService.getImage(WORKSPACE_ID, currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), currentImage.getImageId()))
-                .thenReturn(StatedImage.statedImage(currentImageFromCatalog, CATALOG_URL, CATALOG_NAME));
+                .thenReturn(statedImage);
         ImageFilterResult filteredImages = createFilteredImages(properImage);
         ImageFilterParams imageFilterParams = createImageFilterParams(stack, currentImageFromCatalog);
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(statedImage, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
         when(clusterUpgradeImageFilter.filter(ACCOUNT_ID, WORKSPACE_ID, CATALOG_NAME, imageFilterParams)).thenReturn(filteredImages);
         when(upgradeOptionsResponseFactory.createV4Response(currentImageFromCatalog, filteredImages, stack.getCloudPlatform(), stack.getRegion(),
                 currentImage.getImageCatalogName())).thenReturn(response);
@@ -263,10 +267,12 @@ public class ClusterUpgradeAvailabilityServiceTest {
         response.setUpgradeCandidates(List.of(imageInfo));
         Stack stack = createStack(createStackStatus(Status.CREATE_FAILED), StackType.WORKLOAD);
         ImageFilterParams imageFilterParams = createImageFilterParams(stack, currentImageFromCatalog);
+        StatedImage statedImage = StatedImage.statedImage(currentImageFromCatalog, CATALOG_URL, CATALOG_NAME);
+
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
         when(imageCatalogService.getImage(WORKSPACE_ID, currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), currentImage.getImageId()))
-                .thenReturn(StatedImage.statedImage(currentImageFromCatalog, CATALOG_URL, CATALOG_NAME));
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
+                .thenReturn(statedImage);
+        when(imageFilterParamsFactory.create(statedImage, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
         ImageFilterResult filteredImages = createFilteredImages(properImage);
         when(clusterUpgradeImageFilter.filter(ACCOUNT_ID, WORKSPACE_ID, CATALOG_NAME, imageFilterParams)).thenReturn(filteredImages);
         when(upgradeOptionsResponseFactory.createV4Response(currentImageFromCatalog, filteredImages, stack.getCloudPlatform(), stack.getRegion(),
@@ -297,15 +303,16 @@ public class ClusterUpgradeAvailabilityServiceTest {
         Stack stack = createStack(createStackStatus(Status.AVAILABLE), StackType.WORKLOAD);
         RepairValidation repairValidation = mock(RepairValidation.class);
         ImageFilterParams imageFilterParams = createImageFilterParams(stack, currentImageFromCatalog);
+        StatedImage statedImage = StatedImage.statedImage(currentImageFromCatalog, CATALOG_URL, CATALOG_NAME);
 
         when(clusterRepairService.repairWithDryRun(stack.getId())).thenReturn(result);
         when(clusterRepairService.repairWithDryRun(stack.getId())).thenReturn(result);
         when(result.isError()).thenReturn(true);
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
         when(imageCatalogService.getImage(WORKSPACE_ID, currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), currentImage.getImageId()))
-                .thenReturn(StatedImage.statedImage(currentImageFromCatalog, CATALOG_URL, CATALOG_NAME));
+                .thenReturn(statedImage);
         ImageFilterResult filteredImages = createFilteredImages(properImage);
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(statedImage, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
         when(clusterUpgradeImageFilter.filter(ACCOUNT_ID, WORKSPACE_ID, CATALOG_NAME, imageFilterParams)).thenReturn(filteredImages);
         when(upgradeOptionsResponseFactory.createV4Response(currentImageFromCatalog, filteredImages, stack.getCloudPlatform(), stack.getRegion(),
                 currentImage.getImageCatalogName())).thenReturn(response);
@@ -507,11 +514,12 @@ public class ClusterUpgradeAvailabilityServiceTest {
         Image imageAvailableForUpgrade = mock(com.sequenceiq.cloudbreak.cloud.model.catalog.Image.class);
         ImageFilterResult filteredImages = createFilteredImages(imageAvailableForUpgrade);
         UpgradeV4Response upgradeResponse = mock(UpgradeV4Response.class);
+        StatedImage statedImage = StatedImage.statedImage(image, null, CATALOG_NAME);
 
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
         when(imageCatalogService.getImage(WORKSPACE_ID, currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), currentImage.getImageId()))
-                .thenReturn(StatedImage.statedImage(image, null, CATALOG_NAME));
-        when(imageFilterParamsFactory.create(image, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
+                .thenReturn(statedImage);
+        when(imageFilterParamsFactory.create(statedImage, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
         when(clusterUpgradeImageFilter.filter(ACCOUNT_ID, WORKSPACE_ID, currentImage.getImageCatalogName(), imageFilterParams)).thenReturn(filteredImages);
         when(upgradeOptionsResponseFactory.createV4Response(image, filteredImages, CLOUD_PLATFORM, REGION, CATALOG_NAME)).thenReturn(upgradeResponse);
         when(upgradeResponse.getReason()).thenReturn("done");
@@ -569,7 +577,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
     }
 
     private ImageFilterParams createImageFilterParams(Stack stack, Image currentImageFromCatalog) {
-        return new ImageFilterParams(currentImageFromCatalog, lockComponents, activatedParcels,
+        return new ImageFilterParams(currentImageFromCatalog, null, lockComponents, activatedParcels,
                 stack.getType(), null, STACK_ID, INTERNAL_UPGRADE_SETTINGS, imageCatalogPlatform(CLOUD_PLATFORM), CLOUD_PLATFORM, REGION, false);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradePermissionProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradePermissionProviderTest.java
@@ -56,7 +56,7 @@ public class UpgradePermissionProviderTest {
         String componentVersion = "7.2.1";
         Image currentImage = createImage(componentVersion, "2000");
         Image candidateImage = createImage(componentVersion, "2001");
-        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
+        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, null, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
                 CLOUD_PLATFORM, REGION, false);
 
@@ -75,7 +75,7 @@ public class UpgradePermissionProviderTest {
         String componentVersion = "7.2.1";
         Image currentImage = createImage(componentVersion, "2002");
         Image candidateImage = createImage(componentVersion, "2001");
-        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
+        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, null, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
                 CLOUD_PLATFORM, REGION, false);
 
@@ -95,7 +95,7 @@ public class UpgradePermissionProviderTest {
         String targetVersion = "7.2.2";
         Image currentImage = createImage(currentVersion, "2002");
         Image candidateImage = createImage(targetVersion, "2001");
-        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
+        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, null, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
                 CLOUD_PLATFORM, REGION, false);
 
@@ -117,7 +117,7 @@ public class UpgradePermissionProviderTest {
         String targetVersion = "7.1.2";
         Image currentImage = createImage(currentVersion, "2002");
         Image candidateImage = createImage(targetVersion, "2001");
-        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
+        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, null, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
                 CLOUD_PLATFORM, REGION, false);
 
@@ -137,7 +137,7 @@ public class UpgradePermissionProviderTest {
         String targetVersion = "7.2.2";
         Image currentImage = createImage(currentVersion, "2002");
         Image candidateImage = createImage(targetVersion, "2001");
-        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
+        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, null, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
                 CLOUD_PLATFORM, REGION, false);
 
@@ -159,7 +159,7 @@ public class UpgradePermissionProviderTest {
         String targetVersion = "7.2.2";
         Image currentImage = createImage(currentVersion, "2002");
         Image candidateImage = createImage(targetVersion, "2001");
-        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), StackType.WORKLOAD, null, STACK_ID,
+        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, null, true, Map.of(), StackType.WORKLOAD, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
                 CLOUD_PLATFORM, REGION, false);
 
@@ -180,7 +180,7 @@ public class UpgradePermissionProviderTest {
         String targetVersion = "7.2.2";
         Image currentImage = createImage(currentVersion, "2002");
         Image candidateImage = createImage(targetVersion, "2001");
-        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
+        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, null, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
                 CLOUD_PLATFORM, REGION, false);
 
@@ -198,7 +198,7 @@ public class UpgradePermissionProviderTest {
     public void testPermitStackUpgradeShouldReturnFalseWhenTheCmBuildNumberIsNotAvailable() {
         Image currentImage = createImage("7.2.1", "2002");
         Image candidateImage = createImage("7.2.1", null);
-        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
+        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, null, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
                 CLOUD_PLATFORM, REGION, false);
 
@@ -218,7 +218,7 @@ public class UpgradePermissionProviderTest {
         String targetVersion = "7.2.10";
         Image currentImage = createImage(currentVersion, "2002");
         Image candidateImage = createImage(targetVersion, "2010");
-        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
+        ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, null, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
                 CLOUD_PLATFORM, REGION, false);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/BlueprintBasedUpgradeValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/BlueprintBasedUpgradeValidatorTest.java
@@ -84,7 +84,7 @@ class BlueprintBasedUpgradeValidatorTest {
     private ImageFilterParams createImageFilterParams(String blueprintName, StackType stackType) {
         Blueprint blueprint = new Blueprint();
         blueprint.setName(blueprintName);
-        return new ImageFilterParams(null, true, null, stackType, blueprint, null, new InternalUpgradeSettings(true, true, true), null, null, null, false);
+        return new ImageFilterParams(null, "", true, null, stackType, blueprint, null, new InternalUpgradeSettings(true, true, true), null, null, null, false);
     }
 
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilterTest.java
@@ -122,7 +122,7 @@ public class ClusterUpgradeImageFilterTest {
     }
 
     private ImageFilterParams createImageFilterParams() {
-        return new ImageFilterParams(image, false, Collections.emptyMap(), StackType.DATALAKE, new Blueprint(), STACK_ID,
+        return new ImageFilterParams(image, null, false, Collections.emptyMap(), StackType.DATALAKE, new Blueprint(), STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
                 CLOUD_PLATFORM, REGION, false);
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/CsdLocationFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/CsdLocationFilterTest.java
@@ -30,7 +30,7 @@ public class CsdLocationFilterTest {
 
     @Test
     public void testFilterImageShouldReturnTrueWhenTheStackTypeIsNotWorkload() {
-        assertTrue(underTest.filterImage(null, null, new ImageFilterParams(null, false, null, StackType.DATALAKE, null, STACK_ID,
+        assertTrue(underTest.filterImage(null, null, new ImageFilterParams(null, null, false, null, StackType.DATALAKE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM), CLOUD_PLATFORM, REGION, false)));
     }
 
@@ -112,7 +112,7 @@ public class CsdLocationFilterTest {
     }
 
     private ImageFilterParams createImageFilterParams(Map<String, String> stackRelatedParcels) {
-        return new ImageFilterParams(null, false, stackRelatedParcels, StackType.WORKLOAD, null, STACK_ID,
+        return new ImageFilterParams(null, null, false, stackRelatedParcels, StackType.WORKLOAD, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM), CLOUD_PLATFORM, REGION, false);
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/PreWarmParcelLocationFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/PreWarmParcelLocationFilterTest.java
@@ -31,7 +31,7 @@ public class PreWarmParcelLocationFilterTest {
 
     @Test
     public void testFilterImageShouldReturnTrueWhenTheStackTypeIsNotWorkload() {
-        assertTrue(underTest.filterImage(null, null, new ImageFilterParams(null, false, null, StackType.DATALAKE, null, STACK_ID,
+        assertTrue(underTest.filterImage(null, null, new ImageFilterParams(null, null, false, null, StackType.DATALAKE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM), CLOUD_PLATFORM, REGION, false)));
     }
 
@@ -141,7 +141,7 @@ public class PreWarmParcelLocationFilterTest {
     }
 
     private ImageFilterParams createImageFilterParams(Map<String, String> stackRelatedParcels) {
-        return new ImageFilterParams(null, false, stackRelatedParcels, StackType.WORKLOAD, null, STACK_ID, new InternalUpgradeSettings(false, true,
+        return new ImageFilterParams(null, null, false, stackRelatedParcels, StackType.WORKLOAD, null, STACK_ID, new InternalUpgradeSettings(false, true,
                 true), imageCatalogPlatform(CLOUD_PLATFORM), CLOUD_PLATFORM, REGION, false);
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/CloudPlatformBasedUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/CloudPlatformBasedUpgradeImageFilterTest.java
@@ -61,7 +61,7 @@ class CloudPlatformBasedUpgradeImageFilterTest {
     }
 
     private ImageFilterParams createImageFilterParams() {
-        return new ImageFilterParams(null, false, null, null, null, null, null, imageCatalogPlatform(AWS.name()), null, null, false);
+        return new ImageFilterParams(null, null, false, null, null, null, null, null, imageCatalogPlatform(AWS.name()), null, null, false);
     }
 
     private Image createImage(String imageId, String cloudPlatform) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/CmAndStackVersionUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/CmAndStackVersionUpgradeImageFilterTest.java
@@ -113,8 +113,8 @@ class CmAndStackVersionUpgradeImageFilterTest {
     }
 
     private ImageFilterParams createImageFilterParams(boolean lockComponents) {
-        return new ImageFilterParams(currentImage, lockComponents, activatedParcels, StackType.DATALAKE, null, 1L, new InternalUpgradeSettings(false, true,
-                true), imageCatalogPlatform("AWS"), null, null, false);
+        return new ImageFilterParams(currentImage, null, lockComponents, activatedParcels, StackType.DATALAKE, null, 1L,
+                new InternalUpgradeSettings(false, true, true), imageCatalogPlatform("AWS"), null, null, false);
     }
 
     private void assertLockedCommon(ImageFilterResult actual) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/CurrentImageUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/CurrentImageUpgradeImageFilterTest.java
@@ -38,7 +38,7 @@ class CurrentImageUpgradeImageFilterTest {
     @Test
     public void testFilterShouldReturnAllImage() {
         List<Image> images = List.of(createImage("image1"), createImage(CURRENT_IMAGE_ID));
-        when(currentImageUsageCondition.currentImageUsedOnInstances(CURRENT_STACK_ID, CURRENT_IMAGE_ID)).thenReturn(true);
+        when(currentImageUsageCondition.currentImageUsedOnInstances(CURRENT_STACK_ID, CURRENT_IMAGE_ID)).thenReturn(false);
 
         ImageFilterResult actual = underTest.filter(createImageFilterResult(images), imageFilterParams);
 
@@ -51,7 +51,7 @@ class CurrentImageUpgradeImageFilterTest {
     public void testFilterShouldReturnImagesWithoutCurrentImageWhenTheCurrentImageFilteringIsNotAllowed() {
         Image image1 = createImage("image1");
         Image currentImage = createImage(CURRENT_IMAGE_ID);
-        when(currentImageUsageCondition.currentImageUsedOnInstances(CURRENT_STACK_ID, CURRENT_IMAGE_ID)).thenReturn(false);
+        when(currentImageUsageCondition.currentImageUsedOnInstances(CURRENT_STACK_ID, CURRENT_IMAGE_ID)).thenReturn(true);
 
         ImageFilterResult actual = underTest.filter(createImageFilterResult(List.of(image1, currentImage)), imageFilterParams);
 
@@ -73,7 +73,7 @@ class CurrentImageUpgradeImageFilterTest {
     }
 
     private ImageFilterParams createImageFilterParams() {
-        return new ImageFilterParams(createImage(CURRENT_IMAGE_ID), false, null, null, null, CURRENT_STACK_ID, null, null, null, null, false);
+        return new ImageFilterParams(createImage(CURRENT_IMAGE_ID), null, false, null, null, null, CURRENT_STACK_ID, null, null, null, null, false);
     }
 
     private Image createImage(String imageId) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/ImageCreationBasedUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/ImageCreationBasedUpgradeImageFilterTest.java
@@ -192,6 +192,6 @@ class ImageCreationBasedUpgradeImageFilterTest {
     }
 
     private ImageFilterParams createImageFilterParams(Image currentImage) {
-        return new ImageFilterParams(currentImage, false, null, null, null, null, null, null, null, null, false);
+        return new ImageFilterParams(currentImage, null, false, null, null, null, null, null, null, null, null, false);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/ImageNameUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/ImageNameUpgradeImageFilterTest.java
@@ -88,6 +88,6 @@ class ImageNameUpgradeImageFilterTest {
     }
 
     private ImageFilterParams createImageFilterParams(String platform, String region) {
-        return new ImageFilterParams(null, false, null, null, null, null, null, imageCatalogPlatform(platform), platform, region, false);
+        return new ImageFilterParams(null, null, false, null, null, null, null, null, imageCatalogPlatform(platform), platform, region, false);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/OsVersionBasedUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/OsVersionBasedUpgradeImageFilterTest.java
@@ -77,7 +77,8 @@ class OsVersionBasedUpgradeImageFilterTest {
     }
 
     private ImageFilterParams createImageFilterParams() {
-        return new ImageFilterParams(createImage("current-image", CURRENT_OS, CURRENT_OS_TYPE), false, null, null, null, null, null, null, null, null, false);
+        return new ImageFilterParams(
+                createImage("current-image", CURRENT_OS, CURRENT_OS_TYPE), null, false, null, null, null, null, null, null, null, null, false);
     }
 
     private Image createImage(String imageId, String os, String osType) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/RuntimeDependencyBasedUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/RuntimeDependencyBasedUpgradeImageFilterTest.java
@@ -1,0 +1,103 @@
+package com.sequenceiq.cloudbreak.service.upgrade.image.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
+import com.sequenceiq.cloudbreak.service.image.ImageTestBuilder;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
+import com.sequenceiq.cloudbreak.service.upgrade.image.ImageFilterParams;
+import com.sequenceiq.cloudbreak.service.upgrade.image.ImageFilterResult;
+import com.sequenceiq.cloudbreak.service.upgrade.validation.PythonVersionBasedRuntimeVersionValidator;
+import com.sequenceiq.cloudbreak.service.upgrade.validation.service.PythonVersionValidator;
+import com.sequenceiq.common.model.ImageCatalogPlatform;
+
+@ExtendWith(MockitoExtension.class)
+class RuntimeDependencyBasedUpgradeImageFilterTest {
+
+    private static final long STACK_ID = 1L;
+
+    private static final List<Image> IMAGES = Collections.emptyList();
+
+    private static final long WORKSPACE_ID = 2L;
+
+    private static final String IMAGE_CATALOG_NAME = "image-catalog-name";
+
+    @InjectMocks
+    private RuntimeDependencyBasedUpgradeImageFilter underTest;
+
+    @Mock
+    private PythonVersionBasedRuntimeVersionValidator pythonVersionBasedRuntimeVersionValidator;
+
+    @Mock
+    private StackDtoService stackDtoService;
+
+    @Mock
+    private ImageCatalogService imageCatalogService;
+
+    @Mock
+    private StackDto stack;
+
+    @Test
+    void testFilterShouldReturnTheImagesWithTheCorrectPythonVersion() throws CloudbreakImageCatalogException {
+        Image image1 = ImageTestBuilder.builder().withUuid("image1").build();
+        Image image2 = ImageTestBuilder.builder().withUuid("image2").build();
+        ImageFilterParams imageFilterParams = createImageFilterParams();
+
+        when(stackDtoService.getById(STACK_ID)).thenReturn(stack);
+        when(stack.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+        when(imageCatalogService.getAllCdhImages(any(), eq(WORKSPACE_ID), eq(IMAGE_CATALOG_NAME), any())).thenReturn(IMAGES);
+        when(pythonVersionBasedRuntimeVersionValidator.isUpgradePermittedForRuntime(stack, IMAGES, imageFilterParams.getCurrentImage(), image1))
+                .thenReturn(true);
+        when(pythonVersionBasedRuntimeVersionValidator.isUpgradePermittedForRuntime(stack, IMAGES, imageFilterParams.getCurrentImage(), image2))
+                .thenReturn(false);
+
+        ImageFilterResult actual = underTest.filter(new ImageFilterResult(List.of(image1, image2)), imageFilterParams);
+
+        assertTrue(actual.getImages().contains(image1));
+        assertFalse(actual.getImages().contains(image2));
+        assertTrue(actual.getReason().isEmpty());
+    }
+
+    @Test
+    void testFilterShouldReturnErrorMessageWhenThereAreNoCorrectImageLeft() throws CloudbreakImageCatalogException {
+        Image image1 = ImageTestBuilder.builder().withUuid("image1").build();
+        Image image2 = ImageTestBuilder.builder().withUuid("image2").build();
+        ImageFilterParams imageFilterParams = createImageFilterParams();
+
+        when(stackDtoService.getById(STACK_ID)).thenReturn(stack);
+        when(stack.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+        when(imageCatalogService.getAllCdhImages(any(), eq(WORKSPACE_ID), eq(IMAGE_CATALOG_NAME), any())).thenReturn(IMAGES);
+        when(pythonVersionBasedRuntimeVersionValidator.isUpgradePermittedForRuntime(stack, IMAGES, imageFilterParams.getCurrentImage(), image1))
+                .thenReturn(false);
+        when(pythonVersionBasedRuntimeVersionValidator.isUpgradePermittedForRuntime(stack, IMAGES, imageFilterParams.getCurrentImage(), image2))
+                .thenReturn(false);
+
+        ImageFilterResult actual = underTest.filter(new ImageFilterResult(List.of(image1, image2)), imageFilterParams);
+
+        assertTrue(actual.getImages().isEmpty());
+        assertEquals(PythonVersionValidator.ERROR_MESSAGE, actual.getReason());
+    }
+
+    private ImageFilterParams createImageFilterParams() {
+        return new ImageFilterParams(ImageTestBuilder.builder().withUuid("current").build(), IMAGE_CATALOG_NAME, false, null, null, null, STACK_ID, null,
+                new ImageCatalogPlatform(CloudPlatform.AWS.name()), null, null, false);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/UpgradeImageFilterConfigTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/UpgradeImageFilterConfigTest.java
@@ -19,9 +19,12 @@ import org.springframework.test.context.junit4.SpringRunner;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.conf.UpgradeImageFilterConfig;
 import com.sequenceiq.cloudbreak.service.image.CurrentImageUsageCondition;
+import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.service.upgrade.UpgradePermissionProvider;
 import com.sequenceiq.cloudbreak.service.upgrade.image.locked.LockedComponentChecker;
+import com.sequenceiq.cloudbreak.service.upgrade.validation.PythonVersionBasedRuntimeVersionValidator;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { UpgradeImageFilterConfigTest.TestAppContext.class, UpgradeImageFilterConfig.class })
@@ -60,6 +63,15 @@ public class UpgradeImageFilterConfigTest {
 
         @MockBean
         private ImageService imageService;
+
+        @MockBean
+        private PythonVersionBasedRuntimeVersionValidator pythonVersionBasedRuntimeVersionValidator;
+
+        @MockBean
+        private StackDtoService stackDtoService;
+
+        @MockBean
+        private ImageCatalogService imageCatalogService;
 
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/PythonVersionBasedRuntimeVersionValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/PythonVersionBasedRuntimeVersionValidatorTest.java
@@ -1,0 +1,100 @@
+package com.sequenceiq.cloudbreak.service.upgrade.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.ImagePackageVersion;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.ImageStackDetails;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.service.image.CurrentImagePackageProvider;
+import com.sequenceiq.cloudbreak.service.image.ImageTestBuilder;
+import com.sequenceiq.cloudbreak.service.upgrade.image.locked.LockedComponentService;
+
+@ExtendWith(MockitoExtension.class)
+class PythonVersionBasedRuntimeVersionValidatorTest {
+
+    private static final long STACK_ID = 1L;
+
+    private static final List<Image> CDH_IMAGES_FROM_CATALOG = Collections.emptyList();
+
+    @InjectMocks
+    private PythonVersionBasedRuntimeVersionValidator underTest;
+
+    @Mock
+    private LockedComponentService lockedComponentService;
+
+    @Mock
+    private StackDto stack;
+
+    @Mock
+    private CurrentImagePackageProvider currentImagePackageProvider;
+
+    @ParameterizedTest(name = "Current runtime: {0} contains Python 3.8: {1} current image used on instances: {2}, "
+            + "Target runtime: {3} contains Python 3.8: {4}, Os upgrade: {5}, Permitting upgrade: {6}")
+    @MethodSource("testScenariosProvider")
+    public void test(String currentRuntimeVersion, boolean currentImageContainsPython, boolean allInstanceContainsPython,
+            String targetRuntimeVersion, boolean targetImageContainsPython, boolean osUpgrade, boolean expectedValue) {
+        Image currentImage = createImage(currentRuntimeVersion, currentImageContainsPython);
+        Image targetImage = createImage(targetRuntimeVersion, targetImageContainsPython);
+        lenient().when(lockedComponentService.isComponentsLocked(stack, currentImage, targetImage)).thenReturn(osUpgrade);
+        lenient().when(stack.getId()).thenReturn(STACK_ID);
+        when(stack.getType()).thenReturn(StackType.WORKLOAD);
+        lenient().when(currentImagePackageProvider.currentInstancesContainsPackage(STACK_ID, CDH_IMAGES_FROM_CATALOG, ImagePackageVersion.PYTHON38))
+                .thenReturn(allInstanceContainsPython);
+
+        assertEquals(expectedValue, underTest.isUpgradePermittedForRuntime(stack, CDH_IMAGES_FROM_CATALOG, currentImage, targetImage));
+    }
+
+    private static Object[][] testScenariosProvider() {
+        return new Object[][] {
+                { "7.2.12", true, true, "7.2.12", true, false, true },
+                { "7.2.12", true, true, "7.2.12", true, true, true },
+                { "7.2.12", false, true, "7.2.12", true, true, true },
+                { "7.2.12", false, true, "7.2.12", false, true, true },
+                { "7.2.12", true, false, "7.2.12", true, true, true },
+
+                { "7.2.12", true, true, "7.2.15", true, false, true },
+                { "7.2.12", false, true, "7.2.15", true, false, true },
+                { "7.2.12", true, false, "7.2.15", true, false, true },
+                { "7.2.12", true, true, "7.2.15", false, false, true },
+                { "7.2.12", true, true, "7.2.15", false, false, true },
+                { "7.2.12", false, true, "7.2.15", false, false, true },
+                { "7.2.12", false, false, "7.2.15", false, false, true },
+
+                { "7.2.15", true, true, "7.2.16", true, false, true },
+                { "7.2.15", false, true, "7.2.16", true, false, false },
+                { "7.2.15", true, false, "7.2.16", true, false, false },
+
+                { "7.2.16", true, true, "7.2.16", true, true, true },
+                { "7.2.16", true, true, "7.2.16", true, false, true },
+                { "7.2.16", false, true, "7.2.16", true, false, false },
+                { "7.2.16", true, false, "7.2.16", true, false, false },
+                { "7.2.16", true, false, "7.2.16", true, true, true },
+                { "7.2.16", false, true, "7.2.16", true, true, true },
+
+                { "7.2.16", true, true, "7.2.17", true, false, true },
+                { "7.2.16", false, true, "7.2.17", true, false, false },
+        };
+    }
+
+    private Image createImage(String runtimeVersion, boolean containsPython38) {
+        return ImageTestBuilder.builder()
+                .withStackDetails(new ImageStackDetails(runtimeVersion, null, null))
+                .withPackageVersions(containsPython38 ? Map.of(ImagePackageVersion.PYTHON38.getKey(), "3.8") : Collections.emptyMap())
+                .build();
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/ActiveCommandsValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/ActiveCommandsValidatorTest.java
@@ -20,7 +20,7 @@ import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterStatusService;
 import com.sequenceiq.cloudbreak.cluster.model.ClusterManagerCommand;
 import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 
 @ExtendWith(MockitoExtension.class)
@@ -49,7 +49,7 @@ public class ActiveCommandsValidatorTest {
     private ClusterStatusService clusterStatusService;
 
     @Mock
-    private Stack stack;
+    private StackDto stack;
 
     @Test
     public void testValidateIfActiveCommandsListIsEmpty() {
@@ -57,7 +57,7 @@ public class ActiveCommandsValidatorTest {
         when(clusterApiConnectors.getConnector(stack)).thenReturn(connector);
         when(connector.clusterStatusService()).thenReturn(clusterStatusService);
         // WHEN
-        underTest.validate(new ServiceUpgradeValidationRequest(stack, true, ""));
+        underTest.validate(new ServiceUpgradeValidationRequest(stack, true, "", null));
         // THEN no exception is thrown
     }
 
@@ -68,7 +68,7 @@ public class ActiveCommandsValidatorTest {
         when(connector.clusterStatusService()).thenReturn(clusterStatusService);
         when(clusterStatusService.getActiveCommandsList()).thenReturn(null);
         // WHEN
-        underTest.validate(new ServiceUpgradeValidationRequest(stack, true, ""));
+        underTest.validate(new ServiceUpgradeValidationRequest(stack, true, "", null));
         // THEN no exception is thrown
     }
 
@@ -80,7 +80,7 @@ public class ActiveCommandsValidatorTest {
         initGlobalPrivateFields();
         when(clusterStatusService.getActiveCommandsList()).thenReturn(List.of(createCommand(INTERRUPTABLE_COMMAND_1), createCommand(INTERRUPTABLE_COMMAND_2)));
         // WHEN
-        underTest.validate(new ServiceUpgradeValidationRequest(stack, true, ""));
+        underTest.validate(new ServiceUpgradeValidationRequest(stack, true, "", null));
         // THEN no exception is thrown
     }
 
@@ -94,7 +94,7 @@ public class ActiveCommandsValidatorTest {
                 List.of(createCommand(NON_INTERRUPTABLE_COMMAND_1), createCommand(NON_INTERRUPTABLE_COMMAND_2)));
         // WHEN
         UpgradeValidationFailedException ex = Assertions.assertThrows(UpgradeValidationFailedException.class,
-                () -> underTest.validate(new ServiceUpgradeValidationRequest(stack, true, "")));
+                () -> underTest.validate(new ServiceUpgradeValidationRequest(stack, true, "", null)));
         // THEN exception is thrown
         assertEquals("There are active commands running on CM that are not interruptable, upgrade is not possible. " +
                 "Active commands: [ClusterManagerCommand{id=1, name='non-interruptable-1', startTime='start-time', endTime='null', active=null, " +
@@ -112,7 +112,7 @@ public class ActiveCommandsValidatorTest {
                 List.of(createCommand(INTERRUPTABLE_COMMAND_1), createCommand(NON_INTERRUPTABLE_COMMAND_1)));
         // WHEN
         UpgradeValidationFailedException ex = Assertions.assertThrows(UpgradeValidationFailedException.class,
-                () -> underTest.validate(new ServiceUpgradeValidationRequest(stack, true, "")));
+                () -> underTest.validate(new ServiceUpgradeValidationRequest(stack, true, "", null)));
         // THEN exception is thrown
         assertEquals("There are active commands running on CM that are not interruptable, upgrade is not possible. " +
                 "Active commands: [ClusterManagerCommand{id=1, name='non-interruptable-1', startTime='start-time', endTime='null', active=null, " +

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/FlinkUpgradeValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/FlinkUpgradeValidatorTest.java
@@ -1,9 +1,13 @@
 package com.sequenceiq.cloudbreak.service.upgrade.validation.service;
 
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_14;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_16;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,13 +17,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
-import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateService;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,7 +35,8 @@ public class FlinkUpgradeValidatorTest {
     @InjectMocks
     private FlinkUpgradeValidator underTest;
 
-    private Stack stack;
+    @Mock
+    private StackDto stack;
 
     @Mock
     private CmTemplateService cmTemplateService;
@@ -47,19 +51,16 @@ public class FlinkUpgradeValidatorTest {
     public void before() {
         Blueprint blueprint = new Blueprint();
         blueprint.setBlueprintText(BLUEPRINT_TEXT);
-
         Cluster cluster = new Cluster();
         cluster.setName(CLUSTER_NAME);
-        cluster.setBlueprint(blueprint);
-
-        stack = new Stack();
-        stack.setCluster(cluster);
+        lenient().when(stack.getBlueprint()).thenReturn(blueprint);
+        lenient().when(stack.getCluster()).thenReturn(cluster);
     }
 
     @Test
     void validateNoRuntimeVersion() {
         ServiceUpgradeValidationRequest request =
-                new ServiceUpgradeValidationRequest(stack, false, null);
+                new ServiceUpgradeValidationRequest(stack, false, null, null);
         underTest.validate(request);
         verifyNoInteractions(cmTemplateService);
         verifyNoInteractions(clusterApiConnectors);
@@ -68,7 +69,7 @@ public class FlinkUpgradeValidatorTest {
     @Test
     void validateNotAffectedRuntime() {
         ServiceUpgradeValidationRequest request =
-                new ServiceUpgradeValidationRequest(stack, false, CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_14.getVersion());
+                new ServiceUpgradeValidationRequest(stack, false, CLOUDERA_STACK_VERSION_7_2_14.getVersion(), null);
         underTest.validate(request);
         verifyNoInteractions(cmTemplateService);
         verifyNoInteractions(clusterApiConnectors);
@@ -78,7 +79,7 @@ public class FlinkUpgradeValidatorTest {
     void validateNoFlinkSevice() {
         when(cmTemplateService.isServiceTypePresent("SQL_STREAM_BUILDER", BLUEPRINT_TEXT)).thenReturn(false);
         ServiceUpgradeValidationRequest request =
-                new ServiceUpgradeValidationRequest(stack, false, CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_16.getVersion());
+                new ServiceUpgradeValidationRequest(stack, false, CLOUDERA_STACK_VERSION_7_2_16.getVersion(), null);
         underTest.validate(request);
 
         verifyNoInteractions(clusterApiConnectors);
@@ -90,7 +91,7 @@ public class FlinkUpgradeValidatorTest {
         when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
         when(clusterApi.isRolePresent(CLUSTER_NAME, "STREAMING_SQL_CONSOLE", "SQL_STREAM_BUILDER")).thenReturn(false);
         ServiceUpgradeValidationRequest request =
-                new ServiceUpgradeValidationRequest(stack, false, CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_16.getVersion());
+                new ServiceUpgradeValidationRequest(stack, false, CLOUDERA_STACK_VERSION_7_2_16.getVersion(), null);
         underTest.validate(request);
     }
 
@@ -102,7 +103,7 @@ public class FlinkUpgradeValidatorTest {
                 .thenThrow(new CloudbreakServiceException("Api exception"));
 
         ServiceUpgradeValidationRequest request =
-                new ServiceUpgradeValidationRequest(stack, false, CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_16.getVersion());
+                new ServiceUpgradeValidationRequest(stack, false, CLOUDERA_STACK_VERSION_7_2_16.getVersion(), null);
 
         CloudbreakServiceException exception = assertThrows(CloudbreakServiceException.class, () -> underTest.validate(request));
 
@@ -116,7 +117,7 @@ public class FlinkUpgradeValidatorTest {
         when(clusterApi.isRolePresent(CLUSTER_NAME, "STREAMING_SQL_CONSOLE", "SQL_STREAM_BUILDER")).thenReturn(true);
 
         ServiceUpgradeValidationRequest request =
-                new ServiceUpgradeValidationRequest(stack, false, CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_16.getVersion());
+                new ServiceUpgradeValidationRequest(stack, false, CLOUDERA_STACK_VERSION_7_2_16.getVersion(), null);
 
         UpgradeValidationFailedException exception = assertThrows(UpgradeValidationFailedException.class, () -> underTest.validate(request));
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/PythonVersionValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/PythonVersionValidatorTest.java
@@ -1,0 +1,95 @@
+package com.sequenceiq.cloudbreak.service.upgrade.validation.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
+import com.sequenceiq.cloudbreak.common.service.PlatformStringTransformer;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
+import com.sequenceiq.cloudbreak.service.image.ImageTestBuilder;
+import com.sequenceiq.cloudbreak.service.image.StatedImage;
+import com.sequenceiq.cloudbreak.service.upgrade.UpgradeImageInfo;
+import com.sequenceiq.cloudbreak.service.upgrade.validation.PythonVersionBasedRuntimeVersionValidator;
+import com.sequenceiq.common.model.ImageCatalogPlatform;
+
+@ExtendWith(MockitoExtension.class)
+class PythonVersionValidatorTest {
+
+    private static final List<Image> CDH_IMAGES = Collections.emptyList();
+
+    private static final String CLOUD_PLATFORM = "cloud-platform";
+
+    private static final String PLATFORM_VARIANT = "platform-variant";
+
+    private static final long WORKSPACE_ID = 2L;
+
+    private static final String IMAGE_CATALOG_NAME = "image-catalog-name";
+
+    @InjectMocks
+    private PythonVersionValidator underTest;
+
+    @Mock
+    private PythonVersionBasedRuntimeVersionValidator pythonVersionBasedRuntimeVersionValidator;
+
+    @Mock
+    private ImageCatalogService imageCatalogService;
+
+    @Mock
+    private PlatformStringTransformer platformStringTransformer;
+
+    @Mock
+    private StackDto stack;
+
+    @Mock
+    private Set<ImageCatalogPlatform> imageCatalogPlatformSet;
+
+    @BeforeEach
+    void before() throws CloudbreakImageCatalogException {
+        when(stack.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+        when(stack.getCloudPlatform()).thenReturn(CLOUD_PLATFORM);
+        when(stack.getPlatformVariant()).thenReturn(PLATFORM_VARIANT);
+        when(platformStringTransformer.getPlatformStringForImageCatalogSet(CLOUD_PLATFORM, PLATFORM_VARIANT)).thenReturn(imageCatalogPlatformSet);
+        when(imageCatalogService.getAllCdhImages(any(), eq(WORKSPACE_ID), eq(IMAGE_CATALOG_NAME), eq(imageCatalogPlatformSet))).thenReturn(CDH_IMAGES);
+    }
+
+    @Test
+    void testValidateShouldThrowValidationExceptionWhenTheUpgradeIsNotPermittedForTheTargetImage() {
+        Image currentImage = ImageTestBuilder.builder().withUuid("currentImage").build();
+        Image targetImage = ImageTestBuilder.builder().withUuid("targetImage").build();
+
+        when(pythonVersionBasedRuntimeVersionValidator.isUpgradePermittedForRuntime(stack, CDH_IMAGES, currentImage, targetImage)).thenReturn(false);
+
+        assertThrows(UpgradeValidationFailedException.class, () -> underTest.validate(createValidationRequest(currentImage, targetImage)));
+    }
+
+    @Test
+    void testValidateShouldNotThrowValidationExceptionWhenTheUpgradeIsPermittedForTheTargetImage() {
+        Image currentImage = ImageTestBuilder.builder().withUuid("currentImage").build();
+        Image targetImage = ImageTestBuilder.builder().withUuid("targetImage").build();
+
+        when(pythonVersionBasedRuntimeVersionValidator.isUpgradePermittedForRuntime(stack, CDH_IMAGES, currentImage, targetImage)).thenReturn(true);
+
+        underTest.validate(createValidationRequest(currentImage, targetImage));
+    }
+
+    private ServiceUpgradeValidationRequest createValidationRequest(Image currentImage, Image targetImage) {
+        return new ServiceUpgradeValidationRequest(stack, false, null,
+                new UpgradeImageInfo(null, StatedImage.statedImage(currentImage, null, IMAGE_CATALOG_NAME), StatedImage.statedImage(targetImage, null, null)));
+    }
+}

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeAvailabilityServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeAvailabilityServiceTest.java
@@ -65,6 +65,8 @@ public class DistroXUpgradeAvailabilityServiceTest {
 
     private static final String DATALAKE_CRN = "crn:cdp:datalake:us-west-1:default:datalake:d3b8df82-878d-4395-94b1-2e355217446d";
 
+    private static final long STACK_ID = 2L;
+
     @Mock
     private EntitlementService entitlementService;
 
@@ -104,6 +106,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         cluster.setBlueprint(blueprint);
         stack.setCluster(cluster);
         stack.setEnvironmentCrn("envcrn");
+        stack.setId(STACK_ID);
     }
 
     @Test
@@ -145,7 +148,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         stack.setDatalakeCrn(DATALAKE_CRN);
         UpgradeV4Request request = new UpgradeV4Request();
         UpgradeV4Response response = new UpgradeV4Response();
-        ImageInfoV4Response currentImage = createImageResponse(2L, "7.2.0");
+        ImageInfoV4Response currentImage = createImageResponse(STACK_ID, "7.2.0");
         ImageInfoV4Response candidateImage1 = createImageResponse(3L, "7.2.1");
         ImageInfoV4Response candidateImage2 = createImageResponse(4L, "7.2.2");
 
@@ -171,7 +174,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         stack.setCluster(TestUtil.cluster());
         UpgradeV4Request request = new UpgradeV4Request();
         UpgradeV4Response response = new UpgradeV4Response();
-        ImageInfoV4Response currentImage = createImageResponse(2L, "7.2.0");
+        ImageInfoV4Response currentImage = createImageResponse(STACK_ID, "7.2.0");
         ImageInfoV4Response candidateImage1 = createImageResponse(3L, "7.2.1");
         ImageInfoV4Response candidateImage2 = createImageResponse(4L, "7.2.2");
 
@@ -191,7 +194,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
     public void testWhenRangerRazDisabledAndEntitlementGrantedThenUpgradeAllowed() {
         UpgradeV4Request request = new UpgradeV4Request();
         UpgradeV4Response response = new UpgradeV4Response();
-        ImageInfoV4Response currentImage = createImageResponse(2L, "7.2.0");
+        ImageInfoV4Response currentImage = createImageResponse(STACK_ID, "7.2.0");
         ImageInfoV4Response candidateImage1 = createImageResponse(3L, "7.2.1");
         ImageInfoV4Response candidateImage2 = createImageResponse(4L, "7.2.2");
 
@@ -221,6 +224,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         response.setCurrent(new ImageInfoV4Response());
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
         when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
+        when(currentImageUsageCondition.currentImageUsedOnInstances(any(), any())).thenReturn(true);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
@@ -233,7 +237,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         UpgradeV4Request request = new UpgradeV4Request();
         request.setShowAvailableImages(UpgradeShowAvailableImages.LATEST_ONLY);
         UpgradeV4Response response = new UpgradeV4Response();
-        ImageInfoV4Response image1 = createImageResponse(2L, "A");
+        ImageInfoV4Response image1 = createImageResponse(STACK_ID, "A");
         ImageInfoV4Response image2 = createImageResponse(8L, "A");
         ImageInfoV4Response image3 = createImageResponse(6L, "A");
         ImageInfoV4Response image4 = createImageResponse(1L, "B");
@@ -246,6 +250,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         response.setCurrent(new ImageInfoV4Response());
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
         when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
+        when(currentImageUsageCondition.currentImageUsedOnInstances(any(), any())).thenReturn(true);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
@@ -260,7 +265,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         UpgradeV4Request request = new UpgradeV4Request();
         request.setShowAvailableImages(UpgradeShowAvailableImages.LATEST_ONLY);
         UpgradeV4Response response = new UpgradeV4Response();
-        ImageInfoV4Response image1 = createImageResponse(2L, "A");
+        ImageInfoV4Response image1 = createImageResponse(STACK_ID, "A");
         ImageInfoV4Response image2 = createImageResponse(8L, "A");
         ImageInfoV4Response image3 = createImageResponse(6L, "A");
         ImageInfoV4Response image4 = createImageResponse(1L, "B");
@@ -270,7 +275,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         ImageInfoV4Response image8 = createImageResponse(8L, "C");
         ImageInfoV4Response image9 = createImageResponse(6L, "C");
         response.setUpgradeCandidates(List.of(image1, image2, image3, image4, image5, image6, image7, image8, image9));
-        response.setCurrent(new ImageInfoV4Response());
+        response.setCurrent(createImageResponse(6L, "C"));
         StackView stackView = new StackView();
         ClusterView clusterView = new ClusterView();
         clusterView.setId(1L);
@@ -280,6 +285,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         when(stackViewService.findDatalakeViewByEnvironmentCrn(stack.getEnvironmentCrn())).thenReturn(Optional.of(stackView));
         when(runtimeVersionService.getRuntimeVersion(eq(clusterView.getId()))).thenReturn(Optional.of("C"));
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
+        when(currentImageUsageCondition.currentImageUsedOnInstances(any(), any())).thenReturn(true);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
@@ -297,6 +303,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         response.setCurrent(new ImageInfoV4Response());
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
         when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
+        when(currentImageUsageCondition.currentImageUsedOnInstances(any(), any())).thenReturn(true);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
@@ -311,11 +318,11 @@ public class DistroXUpgradeAvailabilityServiceTest {
     public void testCheckForUpgradeWhenDataLakeAndDataHubIsOnTheSameVersionAndNoUpgradeIsAvailable() {
         UpgradeV4Request request = new UpgradeV4Request();
         UpgradeV4Response response = new UpgradeV4Response();
-        ImageInfoV4Response image1 = createImageResponse(2L, "7.2.0");
+        ImageInfoV4Response image1 = createImageResponse(STACK_ID, "7.2.0");
         ImageInfoV4Response image2 = createImageResponse(8L, "7.3.0");
         ImageInfoV4Response image3 = createImageResponse(6L, "7.4.0");
         response.setUpgradeCandidates(List.of(image1, image2, image3));
-        response.setCurrent(new ImageInfoV4Response());
+        response.setCurrent(createImageResponse(6L, "7.1.0"));
         StackView stackView = new StackView();
         ClusterView clusterView = new ClusterView();
         clusterView.setId(1L);
@@ -326,6 +333,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         when(runtimeVersionService.getRuntimeVersion(eq(clusterView.getId()))).thenReturn(Optional.of("7.1.0"));
         when(entitlementService.isDifferentDataHubAndDataLakeVersionAllowed(anyString())).thenReturn(false);
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
+        when(currentImageUsageCondition.currentImageUsedOnInstances(any(), any())).thenReturn(true);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
@@ -342,7 +350,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
     public void testCheckForUpgradeWhenDataLakeAndDataHubIsOnTheSameVersionAndUpgradeIsAvailable() {
         UpgradeV4Request request = new UpgradeV4Request();
         UpgradeV4Response response = new UpgradeV4Response();
-        ImageInfoV4Response image1 = createImageResponse(2L, "7.2.0");
+        ImageInfoV4Response image1 = createImageResponse(STACK_ID, "7.2.0");
         ImageInfoV4Response image2 = createImageResponse(8L, "7.3.0");
         ImageInfoV4Response image3 = createImageResponse(6L, "7.4.0");
         response.setUpgradeCandidates(List.of(image1, image2, image3));
@@ -354,6 +362,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
         when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
         when(entitlementService.isDifferentDataHubAndDataLakeVersionAllowed(anyString())).thenReturn(true);
+        when(currentImageUsageCondition.currentImageUsedOnInstances(any(), any())).thenReturn(true);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
@@ -369,7 +378,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         UpgradeV4Request request = new UpgradeV4Request();
         UpgradeV4Response response = new UpgradeV4Response();
         ImageInfoV4Response current = createImageResponse(1L, "7.1.0");
-        ImageInfoV4Response image1 = createImageResponse(2L, "7.2.0");
+        ImageInfoV4Response image1 = createImageResponse(STACK_ID, "7.2.0");
         ImageInfoV4Response image2 = createImageResponse(8L, "7.3.0");
         ImageInfoV4Response image3 = createImageResponse(6L, "7.4.0");
         response.setUpgradeCandidates(List.of(image1, image2, image3));
@@ -378,6 +387,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
         when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(false);
+        when(currentImageUsageCondition.currentImageUsedOnInstances(any(), any())).thenReturn(true);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
@@ -395,7 +405,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         UpgradeV4Request request = new UpgradeV4Request();
         UpgradeV4Response response = new UpgradeV4Response();
         ImageInfoV4Response current = createImageResponse(1L, "7.1.0");
-        ImageInfoV4Response image1 = createImageResponse(2L, "7.1.0");
+        ImageInfoV4Response image1 = createImageResponse(STACK_ID, "7.1.0");
         ImageInfoV4Response image2 = createImageResponse(8L, "7.2.0");
         ImageInfoV4Response image3 = createImageResponse(6L, "7.3.0");
         response.setUpgradeCandidates(List.of(image1, image2, image3));
@@ -404,11 +414,12 @@ public class DistroXUpgradeAvailabilityServiceTest {
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
         when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(false);
+        when(currentImageUsageCondition.currentImageUsedOnInstances(any(), any())).thenReturn(true);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
         assertEquals(1, result.getUpgradeCandidates().size());
-        assertTrue(result.getUpgradeCandidates().stream().anyMatch(img -> img.getCreated() == 2L && "7.1.0".equals(img.getComponentVersions().getCdp())));
+        assertTrue(result.getUpgradeCandidates().stream().anyMatch(img -> img.getCreated() == STACK_ID && "7.1.0".equals(img.getComponentVersions().getCdp())));
     }
 
     @Test
@@ -421,7 +432,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         request.setDryRun(true);
         UpgradeV4Response response = new UpgradeV4Response();
         ImageInfoV4Response current = createImageResponse(1L, "7.1.0");
-        ImageInfoV4Response image1 = createImageResponse(2L, "7.1.0");
+        ImageInfoV4Response image1 = createImageResponse(STACK_ID, "7.1.0");
         ImageInfoV4Response image2 = createImageResponse(3L, "7.1.0");
         ImageInfoV4Response image3 = createImageResponse(6L, "7.3.0");
         response.setUpgradeCandidates(List.of(image1, image2, image3));
@@ -439,6 +450,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         when(entitlementService.isDifferentDataHubAndDataLakeVersionAllowed(anyString())).thenReturn(false);
         when(stackViewService.findDatalakeViewByEnvironmentCrn(stack.getEnvironmentCrn())).thenReturn(Optional.of(stackView));
         when(runtimeVersionService.getRuntimeVersion(eq(clusterView.getId()))).thenReturn(Optional.of("7.1.0"));
+        when(currentImageUsageCondition.currentImageUsedOnInstances(any(), any())).thenReturn(true);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
@@ -456,7 +468,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         UpgradeV4Request request = new UpgradeV4Request();
         UpgradeV4Response response = new UpgradeV4Response();
         ImageInfoV4Response current = createImageResponse(1L, "7.1.0");
-        ImageInfoV4Response image1 = createImageResponse(2L, "7.1.0");
+        ImageInfoV4Response image1 = createImageResponse(STACK_ID, "7.1.0");
         ImageInfoV4Response image2 = createImageResponse(8L, "7.2.0");
         ImageInfoV4Response image3 = createImageResponse(6L, "7.3.0");
         response.setUpgradeCandidates(List.of(image1, image2, image3));
@@ -464,12 +476,13 @@ public class DistroXUpgradeAvailabilityServiceTest {
         stack.getCluster().getBlueprint().setBlueprintUpgradeOption(BlueprintUpgradeOption.GA);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
         when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
+        when(currentImageUsageCondition.currentImageUsedOnInstances(any(), any())).thenReturn(true);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
         verify(entitlementService, times(1)).datahubRuntimeUpgradeEnabled(ACCOUNT_ID);
         assertEquals(3, result.getUpgradeCandidates().size());
-        assertTrue(result.getUpgradeCandidates().stream().anyMatch(img -> img.getCreated() == 2L && "7.1.0".equals(img.getComponentVersions().getCdp())));
+        assertTrue(result.getUpgradeCandidates().stream().anyMatch(img -> img.getCreated() == STACK_ID && "7.1.0".equals(img.getComponentVersions().getCdp())));
     }
 
     @Test
@@ -481,7 +494,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         UpgradeV4Request request = new UpgradeV4Request();
         UpgradeV4Response response = new UpgradeV4Response();
         ImageInfoV4Response current = createImageResponse(1L, "7.1.0");
-        ImageInfoV4Response image1 = createImageResponse(2L, "7.1.0");
+        ImageInfoV4Response image1 = createImageResponse(STACK_ID, "7.1.0");
         ImageInfoV4Response image2 = createImageResponse(8L, "7.2.0");
         ImageInfoV4Response image3 = createImageResponse(6L, "7.3.0");
         response.setUpgradeCandidates(List.of(image1, image2, image3));
@@ -490,12 +503,13 @@ public class DistroXUpgradeAvailabilityServiceTest {
         stack.getCluster().getBlueprint().setBlueprintUpgradeOption(BlueprintUpgradeOption.OS_UPGRADE_DISABLED);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
         when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
+        when(currentImageUsageCondition.currentImageUsedOnInstances(any(), any())).thenReturn(true);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
         verify(entitlementService, times(1)).datahubRuntimeUpgradeEnabled(ACCOUNT_ID);
         assertEquals(3, result.getUpgradeCandidates().size());
-        assertTrue(result.getUpgradeCandidates().stream().anyMatch(img -> img.getCreated() == 2L && "7.1.0".equals(img.getComponentVersions().getCdp())));
+        assertTrue(result.getUpgradeCandidates().stream().anyMatch(img -> img.getCreated() == STACK_ID && "7.1.0".equals(img.getComponentVersions().getCdp())));
     }
 
     private ImageInfoV4Response createImageResponse(long creation, String cdp) {

--- a/integration-test/src/main/resources/mockresponse/imagecatalog/catalog-with-for-upgrade.json
+++ b/integration-test/src/main/resources/mockresponse/imagecatalog/catalog-with-for-upgrade.json
@@ -18,7 +18,8 @@
           "cm": "CDH_RUNTIME",
           "salt": "2017.7.5",
           "salt-bootstrap": "0.13.0-2018-05-03T07:39:07",
-          "stack": "CDH_RUNTIME"
+          "stack": "CDH_RUNTIME",
+          "python38": "3.8.13-1.el7"
         },
         "stack-details": {
           "repo": {
@@ -86,7 +87,8 @@
           "cm": "CDH_RUNTIME",
           "salt": "2017.7.5",
           "salt-bootstrap": "0.13.0-2018-05-03T07:39:07",
-          "stack": "CDH_RUNTIME"
+          "stack": "CDH_RUNTIME",
+          "python38": "3.8.13-1.el7"
         },
         "stack-details": {
           "repo": {

--- a/integration-test/src/main/resources/mockresponse/imagecatalog/catalog-with-prewarmed.json
+++ b/integration-test/src/main/resources/mockresponse/imagecatalog/catalog-with-prewarmed.json
@@ -18,7 +18,8 @@
           "cm": "7.x.0",
           "salt": "2017.7.5",
           "salt-bootstrap": "0.13.0-2018-05-03T07:39:07",
-          "stack": "CDH_RUNTIME"
+          "stack": "CDH_RUNTIME",
+          "python38": "3.8.13-1.el7"
         },
         "stack-details": {
           "repo": {
@@ -73,7 +74,8 @@
           "cm": "7.x.0",
           "salt": "2017.7.5",
           "salt-bootstrap": "0.13.0-2018-05-03T07:39:07",
-          "stack": "CDH_RUNTIME"
+          "stack": "CDH_RUNTIME",
+          "python38": "3.8.13-1.el7"
         },
         "stack-details": {
           "repo": {

--- a/mock-infrastructure/src/main/resources/mock-image-catalogs/catalog-with-prewarmed.json
+++ b/mock-infrastructure/src/main/resources/mock-image-catalogs/catalog-with-prewarmed.json
@@ -19,7 +19,8 @@
           "cm-build-number": "14450219",
           "salt": "2017.7.5",
           "salt-bootstrap": "0.13.0-2018-05-03T07:39:07",
-          "stack": "CDH_RUNTIME"
+          "stack": "CDH_RUNTIME",
+          "python38": "3.8.13-1.el7"
         },
         "stack-details": {
           "repo": {
@@ -75,7 +76,8 @@
           "cm-build-number": "14450219",
           "salt": "2017.7.5",
           "salt-bootstrap": "0.13.0-2018-05-03T07:39:07",
-          "stack": "CDH_RUNTIME_NEXT"
+          "stack": "CDH_RUNTIME_NEXT",
+          "python38": "3.8.13-1.el7"
         },
         "stack-details": {
           "repo": {


### PR DESCRIPTION
In this commit I've added new validation for CDH 7.2.16.3 because it has a newly added hard dependency on Python 3.8.

I've created two validations:
- Validating the images during we're retrieving the upgrade candidate images. So we're not offering those images as an upgrade candidate that requires the Python 3.8 but our current image does not contains it.
- Validating the target image in the "Prepare and validate" phase