### PR TITLE
CB-21551 API E2E Refactor the MOCK_UMS_PASSWORD with getWorkloadPassword and getWorkloadUserName in the test project

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakTest.java
@@ -38,6 +38,8 @@ public class CloudbreakTest extends AbstractTestNGSpringContextTests {
 
     public static final String USER_NAME = "USER_NAME";
 
+    public static final String WORKLOAD_USER_NAME = "WORKLOAD_USER_NAME";
+
     public static final String SECONDARY_ACCESS_KEY = "SECONDARY_ACCESS_KEY";
 
     public static final String SECONDARY_SECRET_KEY = "SECONDARY_SECRET_KEY";
@@ -55,6 +57,9 @@ public class CloudbreakTest extends AbstractTestNGSpringContextTests {
 
     @Value("${integrationtest.user.name:}")
     private String userName;
+
+    @Value("${integrationtest.user.workloadUserName:}")
+    private String workloadUserName;
 
     @Value("${mock.imagecatalog.server:localhost}")
     private String mockImageCatalogAddr;
@@ -90,9 +95,11 @@ public class CloudbreakTest extends AbstractTestNGSpringContextTests {
         testParameter.put(SECRET_KEY, secretkey);
         testParameter.put(USER_CRN, userCrn);
         testParameter.put(USER_NAME, userName);
+        testParameter.put(WORKLOAD_USER_NAME, workloadUserName);
 
-        LOGGER.info(" Default user details in test parameters:: \nACCESS_KEY: {} \nSECRET_KEY: {} \nUSER_CRN: {} \nUSER_NAME: {} ",
-                testParameter.get(ACCESS_KEY), testParameter.get(SECRET_KEY), testParameter.get(USER_CRN), testParameter.get(USER_NAME));
+        LOGGER.info(" Default user details in test parameters:: \nACCESS_KEY: {} \nSECRET_KEY: {} \nUSER_CRN: {} \nUSER_NAME: {} \nWORKLOAD_USER_NAME: {} ",
+                testParameter.get(ACCESS_KEY), testParameter.get(SECRET_KEY), testParameter.get(USER_CRN), testParameter.get(USER_NAME),
+                testParameter.get(WORKLOAD_USER_NAME));
     }
 
     public TestParameter getTestParameter() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/datalake/RecipeTestAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/datalake/RecipeTestAssertion.java
@@ -21,7 +21,7 @@ public class RecipeTestAssertion {
     }
 
     public static <T extends AbstractSdxTestDto> Assertion<T, SdxClient> validateFilesOnHost(List<String> hostGroupNames, String filePath, String fileName,
-            long requiredNumberOfFiles, String user, String password, SshJUtil sshJUtil) {
+            long requiredNumberOfFiles, SshJUtil sshJUtil) {
         return (testContext, testDto, sdxClient) -> {
             Log.log(LOGGER, " Checking generated file(s) by recipe at datalake instance(s) (%s) on '%s' path by '%s' name! ", testDto.getCrn(),
                     filePath, fileName);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/proxy/ProxyConfigCmAssertions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/proxy/ProxyConfigCmAssertions.java
@@ -16,13 +16,12 @@ import com.sequenceiq.it.cloudbreak.dto.proxy.ProxyTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.microservice.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.microservice.SdxClient;
-import com.sequenceiq.it.cloudbreak.testcase.e2e.proxy.ModifyProxyConfigE2ETest;
 import com.sequenceiq.it.cloudbreak.util.clouderamanager.ClouderaManagerUtil;
 
 @Component
 class ProxyConfigCmAssertions {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ModifyProxyConfigE2ETest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyConfigCmAssertions.class);
 
     @Inject
     private ProxyConfigProperties proxyConfigProperties;
@@ -34,7 +33,7 @@ class ProxyConfigCmAssertions {
         return (testContext, testDto, client) -> {
             LOGGER.info("Validating {} datalake's CM has no proxy settings", testDto.getCrn());
             Map<String, String> expectedConfig = getEmptyExpectedConfig();
-            clouderaManagerUtil.checkConfig(testDto, testContext.getWorkloadUserName(), testContext.getWorkloadPassword(), expectedConfig);
+            clouderaManagerUtil.checkConfig(testDto, testContext, expectedConfig);
             return testDto;
         };
     }
@@ -43,7 +42,7 @@ class ProxyConfigCmAssertions {
         return (testContext, testDto, client) -> {
             LOGGER.info("Validating {} datahub's CM has no proxy settings", testDto.getCrn());
             Map<String, String> expectedConfig = getEmptyExpectedConfig();
-            clouderaManagerUtil.checkConfig(testDto, testContext.getWorkloadUserName(), testContext.getWorkloadPassword(), expectedConfig);
+            clouderaManagerUtil.checkConfig(testDto, testContext, expectedConfig);
             return testDto;
         };
     }
@@ -52,7 +51,7 @@ class ProxyConfigCmAssertions {
         return (testContext, testDto, client) -> {
             LOGGER.info("Validating {} datalake's CM has correct proxy settings {}", testDto.getCrn(), proxy.getName());
             Map<String, String> expectedConfig = getExpectedConfig(proxy);
-            clouderaManagerUtil.checkConfig(testDto, testContext.getWorkloadUserName(), testContext.getWorkloadPassword(), expectedConfig);
+            clouderaManagerUtil.checkConfig(testDto, testContext, expectedConfig);
             return testDto;
         };
     }
@@ -61,7 +60,7 @@ class ProxyConfigCmAssertions {
         return (testContext, testDto, client) -> {
             LOGGER.info("Validating {} datahub's CM has correct proxy settings {}", testDto.getCrn(), proxy.getName());
             Map<String, String> expectedConfig = getExpectedConfig(proxy);
-            clouderaManagerUtil.checkConfig(testDto, testContext.getWorkloadUserName(), testContext.getWorkloadPassword(), expectedConfig);
+            clouderaManagerUtil.checkConfig(testDto, testContext, expectedConfig);
             return testDto;
         };
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
@@ -54,6 +54,11 @@ public class MeasuredTestContext extends MockedTestContext {
     }
 
     @Override
+    public String getMockUmsPassword() {
+        return wrappedTestContext.getMockUmsPassword();
+    }
+
+    @Override
     public TestParameter getTestParameter() {
         return wrappedTestContext.getTestParameter();
     }
@@ -161,6 +166,16 @@ public class MeasuredTestContext extends MockedTestContext {
     @Override
     public String getActingUserOwnerTag() {
         return wrappedTestContext.getActingUserOwnerTag();
+    }
+
+    @Override
+    public String getWorkloadUserName() {
+        return wrappedTestContext.getWorkloadUserName();
+    }
+
+    @Override
+    public String getWorkloadPassword() {
+        return wrappedTestContext.getWorkloadPassword();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXRepairTests.java
@@ -15,7 +15,6 @@ import org.testng.annotations.Test;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
-import com.sequenceiq.cloudbreak.util.SanitizerUtil;
 import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
 import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
 import com.sequenceiq.it.cloudbreak.context.Description;
@@ -36,8 +35,6 @@ import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
  */
 public class DistroXRepairTests extends AbstractE2ETest {
     private static final Logger LOGGER = LoggerFactory.getLogger(DistroXRepairTests.class);
-
-    private static final String MOCK_UMS_PASSWORD = "Password123!";
 
     @Inject
     private DistroXTestClient distroXTestClient;
@@ -69,9 +66,6 @@ public class DistroXRepairTests extends AbstractE2ETest {
         List<String> actualVolumeIds = new ArrayList<>();
         List<String> expectedVolumeIds = new ArrayList<>();
 
-        String username = testContext.getActingUserCrn().getResource();
-        String sanitizedUserName = SanitizerUtil.sanitizeWorkloadUsername(username);
-
         testContext
                 .given(distrox, DistroXTestDto.class)
                 .withInstanceGroupsEntity(new DistroXInstanceGroupsBuilder(testContext)
@@ -94,8 +88,7 @@ public class DistroXRepairTests extends AbstractE2ETest {
                 .await(STACK_AVAILABLE, key(distrox))
                 .awaitForHealthyInstances()
                 .then(this::verifyMountedDisks)
-                .then((tc, testDto, client) -> clouderaManagerUtil.checkClouderaManagerYarnNodemanagerRoleConfigGroups(testDto, sanitizedUserName,
-                        MOCK_UMS_PASSWORD))
+                .then((tc, testDto, client) -> clouderaManagerUtil.checkClouderaManagerYarnNodemanagerRoleConfigGroups(testDto, tc))
                 .then((tc, testDto, client) -> {
                     CloudFunctionality cloudFunctionality = tc.getCloudProvider().getCloudFunctionality();
                     List<String> instanceIds = distroxUtil.getInstanceIds(testDto, client, MASTER.getName());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXUpgradeTests.java
@@ -9,7 +9,6 @@ import javax.inject.Inject;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
-import com.sequenceiq.cloudbreak.util.SanitizerUtil;
 import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
@@ -27,8 +26,6 @@ import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
 public class DistroXUpgradeTests extends AbstractE2ETest {
-
-    private static final String MOCK_UMS_PASSWORD = "Password123!";
 
     @Inject
     private SdxTestClient sdxTestClient;
@@ -60,9 +57,6 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
         String distroXName = resourcePropertyProvider().getName();
         String currentRuntimeVersion = commonClusterManagerProperties.getUpgrade().getDistroXUpgradeCurrentVersion();
         String targetRuntimeVersion = commonClusterManagerProperties.getUpgrade().getDistroXUpgradeTargetVersion();
-
-        String username = testContext.getActingUserCrn().getResource();
-        String sanitizedUserName = SanitizerUtil.sanitizeWorkloadUsername(username);
 
         testContext
                 .given(sdxName, SdxTestDto.class)
@@ -96,8 +90,7 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
                     cloudFunctionality.checkMountedDisks(instanceGroups, List.of(HostGroupType.WORKER.getName()));
                     return testDto;
                 })
-                .then((tc, testDto, client) -> clouderaManagerUtil.checkClouderaManagerYarnNodemanagerRoleConfigGroupsDirect(testDto, sanitizedUserName,
-                        MOCK_UMS_PASSWORD))
+                .then((tc, testDto, client) -> clouderaManagerUtil.checkClouderaManagerYarnNodemanagerRoleConfigGroupsDirect(testDto, tc))
                 .validate();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
@@ -20,7 +20,6 @@ import org.testng.annotations.Test;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceGroupV4Base;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
-import com.sequenceiq.cloudbreak.util.SanitizerUtil;
 import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseAvailabilityType;
 import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseRequest;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
@@ -71,8 +70,6 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
 
     private static final String VERTICAL_SCALE_FAIL_MSG_FORMAT = "%s vertical scale was not successful, because the expected instance type is the following: %s"
             + ", but the actual is: %s";
-
-    private static final String MOCK_UMS_PASSWORD = "Password123!";
 
     private static final String FREEIPA_VERTICAL_SCALE_KEY = "freeipaVerticalScaleKey";
 
@@ -343,9 +340,7 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
     }
 
     private DistroXTestDto verifyCmServicesStartedSuccessfully(TestContext testContext, DistroXTestDto testDto, CloudbreakClient cloudbreakClient) {
-        String username = testContext.getActingUserCrn().getResource();
-        String sanitizedUserName = SanitizerUtil.sanitizeWorkloadUsername(username);
-        clouderaManagerUtil.checkCmServicesStartedSuccessfully(testDto, sanitizedUserName, MOCK_UMS_PASSWORD);
+        clouderaManagerUtil.checkCmServicesStartedSuccessfully(testDto, testContext);
         return testDto;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/InternalSdxRepairWithRecipeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/InternalSdxRepairWithRecipeTest.java
@@ -120,7 +120,7 @@ public class InternalSdxRepairWithRecipeTest extends PreconditionSdxE2ETest {
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal))
                 .awaitForHealthyInstances()
-                .then(RecipeTestAssertion.validateFilesOnHost(List.of(MASTER.getName(), IDBROKER.getName()), filePath, fileName, 1, null, null, sshJUtil))
+                .then(RecipeTestAssertion.validateFilesOnHost(List.of(MASTER.getName(), IDBROKER.getName()), filePath, fileName, 1, sshJUtil))
                 .then((tc, dto, client) -> {
                     if (!StringUtils.equalsIgnoreCase(dto.getResponse().getStackV4Response().getImage().getId(), selectedImageID)) {
                         throw new TestFailException(String.format("The datalake image Id (%s) do NOT match with the selected pre-warmed image Id: '%s'!",
@@ -139,7 +139,7 @@ public class InternalSdxRepairWithRecipeTest extends PreconditionSdxE2ETest {
                 .await(SdxClusterStatusResponse.REPAIR_IN_PROGRESS, key(sdxInternal).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal))
                 .awaitForHealthyInstances()
-                .then(RecipeTestAssertion.validateFilesOnHost(List.of(MASTER.getName(), IDBROKER.getName()), filePath, fileName, 1, null, null, sshJUtil))
+                .then(RecipeTestAssertion.validateFilesOnHost(List.of(MASTER.getName(), IDBROKER.getName()), filePath, fileName, 1, sshJUtil))
                 .validate();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRecipeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRecipeTests.java
@@ -70,7 +70,7 @@ public class SdxRecipeTests extends PreconditionSdxE2ETest {
                 .when(sdxTestClient.create())
                 .await(SdxClusterStatusResponse.RUNNING)
                 .awaitForHealthyInstances()
-                .then(RecipeTestAssertion.validateFilesOnHost(List.of(MASTER.getName()), filePath, fileName, 1, null, null, sshJUtil))
+                .then(RecipeTestAssertion.validateFilesOnHost(List.of(MASTER.getName()), filePath, fileName, 1, sshJUtil))
                 .then(saltHighStateDurationAssertions::saltHighStateDurationLimits)
                 .when(sdxTestClient.delete())
                 .await(SdxClusterStatusResponse.DELETED)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/ClouderaManagerUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/ClouderaManagerUtil.java
@@ -7,6 +7,7 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.util.clouderamanager.action.ClouderaManagerClientActions;
@@ -20,35 +21,35 @@ public class ClouderaManagerUtil {
     private ClouderaManagerUtil() {
     }
 
-    public SdxInternalTestDto checkClouderaManagerKnoxIDBrokerRoleConfigGroups(SdxInternalTestDto testDto, String user, String password) {
-        return clouderaManagerClientActions.checkCmKnoxIDBrokerRoleConfigGroups(testDto, user, password);
+    public SdxInternalTestDto checkClouderaManagerKnoxIDBrokerRoleConfigGroups(SdxInternalTestDto testDto, TestContext testContext) {
+        return clouderaManagerClientActions.checkCmKnoxIDBrokerRoleConfigGroups(testDto, testContext);
     }
 
-    public SdxInternalTestDto checkConfig(SdxInternalTestDto testDto, String user, String password, Map<String, String> expectedConfig) {
-        return clouderaManagerClientActions.checkConfig(testDto, user, password, expectedConfig);
+    public SdxInternalTestDto checkConfig(SdxInternalTestDto testDto, TestContext testContext, Map<String, String> expectedConfig) {
+        return clouderaManagerClientActions.checkConfig(testDto, testContext, expectedConfig);
     }
 
-    public DistroXTestDto checkConfig(DistroXTestDto testDto, String user, String password, Map<String, String> expectedConfig) {
-        return clouderaManagerClientActions.checkConfig(testDto, user, password, expectedConfig);
+    public DistroXTestDto checkConfig(DistroXTestDto testDto, TestContext testContext, Map<String, String> expectedConfig) {
+        return clouderaManagerClientActions.checkConfig(testDto, testContext, expectedConfig);
     }
 
-    public DistroXTestDto checkClouderaManagerYarnNodemanagerRoleConfigGroups(DistroXTestDto testDto, String user, String password) {
-        return clouderaManagerClientActions.checkCmYarnNodemanagerRoleConfigGroups(testDto, user, password);
+    public DistroXTestDto checkClouderaManagerYarnNodemanagerRoleConfigGroups(DistroXTestDto testDto, TestContext testContext) {
+        return clouderaManagerClientActions.checkCmYarnNodemanagerRoleConfigGroups(testDto, testContext);
     }
 
-    public DistroXTestDto checkClouderaManagerYarnNodemanagerRoleConfigGroupsDirect(DistroXTestDto testDto, String user, String password) {
-        return clouderaManagerClientActions.checkCmYarnNodemanagerRoleConfigGroupsDirect(testDto, user, password);
+    public DistroXTestDto checkClouderaManagerYarnNodemanagerRoleConfigGroupsDirect(DistroXTestDto testDto, TestContext testContext) {
+        return clouderaManagerClientActions.checkCmYarnNodemanagerRoleConfigGroupsDirect(testDto, testContext);
     }
 
-    public DistroXTestDto checkClouderaManagerHdfsNamenodeRoleConfigGroups(DistroXTestDto testDto, String user, String password, Set<String> mountPoints) {
-        return clouderaManagerClientActions.checkCmHdfsNamenodeRoleConfigGroups(testDto, user, password, mountPoints);
+    public DistroXTestDto checkClouderaManagerHdfsNamenodeRoleConfigGroups(DistroXTestDto testDto, TestContext testContext, Set<String> mountPoints) {
+        return clouderaManagerClientActions.checkCmHdfsNamenodeRoleConfigGroups(testDto, testContext, mountPoints);
     }
 
-    public DistroXTestDto checkClouderaManagerHdfsDatanodeRoleConfigGroups(DistroXTestDto testDto, String user, String password, Set<String> mountPoints) {
-        return clouderaManagerClientActions.checkCmHdfsDatanodeRoleConfigGroups(testDto, user, password, mountPoints);
+    public DistroXTestDto checkClouderaManagerHdfsDatanodeRoleConfigGroups(DistroXTestDto testDto, TestContext testContext, Set<String> mountPoints) {
+        return clouderaManagerClientActions.checkCmHdfsDatanodeRoleConfigGroups(testDto, testContext, mountPoints);
     }
 
-    public DistroXTestDto checkCmServicesStartedSuccessfully(DistroXTestDto testDto, String user, String password) {
-        return clouderaManagerClientActions.checkCmServicesStartedSuccessfully(testDto, user, password);
+    public DistroXTestDto checkCmServicesStartedSuccessfully(DistroXTestDto testDto, TestContext testContext) {
+        return clouderaManagerClientActions.checkCmServicesStartedSuccessfully(testDto, testContext);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/action/ClouderaManagerClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/action/ClouderaManagerClientActions.java
@@ -25,6 +25,7 @@ import com.cloudera.api.swagger.model.ApiHost;
 import com.cloudera.api.swagger.model.ApiRoleRef;
 import com.cloudera.api.swagger.model.ApiRoleState;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
@@ -44,21 +45,21 @@ public class ClouderaManagerClientActions extends ClouderaManagerClient {
     private String cloudProvider;
 
     @Retryable
-    public SdxInternalTestDto checkConfig(SdxInternalTestDto testDto, String user, String password, Map<String, String> expectedConfig) {
+    public SdxInternalTestDto checkConfig(SdxInternalTestDto testDto, TestContext testContext, Map<String, String> expectedConfig) {
         String serverIp = testDto.getResponse().getStackV4Response().getCluster().getServerIp();
-        checkConfig(serverIp, testDto.getName(), user, password, expectedConfig);
+        checkConfig(serverIp, testDto.getName(), testContext, expectedConfig);
         return testDto;
     }
 
     @Retryable
-    public DistroXTestDto checkConfig(DistroXTestDto testDto, String user, String password, Map<String, String> expectedConfig) {
+    public DistroXTestDto checkConfig(DistroXTestDto testDto, TestContext testContext, Map<String, String> expectedConfig) {
         String serverIp = testDto.getResponse().getCluster().getServerIp();
-        checkConfig(serverIp, testDto.getName(), user, password, expectedConfig);
+        checkConfig(serverIp, testDto.getName(), testContext, expectedConfig);
         return testDto;
     }
 
-    private void checkConfig(String serverIp, String name, String user, String password, Map<String, String> expectedConfig) {
-        ApiClient apiClient = getCmApiClient(serverIp, name, V_43, user, password);
+    private void checkConfig(String serverIp, String name, TestContext testContext, Map<String, String> expectedConfig) {
+        ApiClient apiClient = getCmApiClient(serverIp, name, V_43, testContext.getWorkloadUserName(), testContext.getWorkloadPassword());
         // CHECKSTYLE:OFF
         ClouderaManagerResourceApi clouderaManagerResourceApi = new ClouderaManagerResourceApi(apiClient);
         // CHECKSTYLE:ON
@@ -85,9 +86,9 @@ public class ClouderaManagerClientActions extends ClouderaManagerClient {
         }
     }
 
-    public SdxInternalTestDto checkCmKnoxIDBrokerRoleConfigGroups(SdxInternalTestDto testDto, String user, String password) {
+    public SdxInternalTestDto checkCmKnoxIDBrokerRoleConfigGroups(SdxInternalTestDto testDto, TestContext testContext) {
         String serverFqdn = testDto.getResponse().getStackV4Response().getCluster().getServerFqdn();
-        ApiClient apiClient = getCmApiClient(serverFqdn, testDto.getName(), V_43, user, password);
+        ApiClient apiClient = getCmApiClient(serverFqdn, testDto.getName(), V_43, testContext.getWorkloadUserName(), testContext.getWorkloadPassword());
         // CHECKSTYLE:OFF
         RoleConfigGroupsResourceApi roleConfigGroupsResourceApi = new RoleConfigGroupsResourceApi(apiClient);
         // CHECKSTYLE:ON
@@ -130,15 +131,18 @@ public class ClouderaManagerClientActions extends ClouderaManagerClient {
         return testDto;
     }
 
-    public DistroXTestDto checkCmYarnNodemanagerRoleConfigGroups(DistroXTestDto testDto, String user, String password) {
+    public DistroXTestDto checkCmYarnNodemanagerRoleConfigGroups(DistroXTestDto testDto, TestContext testContext) {
         String serverIp = testDto.getResponse().getCluster().getServerIp();
+        String user = testContext.getWorkloadUserName();
+        String password = testContext.getWorkloadPassword();
         ApiClient apiClient = getCmApiClientWithTimeoutDisabled(serverIp, testDto.getName(), V_43, user, password);
         return checkCmYarnNodemanagerRoleConfigGroups(apiClient, testDto, user, password);
     }
 
-    public DistroXTestDto checkCmHdfsNamenodeRoleConfigGroups(DistroXTestDto testDto, String user, String password, Set<String> mountPoints) {
+    public DistroXTestDto checkCmHdfsNamenodeRoleConfigGroups(DistroXTestDto testDto, TestContext testContext, Set<String> mountPoints) {
         String serverIp = testDto.getResponse().getCluster().getServerIp();
-        ApiClient apiClient = getCmApiClientWithTimeoutDisabled(serverIp, testDto.getName(), V_43, user, password);
+        ApiClient apiClient = getCmApiClientWithTimeoutDisabled(serverIp, testDto.getName(), V_43, testContext.getWorkloadUserName(),
+                testContext.getWorkloadPassword());
         // CHECKSTYLE:OFF
         RoleConfigGroupsResourceApi roleConfigGroupsResourceApi = new RoleConfigGroupsResourceApi(apiClient);
         // CHECKSTYLE:ON
@@ -176,9 +180,10 @@ public class ClouderaManagerClientActions extends ClouderaManagerClient {
         return testDto;
     }
 
-    public DistroXTestDto checkCmHdfsDatanodeRoleConfigGroups(DistroXTestDto testDto, String user, String password, Set<String> mountPoints) {
+    public DistroXTestDto checkCmHdfsDatanodeRoleConfigGroups(DistroXTestDto testDto, TestContext testContext, Set<String> mountPoints) {
         String serverIp = testDto.getResponse().getCluster().getServerIp();
-        ApiClient apiClient = getCmApiClientWithTimeoutDisabled(serverIp, testDto.getName(), V_43, user, password);
+        ApiClient apiClient = getCmApiClientWithTimeoutDisabled(serverIp, testDto.getName(), V_43, testContext.getWorkloadUserName(),
+                testContext.getWorkloadPassword());
         // CHECKSTYLE:OFF
         RoleConfigGroupsResourceApi roleConfigGroupsResourceApi = new RoleConfigGroupsResourceApi(apiClient);
         // CHECKSTYLE:ON
@@ -216,8 +221,10 @@ public class ClouderaManagerClientActions extends ClouderaManagerClient {
         return testDto;
     }
 
-    public DistroXTestDto checkCmYarnNodemanagerRoleConfigGroupsDirect(DistroXTestDto testDto, String user, String password) {
+    public DistroXTestDto checkCmYarnNodemanagerRoleConfigGroupsDirect(DistroXTestDto testDto, TestContext testContext) {
         String serverIp = testDto.getResponse().getCluster().getServerIp();
+        String user = testContext.getWorkloadUserName();
+        String password = testContext.getWorkloadPassword();
         ApiClient apiClient = getCmApiClientWithTimeoutDisabledDirect(serverIp, testDto.getName(), V_43, user, password);
         return checkCmYarnNodemanagerRoleConfigGroups(apiClient, testDto, user, password);
     }
@@ -258,9 +265,10 @@ public class ClouderaManagerClientActions extends ClouderaManagerClient {
         return testDto;
     }
 
-    public DistroXTestDto checkCmServicesStartedSuccessfully(DistroXTestDto testDto, String user, String password) {
+    public DistroXTestDto checkCmServicesStartedSuccessfully(DistroXTestDto testDto, TestContext testContext) {
         String serverIp = testDto.getResponse().getCluster().getServerIp();
-        ApiClient apiClient = getCmApiClientWithTimeoutDisabledDirect(serverIp, testDto.getName(), V_43, user, password);
+        ApiClient apiClient = getCmApiClientWithTimeoutDisabledDirect(serverIp, testDto.getName(), V_43, testContext.getWorkloadUserName(),
+                testContext.getWorkloadPassword());
         // CHECKSTYLE:OFF
         HostsResourceApi hostsResourceApi = new HostsResourceApi(apiClient);
         // CHECKSTYLE:ON


### PR DESCRIPTION
Right now we have several classes where we implemented the CM access with the help of `MOCK_UMS_PASSWORD` or getWorkloadPassword:
- DistroXStopStartTest
- DistroXUpgradeTests
- DistroXRepairTests
- AwsYcloudHybridCloudTest
- EnvironmentStopStartTests

and with `getWorkloadUserName`:
- InternalSdxSshAndCmAccessTest
- DistroXRepairTests

in the test project next to the `TextContext`.

So we should collect these classes and move the related implementation to a common place...etc.