### PR TITLE
CB-21444 - Implement EDH tracking of image name

### DIFF
--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StackDetailsToCDPImageDetailsConverter.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StackDetailsToCDPImageDetailsConverter.java
@@ -22,6 +22,7 @@ public class StackDetailsToCDPImageDetailsConverter {
                 cdpImageDetails.setImageId(defaultIfEmpty(image.getImageId(), ""));
                 cdpImageDetails.setImageCatalogUrl(defaultIfEmpty(image.getImageCatalogUrl(), ""));
                 cdpImageDetails.setOsType(defaultIfEmpty(image.getOsType(), ""));
+                cdpImageDetails.setImageName(defaultIfEmpty(image.getImageName(), ""));
             }
         }
 

--- a/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StackDetailsToCDPImageDetailsConverterTest.java
+++ b/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StackDetailsToCDPImageDetailsConverterTest.java
@@ -15,6 +15,8 @@ public class StackDetailsToCDPImageDetailsConverterTest {
 
     private static final String IMAGE_ID = "image id";
 
+    private static final String IMAGE_NAME = "image name";
+
     private static final String OS_TYPE = "os type";
 
     private static final String IMAGE_CATALOG = "image catalog";
@@ -36,6 +38,7 @@ public class StackDetailsToCDPImageDetailsConverterTest {
         Assertions.assertEquals("", cdpImageDetails.getImageId());
         Assertions.assertEquals("", cdpImageDetails.getImageCatalogUrl());
         Assertions.assertEquals("", cdpImageDetails.getOsType());
+        Assertions.assertEquals("", cdpImageDetails.getImageName());
     }
 
     @Test
@@ -46,6 +49,7 @@ public class StackDetailsToCDPImageDetailsConverterTest {
         Assertions.assertEquals("", cdpImageDetails.getImageId());
         Assertions.assertEquals("", cdpImageDetails.getImageCatalogUrl());
         Assertions.assertEquals("", cdpImageDetails.getOsType());
+        Assertions.assertEquals("", cdpImageDetails.getImageName());
     }
 
     @Test
@@ -56,6 +60,7 @@ public class StackDetailsToCDPImageDetailsConverterTest {
         imageDetails.setOsType(OS_TYPE);
         imageDetails.setImageCatalogName(IMAGE_CATALOG);
         imageDetails.setImageCatalogUrl(IMAGE_CATALOG_URL);
+        imageDetails.setImageName(IMAGE_NAME);
         stackDetails.setImage(imageDetails);
 
         UsageProto.CDPImageDetails cdpImageDetails = underTest.convert(stackDetails);
@@ -64,5 +69,6 @@ public class StackDetailsToCDPImageDetailsConverterTest {
         Assertions.assertEquals(IMAGE_ID, cdpImageDetails.getImageId());
         Assertions.assertEquals(IMAGE_CATALOG_URL, cdpImageDetails.getImageCatalogUrl());
         Assertions.assertEquals(OS_TYPE, cdpImageDetails.getOsType());
+        Assertions.assertEquals(IMAGE_NAME, cdpImageDetails.getImageName());
     }
 }

--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToCDPImageDetailsConverter.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToCDPImageDetailsConverter.java
@@ -46,6 +46,7 @@ public class StructuredEventToCDPImageDetailsConverter {
                 cdpImageDetails.setImageId(defaultIfEmpty(image.getImageId(), ""));
                 cdpImageDetails.setImageCatalogUrl(defaultIfEmpty(image.getImageCatalogUrl(), ""));
                 cdpImageDetails.setOsType(defaultIfEmpty(image.getOsType(), ""));
+                cdpImageDetails.setImageName(defaultIfEmpty(image.getImageName(), ""));
             }
         }
 

--- a/structuredevent-service-legacy/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToCDPImageDetailsConverterTest.java
+++ b/structuredevent-service-legacy/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToCDPImageDetailsConverterTest.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.structuredevent.service.telemetry.converter;
 
-import org.junit.Assert;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -13,6 +15,8 @@ import com.sequenceiq.cloudbreak.structuredevent.event.StructuredSyncEvent;
 class StructuredEventToCDPImageDetailsConverterTest {
 
     private static final String IMAGE_ID = "image id";
+
+    private static final String IMAGE_NAME = "image name";
 
     private static final String OS_TYPE = "os type";
 
@@ -29,8 +33,8 @@ class StructuredEventToCDPImageDetailsConverterTest {
 
     @Test
     public void testConvertWithNull() {
-        Assert.assertNotNull("We should return empty object for not null", underTest.convert((StructuredFlowEvent) null));
-        Assert.assertNotNull("We should return empty object for not null", underTest.convert((StructuredSyncEvent) null));
+        assertNotNull(underTest.convert((StructuredFlowEvent) null), "We should return empty object for not null");
+        assertNotNull(underTest.convert((StructuredSyncEvent) null), "We should return empty object for not null");
     }
 
     @Test
@@ -39,19 +43,21 @@ class StructuredEventToCDPImageDetailsConverterTest {
 
         UsageProto.CDPImageDetails flowdetails = underTest.convert(structuredFlowEvent);
 
-        Assert.assertEquals("", flowdetails.getImageCatalog());
-        Assert.assertEquals("", flowdetails.getImageId());
-        Assert.assertEquals("", flowdetails.getOsType());
-        Assert.assertEquals("", flowdetails.getImageCatalogUrl());
+        assertEquals("", flowdetails.getImageCatalog());
+        assertEquals("", flowdetails.getImageId());
+        assertEquals("", flowdetails.getOsType());
+        assertEquals("", flowdetails.getImageCatalogUrl());
+        assertEquals("", flowdetails.getImageName());
 
         StructuredSyncEvent structuredSyncEvent = new StructuredSyncEvent();
 
         UsageProto.CDPImageDetails syncDetails = underTest.convert(structuredSyncEvent);
 
-        Assert.assertEquals("", syncDetails.getImageCatalog());
-        Assert.assertEquals("", syncDetails.getImageId());
-        Assert.assertEquals("", syncDetails.getOsType());
-        Assert.assertEquals("", syncDetails.getImageCatalogUrl());
+        assertEquals("", syncDetails.getImageCatalog());
+        assertEquals("", syncDetails.getImageId());
+        assertEquals("", syncDetails.getOsType());
+        assertEquals("", syncDetails.getImageCatalogUrl());
+        assertEquals("", syncDetails.getImageName());
     }
 
     @Test
@@ -61,20 +67,22 @@ class StructuredEventToCDPImageDetailsConverterTest {
 
         UsageProto.CDPImageDetails flowdetails = underTest.convert(structuredFlowEvent);
 
-        Assert.assertEquals(IMAGE_CATALOG, flowdetails.getImageCatalog());
-        Assert.assertEquals(IMAGE_ID, flowdetails.getImageId());
-        Assert.assertEquals(IMAGE_CATALOG_URL, flowdetails.getImageCatalogUrl());
-        Assert.assertEquals(OS_TYPE, flowdetails.getOsType());
+        assertEquals(IMAGE_CATALOG, flowdetails.getImageCatalog());
+        assertEquals(IMAGE_ID, flowdetails.getImageId());
+        assertEquals(IMAGE_CATALOG_URL, flowdetails.getImageCatalogUrl());
+        assertEquals(OS_TYPE, flowdetails.getOsType());
+        assertEquals(IMAGE_NAME, flowdetails.getImageName());
 
         StructuredSyncEvent structuredSyncEvent = new StructuredSyncEvent();
         structuredSyncEvent.setStack(createStackDetails());
 
         UsageProto.CDPImageDetails syncDetails = underTest.convert(structuredSyncEvent);
 
-        Assert.assertEquals(IMAGE_CATALOG, syncDetails.getImageCatalog());
-        Assert.assertEquals(IMAGE_ID, syncDetails.getImageId());
-        Assert.assertEquals(IMAGE_CATALOG_URL, syncDetails.getImageCatalogUrl());
-        Assert.assertEquals(OS_TYPE, syncDetails.getOsType());
+        assertEquals(IMAGE_CATALOG, syncDetails.getImageCatalog());
+        assertEquals(IMAGE_ID, syncDetails.getImageId());
+        assertEquals(IMAGE_CATALOG_URL, syncDetails.getImageCatalogUrl());
+        assertEquals(OS_TYPE, syncDetails.getOsType());
+        assertEquals(IMAGE_NAME, syncDetails.getImageName());
     }
 
     private StackDetails createStackDetails() {
@@ -89,6 +97,7 @@ class StructuredEventToCDPImageDetailsConverterTest {
         imageDetails.setOsType(OS_TYPE);
         imageDetails.setImageCatalogName(IMAGE_CATALOG);
         imageDetails.setImageCatalogUrl(IMAGE_CATALOG_URL);
+        imageDetails.setImageName(IMAGE_NAME);
         return imageDetails;
     }
 }

--- a/usage-collection/src/main/proto/usage.proto
+++ b/usage-collection/src/main/proto/usage.proto
@@ -129,8 +129,12 @@ message Event {
     CDPLiftieRequested cdpLiftieRequested = 52;
     // A CDP Liftie cluster's status changed.
     CDPLiftieClusterStatusChanged cdpLiftieClusterStatusChanged = 53;
-    // A CDP Liftie heartbeat usage event
+    // A CDP Liftie node heartbeat usage event
     CDPLiftieClusterNodeStatesHeartbeat cdpLiftieClusterNodeStatesHeartbeat = 99;
+    // A CDP Liftie pod summary heartbeat usage event
+    CDPLiftieClusterPodStatesHeartbeatSummary cdpLiftieClusterPodStatesHeartbeatSummary = 134;
+    // A CDP Liftie pod heartbeat usage event
+    CDPLiftieClusterPodStatesHeartbeat cdpLiftieClusterPodStatesHeartbeat = 135;
     // A KPI was added to a DataFlow deployment.
     CDPDFDeploymentKpiCreated cdpDFDeploymentKpiCreated = 54;
     // A KPI of a DataFlow deployment was modified.
@@ -224,7 +228,7 @@ message Event {
     CDPEnvironmentProxyConfigEditEvent cdpEnvironmentProxyConfigEditEvent = 107;
     // A CDP CDW Usage Event.
     CDPCDWUsageEvent cdpCDWUsageEvent = 108;
-    // A CDP Liftie summary heartbeat usage event
+    // A CDP Liftie node summary heartbeat usage event
     CDPLiftieClusterNodeStatesHeartbeatSummary cdpLiftieClusterNodeStatesHeartbeatSummary = 109;
     // A CDP CDE session is requested.
     CDPCDESessionRequested cdpCDESessionRequested = 110;
@@ -288,6 +292,8 @@ message AltusIamAccountType {
     TRIAL = 2;
     // A managed Skynet CDPOne trial account.
     MANAGED_SKYNET_CDPONE_TRIAL = 3;
+    // A managed Skynet CDP trial account.
+    MANAGED_SKYNET_CDP_TRIAL = 4;
   }
 }
 
@@ -1466,6 +1472,8 @@ message CDPLiftieClusterNodeStatesHeartbeatSummary {
   CDPLiftieClusterNodesSummary nodesSummary = 7;
   // Summary info for the clusters metering related pods
   CDPLiftieClusterMeteringPodsSummary meteringPodsSummary = 8;
+  // The workload region
+  string workloadRegion = 9;
 }
 
 message CDPLiftieClusterNodesSummary {
@@ -1494,6 +1502,77 @@ message CDPLiftieClusterMeteringPodsSummary {
   int32 numMeteringPods = 3;
   // Total number of unhealthy metering pods
   int32 numMeteringPodsUnhealthy = 4;
+}
+
+message CDPLiftieClusterPodCondition {
+  // Indicates the condition
+  string condition = 1;
+  // Indicates the status of this condition
+  string status = 2;
+  // Last time we probed the condition.
+  uint64 lastProbeTime = 3;
+  // Indicates the last time this condition changed
+  uint64 lastTransitionTime = 4;
+}
+
+message CDPLiftieClusterPodState {
+  // Indicates Id of the pod
+  string id = 1;
+  // Indicates the name of the pod
+  string name = 2;
+  // Indicates the namespace of the pod
+  string namespace = 3;
+  // Indicates the pod condition
+  repeated CDPLiftieClusterPodCondition condition = 4;
+  // All labels present on this pod
+  repeated string labels = 5;
+  // Indicates pod annotations
+  repeated string annotations = 6;
+  // Reason for the conditions last transition
+  string reason = 7;
+  // Human readable string containing details about the last transition
+  string message = 8;
+}
+
+message CDPLiftieClusterPodStatesHeartbeatSummary {
+  // The Compute Cluster CRN
+  string clusterCrn = 1;
+  // Indicates the cluster id
+  string clusterId = 2;
+  // Total number of pods
+  int32 totalNumPods = 3;
+  // Summary Info of Metering Pods
+  CDPLiftieClusterPodSummmary meteringPods = 4;
+  // Summary Info of Fluentd Pods
+  CDPLiftieClusterPodSummmary fluentdPods = 5;
+  // Summary Info of Yunikorn Pods
+  CDPLiftieClusterPodSummmary yunikornPods = 6;
+  // Summary Info of Istio Pods
+  CDPLiftieClusterPodSummmary istioPods = 7;
+  // Summary Info of CoreDNS Pods
+  CDPLiftieClusterPodSummmary coreDNSPods = 8;
+  //List of all the unhealthy pods in each cluster
+  repeated string unhealthyPodList = 9;
+  // The workload region
+  string workloadRegion = 10;
+}
+
+message CDPLiftieClusterPodSummmary {
+  // Total number of pods
+  int32 numTotalPods = 1;
+  // Total number of unhealthy pods
+  int32 numUnhealthyPods = 2;
+}
+
+message CDPLiftieClusterPodStatesHeartbeat {
+  // List of all the pods in each cluster
+  repeated CDPLiftieClusterPodState podStates = 1;
+  // The Compute Cluster CRN
+  string clusterCrn = 2;
+  // Indicates the cluster id
+  string clusterId = 3;
+  // The CDP environment CRN.
+  string environmentCrn = 4;
 }
 
 // The status of a CDP request
@@ -1759,6 +1838,13 @@ message CDPClusterStatus {
     SALT_UPDATE_FINISHED = 59;
     // The status when a salt update operation on the cluster is failed
     SALT_UPDATE_FAILED = 60;
+
+    // The status when a delete volume operation on a cluster is initiated.
+    DELETE_EBS_VOLUMES_STARTED = 61;
+    // The status when a delete volume operation on a cluster has successfully finished.
+    DELETE_EBS_VOLUMES_FINISHED = 62;
+    // The status when a delete volume operation on a cluster has failed.
+    DELETE_EBS_VOLUMES_FAILED = 63;
   }
 }
 
@@ -1977,6 +2063,8 @@ message CDPImageDetails {
   string imageCatalogUrl = 3;
   // OS type
   string osType = 4;
+  // Image name - used for Azure Marketplace usage tracking
+  string imageName = 5;
 }
 
 message CDPClusterShape {
@@ -4405,6 +4493,7 @@ message JobCreatedOrModifiedEvent {
   uint32 notifyStopped = 10;
   string file = 11;
   string reportAttachments = 12;
+  UsageRuntime runtime = 13;
 }
 
 message ExperimentStartEvent {


### PR DESCRIPTION
Here is a sample value set of the `imageName`, based on which it can be easily determined if a given cluster is launched with a VHD or an Azure Marketplace image:

<img width="704" alt="image" src="https://user-images.githubusercontent.com/19725708/234323814-1c3998e1-f78c-4e12-9016-6ff0a8565bf8.png">
