### PR TITLE
CB-21039 Retry deploying azure template during DB upgrade if it retur…

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceService.java
@@ -373,7 +373,7 @@ public class AzureDatabaseResourceService {
             } catch (ManagementException e) {
                 if (azureExceptionHandler.isExceptionCodeConflict(e)) {
                     LOGGER.info("Database server deployment failed with a conflict. It's retried 5 times before failing.", e);
-                    throw azureUtils.convertToActionFailedExceptionCausedByCloudConnectorException(e, "Database server deployment");
+                    throw Retry.ActionFailedException.ofCause(e);
                 } else {
                     throw e;
                 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureExceptionHandler.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureExceptionHandler.java
@@ -99,7 +99,13 @@ public class AzureExceptionHandler {
     }
 
     public boolean isExceptionCodeConflict(ManagementException e) {
-        return e != null && e.getValue() != null && MGMT_ERROR_CODE_CONFLICT.equalsIgnoreCase(e.getValue().getCode());
+        return e != null && e.getValue() != null
+                && (MGMT_ERROR_CODE_CONFLICT.equalsIgnoreCase(e.getValue().getCode()) || isDetailsContainAnyConflict(e));
+    }
+
+    private boolean isDetailsContainAnyConflict(ManagementException e) {
+        return e.getValue().getDetails() != null
+                && e.getValue().getDetails().stream().anyMatch(detail -> MGMT_ERROR_CODE_CONFLICT.equalsIgnoreCase(detail.getCode()));
     }
 
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceServiceTest.java
@@ -277,8 +277,6 @@ class AzureDatabaseResourceServiceTest {
         ManagementException managementException = new ManagementException("asdf", mock(HttpResponse.class), new ManagementError("conflict", "asdf"));
         doThrow(managementException).when(client).createTemplateDeployment(RESOURCE_GROUP_NAME, STACK_NAME, TEMPLATE, "{}");
         when(azureExceptionHandler.isExceptionCodeConflict(managementException)).thenReturn(Boolean.TRUE);
-        when(azureUtils.convertToActionFailedExceptionCausedByCloudConnectorException(managementException, "Database server deployment"))
-                .thenReturn(new Retry.ActionFailedException(managementException));
         when(azureUtils.convertToCloudConnectorException(managementException, "Database stack upgrade")).thenReturn(new CloudConnectorException("fda"));
 
         assertThrows(CloudConnectorException.class,
@@ -299,7 +297,6 @@ class AzureDatabaseResourceServiceTest {
         verify(azureResourceGroupMetadataProvider).getResourceGroupName(cloudContext, databaseStack);
         assertEquals("11", databaseStackArgumentCaptor.getValue().getDatabaseServer().getParameters().get(DB_VERSION));
         verify(persistenceNotifier).notifyAllocations(cloudResourceList, cloudContext);
-        verify(azureUtils).convertToActionFailedExceptionCausedByCloudConnectorException(managementException, "Database server deployment");
     }
 
     @Test

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureExceptionHandlerTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureExceptionHandlerTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.function.Supplier;
 
 import org.assertj.core.api.Assertions;
@@ -168,6 +169,11 @@ public class AzureExceptionHandlerTest {
     void testManagementExceptionIsConflict() {
         assertTrue(underTest.isExceptionCodeConflict(
                 new ManagementException("asdf", mock(HttpResponse.class), new ManagementError("conflict", "asdffda"))));
+        ManagementError managementErrorWithDetails = mock(ManagementError.class);
+        when(managementErrorWithDetails.getCode()).thenReturn("Asdf");
+        when(managementErrorWithDetails.getDetails()).thenAnswer(invocation -> List.of(new ManagementError("conflict", "asdffda")));
+        assertTrue(underTest.isExceptionCodeConflict(
+                new ManagementException("asdf", mock(HttpResponse.class), managementErrorWithDetails)));
         assertFalse(underTest.isExceptionCodeConflict(
                 new ManagementException("asdf", mock(HttpResponse.class), new ManagementError("nope", "asdffda"))));
         assertFalse(underTest.isExceptionCodeConflict(


### PR DESCRIPTION
…ns with a `Conflict`

Added check for the exception details, as it looks like the outside exception can be different than conflict.

See detailed description in the commit message.