### PR TITLE
CB-21442 - No fallback in case Marketplace terms and condition not ac…

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureDeploymentMarketplaceError.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureDeploymentMarketplaceError.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+public enum AzureDeploymentMarketplaceError {
+
+    AUTHORIZATION_FAILED("AuthorizationFailed", "Microsoft.Marketplace"),
+
+    MARKETPLACE_PURCHASE_ELIGIBILITY_FAILED("MarketplacePurchaseEligibilityFailed", "");
+
+    private final String code;
+
+    private final String messageFragment;
+
+    AzureDeploymentMarketplaceError(String code, String messageFragment) {
+        this.code = code;
+        this.messageFragment = messageFragment;
+    }
+
+    public String value() {
+        return code;
+    }
+
+    public String getMessageFragment() {
+        return messageFragment;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTestUtils.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTestUtils.java
@@ -27,7 +27,7 @@ public class AzureTestUtils {
         return managementError;
     }
 
-    public static void setDetails(ApiError apiError, List<ManagementError> details) {
+    public static void setDetails(ManagementError apiError, List<ManagementError> details) {
         setField(apiError, "details", details);
     }
 


### PR DESCRIPTION
…cepted

The fallback mechanism in case of deployment error was only perpared to
handle missing image read permission, this commit adds image terms error
exception too to the use-cases when we need to fall back to use VHDs.

<img width="1344" alt="45C82BC1-1389-4F7D-B4E2-AE7FFB34EF17" src="https://user-images.githubusercontent.com/19725708/233698796-e53f0d08-ada4-485e-b1bc-a591e708785a.png">
