### PR TITLE
CB-21404 Fix DB engine update in Sdx Service: The SdxDatabase.databaseEngineVersion field update is needed when the SdxCluster.databaseEngineVersion field is updated

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxClusterRepository.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxClusterRepository.java
@@ -138,4 +138,6 @@ public interface SdxClusterRepository extends AccountAwareResourceRepository<Sdx
     @Query("SELECT sdxc.resourceCrn FROM SdxCluster sdxc WHERE sdxc.id = :id")
     Optional<String> findCrnById(@Param("id") Long id);
 
+    @Query(value = "SELECT sdxc.sdxDatabase.id FROM SdxCluster sdxc WHERE sdxc.crn = :crn")
+    Optional<Long> findDatabaseIdByCrn(@Param("crn") String crn);
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxDatabaseRepository.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxDatabaseRepository.java
@@ -1,8 +1,22 @@
 package com.sequenceiq.datalake.repository;
 
-import org.springframework.data.repository.CrudRepository;
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 import com.sequenceiq.datalake.entity.SdxDatabase;
 
+@Repository
+@Transactional(TxType.REQUIRED)
+@EntityType(entityClass = SdxDatabase.class)
 public interface SdxDatabaseRepository extends CrudRepository<SdxDatabase, Long> {
+    @Modifying
+    @Query("UPDATE SdxDatabase s SET s.databaseEngineVersion = :databaseEngineVersion WHERE s.id = :id")
+    int updateDatabaseEngineVersion(@Param("id") Long id, @Param("databaseEngineVersion") String externalDatabaseEngineVersion);
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -1403,6 +1403,8 @@ public class SdxService implements ResourceIdProvider, PayloadContextProvider, H
         if (updatedCount < 1) {
             throw notFoundException("SdxCluster with", crn + " crn");
         } else {
+            Optional<Long> databaseId = sdxClusterRepository.findDatabaseIdByCrn(crn);
+            databaseId.ifPresent(id -> sdxDatabaseRepository.updateDatabaseEngineVersion(id, databaseEngineVersion));
             LOGGER.info("Updated database engine version for [{}] with [{}]", crn, databaseEngineVersion);
         }
     }

--- a/datalake/src/main/resources/schema/app/20230426125146_CB-21404_Add_cluster_id_index_to_sdxdatabase_table.sql
+++ b/datalake/src/main/resources/schema/app/20230426125146_CB-21404_Add_cluster_id_index_to_sdxdatabase_table.sql
@@ -1,0 +1,9 @@
+-- // CB-21404 Add cluster_id index to sdxdatabase table
+-- Migration SQL that makes the change goes here.
+
+CREATE UNIQUE INDEX IF NOT EXISTS unq_index_sdxdatabase_sdxcluster_id ON sdxdatabase(sdxcluster_id);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP INDEX IF EXISTS unq_index_sdxdatabase_sdxcluster_id;


### PR DESCRIPTION
CB-21404 Fix DB engine update in Sdx Service: The SdxDatabase.databaseEngineVersion field update is needed when the SdxCluster.databaseEngineVersion field is updated
