### PR TITLE
CB-21447 Adjust Cloudera Manager jvm memory in case of data hub clusters based on the cluster size

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -426,7 +426,7 @@ public enum ResourceEvent {
     CLUSTER_SCALING_STOPSTART_DOWNSCALE_FINISHED("cluster.scaling.stopstart.downscale.finished"),
     CLUSTER_SCALING_STOPSTART_DOWNSCALE_FAILED("cluster.scaling.stopstart.downscale.failed"),
     CLUSTER_SCALING_UPSCALE_FAILED("cluster.scaling.upscale.failed"),
-
+    CLUSTER_SCALING_CM_MEMORY_WARNING("cluster.scaling.cm.memory.warning"),
 
     CLUSTER_SALT_UPDATE_STARTED("cluster.salt.update.started"),
     CLUSTER_SALT_UPDATE_FAILED("cluster.salt.update.failed"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -147,6 +147,7 @@ cluster.scaling.stopstart.downscale.finished=Scaled down (via instance stop) hos
 cluster.scaling.stopstart.downscale.failed=Failed to downscale (via instance stop). Reason: {0}
 
 cluster.scaling.upscale.failed=Upscaling failed for nodes [{0}], possible cause can be a failed/timed out Cloudera Manager operation, please check Cloudera Manager UI for further details or contact support.
+cluster.scaling.cm.memory.warning=Cloudera Manager is low on memory. Based on the current node count {0} GB memory is needed for Cloudera Manager. The current instance has {1} GB of memory, and we can assign 25% of it to Cloudera Manager. To avoid issues please scale vertically the node where Cloudera Manager is running.
 
 cluster.scaling.up=Scaling up host group: {0}
 cluster.re.register.with.cluster.proxy=Re-registering with Cluster Proxy service

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerMemoryAdjuster.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerMemoryAdjuster.java
@@ -1,0 +1,134 @@
+package com.sequenceiq.cloudbreak.core.cluster;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterClientInitException;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.Memory;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
+
+@Component
+public class ClusterManagerMemoryAdjuster {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterManagerMemoryAdjuster.class);
+
+    private static final double MAX_CM_MEMORY_USAGE_FACTOR = 0.25;
+
+    private static final Memory FOUR_GIGABYTES = Memory.ofGigaBytes(4);
+
+    private static final Memory THIRTY_TWO_GIGABYTES = Memory.ofGigaBytes(32);
+
+    private static final int ONE_HUNDRED = 100;
+
+    private static final int MIN_CM_MEMORY_NODE_COUNT = ONE_HUNDRED;
+
+    private static final int MAX_CM_MEMORY_NODE_COUNT = 800;
+
+    @Inject
+    private GatewayConfigService gatewayConfigService;
+
+    @Inject
+    private HostOrchestrator hostOrchestrator;
+
+    @Inject
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Inject
+    private CloudbreakEventService cloudbreakEventService;
+
+    public void adjustMemory(StackDto stackDto, int nodeCount) {
+        if (!StackType.WORKLOAD.equals(stackDto.getType())) {
+            LOGGER.info("Memory adjustment is skipped. It is only supported for data hub clusters.");
+            return;
+        }
+        try {
+            GatewayConfig gateway = gatewayConfigService.getPrimaryGatewayConfig(stackDto);
+            Memory currentMemory = getClusterManagerMemory(gateway);
+            Memory requiredMemory = calcRequiredClusterManagerMemory(nodeCount);
+            if (requiredMemory.getValueInBytes() > currentMemory.getValueInBytes()) {
+                Memory availableMemory = getAvailableMemory(gateway);
+                Memory maxAllowedMemory = Memory.ofGigaBytes((int) (availableMemory.getValueInGigaBytes() * MAX_CM_MEMORY_USAGE_FACTOR));
+                if (requiredMemory.getValueInBytes() > maxAllowedMemory.getValueInBytes()) {
+                    sendWarningToUser(stackDto, requiredMemory, availableMemory);
+                    requiredMemory = maxAllowedMemory;
+                }
+
+                if (requiredMemory.getValueInBytes() > currentMemory.getValueInBytes()) {
+                    LOGGER.info("Updating cluster manager memory. Current value: {}, Target value: {}, Available memory: {}",
+                            currentMemory, requiredMemory, availableMemory);
+                    updateClusterManagerConfig(gateway, requiredMemory);
+                    restartClusterManager(gateway, stackDto);
+                    witForClusterManagerToBecomeAvailable(stackDto);
+                }
+            } else {
+                LOGGER.info("Cluster manager's configured memory {}GB is enough for {} nodes.", currentMemory, nodeCount);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error happened while tried to configure cluster manager memory.", e);
+        }
+    }
+
+    private Memory getClusterManagerMemory(GatewayConfig gatewayConfig) throws CloudbreakOrchestratorFailedException {
+        return hostOrchestrator.getClusterManagerMemory(gatewayConfig)
+                .orElseThrow(() -> new CloudbreakRuntimeException("Couldn't get cloudera manager memory."));
+    }
+
+    private void witForClusterManagerToBecomeAvailable(StackDto stackDto) throws ClusterClientInitException, CloudbreakException {
+        clusterApiConnectors.getConnector(stackDto).waitForServer(false);
+    }
+
+    private void restartClusterManager(GatewayConfig gatewayConfig, StackDto stackDto) throws CloudbreakOrchestratorException {
+        hostOrchestrator.restartClusterManagerOnMaster(
+                gatewayConfig,
+                Set.of(gatewayConfig.getHostname()),
+                ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel(stackDto.getId(), stackDto.getCluster().getId()));
+    }
+
+    private void updateClusterManagerConfig(GatewayConfig gatewayConfig, Memory requiredMemory) throws CloudbreakOrchestratorFailedException {
+        hostOrchestrator.setClusterManagerMemory(gatewayConfig, requiredMemory);
+    }
+
+    private Memory getAvailableMemory(GatewayConfig gatewayConfig) throws CloudbreakOrchestratorFailedException {
+        return hostOrchestrator.getMemoryInfo(gatewayConfig)
+                .orElseThrow(() -> new CloudbreakRuntimeException("Couldn't get memory information."))
+                .getTotalMemory();
+    }
+
+    private Memory calcRequiredClusterManagerMemory(int nodeCount) {
+        if (nodeCount < MIN_CM_MEMORY_NODE_COUNT) {
+            return FOUR_GIGABYTES;
+        }
+        if (nodeCount >= MAX_CM_MEMORY_NODE_COUNT) {
+            return THIRTY_TWO_GIGABYTES;
+        }
+        return new Memory(FOUR_GIGABYTES.getValueInBytes() * Math.floorDiv(nodeCount, ONE_HUNDRED));
+    }
+
+    private void sendWarningToUser(StackDto stackDto, Memory requiredMemory, Memory availableMemory) {
+        cloudbreakEventService.fireCloudbreakEvent(
+                stackDto.getId(),
+                Status.UPDATE_IN_PROGRESS.name(),
+                ResourceEvent.CLUSTER_SCALING_CM_MEMORY_WARNING,
+                List.of(String.format("%.2f", requiredMemory.getValueInGigaBytes()),
+                        String.format("%.2f", availableMemory.getValueInGigaBytes())));
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleService.java
@@ -56,6 +56,9 @@ public class ClusterManagerUpscaleService {
     @Inject
     private InstanceMetaDataService instanceMetaDataService;
 
+    @Inject
+    private ClusterManagerMemoryAdjuster clusterManagerMemoryAdjuster;
+
     public void upscaleClusterManager(Long stackId, Map<String, Integer> hostGroupWithAdjustment, boolean primaryGatewayChanged, boolean repair)
             throws ClusterClientInitException {
         StackDto stackDto = stackDtoService.getById(stackId);
@@ -71,6 +74,8 @@ public class ClusterManagerUpscaleService {
         }
         clusterService.updateInstancesToRunning(stackId, nodeReachabilityResult.getReachableNodes());
         clusterService.updateInstancesToZombie(stackId, nodeReachabilityResult.getUnreachableNodes());
+
+        clusterManagerMemoryAdjuster.adjustMemory(stackDto, nodeReachabilityResult.getReachableNodes().size());
 
         ClusterApi connector = clusterApiConnectors.getConnector(stackDto, clusterManagerIp);
         ExtendedPollingResult result;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerMemoryAdjusterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerMemoryAdjusterTest.java
@@ -1,0 +1,161 @@
+package com.sequenceiq.cloudbreak.core.cluster;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterClientInitException;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.Memory;
+import com.sequenceiq.cloudbreak.orchestrator.model.MemoryInfo;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
+import com.sequenceiq.cloudbreak.view.ClusterView;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterManagerMemoryAdjusterTest {
+
+    @Mock
+    private GatewayConfigService gatewayConfigService;
+
+    @Mock
+    private HostOrchestrator hostOrchestrator;
+
+    @Mock
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Mock
+    private CloudbreakEventService cloudbreakEventService;
+
+    @InjectMocks
+    private ClusterManagerMemoryAdjuster clusterManagerMemoryAdjuster;
+
+    @Mock
+    private StackDto stackDto;
+
+    @Mock
+    private ClusterView clusterView;
+
+    @Mock
+    private GatewayConfig gatewayConfig;
+
+    @Mock
+    private ClusterApi clusterApi;
+
+    @ParameterizedTest
+    @MethodSource("memoryTestData")
+    public void testMemoryAdjustment(int availableMemoryGB, int currentCMMemoryGB, int expectedNewCMMemoryGB, int nodeCount)
+            throws CloudbreakOrchestratorException, ClusterClientInitException, CloudbreakException {
+        setUpMocks(availableMemoryGB, currentCMMemoryGB);
+
+        clusterManagerMemoryAdjuster.adjustMemory(stackDto, nodeCount);
+
+        verify(hostOrchestrator).setClusterManagerMemory(gatewayConfig, Memory.ofGigaBytes(expectedNewCMMemoryGB));
+        verify(hostOrchestrator).restartClusterManagerOnMaster(
+                eq(gatewayConfig),
+                eq(Set.of("host.master0.site")),
+                any());
+        verify(clusterApi).waitForServer(false);
+    }
+
+    @Test
+    public void testMemoryIsAdjustedToTheHighestPossible() throws CloudbreakOrchestratorException, ClusterClientInitException, CloudbreakException {
+        testMemoryAdjustment(12, 2, 3, 10);
+
+        verify(cloudbreakEventService).fireCloudbreakEvent(
+                1L, "UPDATE_IN_PROGRESS", ResourceEvent.CLUSTER_SCALING_CM_MEMORY_WARNING,
+                List.of("4.00", "12.00"));
+    }
+
+    @Test
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    public void testMemoryIsNotChangedIfNoChangeISRequired() throws CloudbreakOrchestratorException {
+        setUpMocks(16, 4);
+
+        clusterManagerMemoryAdjuster.adjustMemory(stackDto, 1);
+
+        verify(hostOrchestrator, never()).setClusterManagerMemory(any(), any());
+        verify(hostOrchestrator, never()).restartClusterManagerOnMaster(any(), any(), any());
+        verify(cloudbreakEventService, never()).fireCloudbreakEvent(any(), any(), any(), any());
+    }
+
+    @Test
+    public void testMemoryChangeIsSkippedIfStackIsNotDataHub() throws CloudbreakOrchestratorException {
+        when(stackDto.getType()).thenReturn(StackType.DATALAKE);
+
+        clusterManagerMemoryAdjuster.adjustMemory(stackDto, 1);
+
+        verify(gatewayConfigService, never()).getPrimaryGatewayConfig(any());
+        verify(hostOrchestrator, never()).setClusterManagerMemory(any(), any());
+        verify(hostOrchestrator, never()).restartClusterManagerOnMaster(any(), any(), any());
+        verify(cloudbreakEventService, never()).fireCloudbreakEvent(any(), any(), any(), any());
+    }
+
+    private void setUpMocks(int availableMemoryGB, int currentCMMemoryGB) throws CloudbreakOrchestratorFailedException {
+        when(stackDto.getType()).thenReturn(StackType.WORKLOAD);
+        when(stackDto.getId()).thenReturn(1L);
+        when(stackDto.getCluster()).thenReturn(clusterView);
+        when(gatewayConfig.getHostname()).thenReturn("host.master0.site");
+        when(gatewayConfigService.getPrimaryGatewayConfig(stackDto)).thenReturn(gatewayConfig);
+        when(hostOrchestrator.getClusterManagerMemory(gatewayConfig))
+                .thenReturn(Optional.of(Memory.ofGigaBytes(currentCMMemoryGB)));
+        when(hostOrchestrator.getMemoryInfo(gatewayConfig))
+                .thenReturn(Optional.of(new MemoryInfo(Map.of("MemTotal", Map.of("value", String.valueOf(availableMemoryGB), "unit", "GB")))));
+        when(clusterApiConnectors.getConnector(stackDto)).thenReturn(clusterApi);
+    }
+
+    private static Stream<Arguments> memoryTestData() {
+        int availableMemoryGB = 256;
+        int currentCMMemoryGB = 2;
+
+        Stream.Builder<Arguments> builder = Stream.builder();
+        addTestData(builder, availableMemoryGB, currentCMMemoryGB, 1, 199, 4);
+        addTestData(builder, availableMemoryGB, currentCMMemoryGB, 200, 299, 8);
+        addTestData(builder, availableMemoryGB, currentCMMemoryGB, 300, 399, 12);
+        addTestData(builder, availableMemoryGB, currentCMMemoryGB, 400, 499, 16);
+        addTestData(builder, availableMemoryGB, currentCMMemoryGB, 500, 599, 20);
+        addTestData(builder, availableMemoryGB, currentCMMemoryGB, 600, 699, 24);
+        addTestData(builder, availableMemoryGB, currentCMMemoryGB, 700, 799, 28);
+        addTestData(builder, availableMemoryGB, currentCMMemoryGB, 800, 950, 32);
+        return builder.build();
+    }
+
+    private static void addTestData(Stream.Builder<Arguments> builder,
+            int availableMemoryGB,
+            int currentCMMemoryGB,
+            int startNodeCount,
+            int endNodeCount,
+            int expectedCMMemoryGB) {
+        for (int nodeCount = startNodeCount; nodeCount <= endNodeCount; nodeCount++) {
+            builder.add(Arguments.of(availableMemoryGB, currentCMMemoryGB, expectedCMMemoryGB, nodeCount));
+        }
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -73,6 +74,9 @@ public class ClusterManagerUpscaleServiceTest {
     @Mock
     private InstanceMetaDataService instanceMetaDataService;
 
+    @Mock
+    private ClusterManagerMemoryAdjuster clusterManagerMemoryAdjuster;
+
     @InjectMocks
     private ClusterManagerUpscaleService underTest;
 
@@ -98,6 +102,7 @@ public class ClusterManagerUpscaleServiceTest {
 
         verifyNoMoreInteractions(clusterServiceRunner);
         verify(clusterApi, times(2)).waitForHosts(any());
+        verify(clusterManagerMemoryAdjuster, times(2)).adjustMemory(eq(stackDto), anyInt());
     }
 
     @Test

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -17,6 +17,8 @@ import com.sequenceiq.cloudbreak.orchestrator.model.BootstrapParams;
 import com.sequenceiq.cloudbreak.orchestrator.model.CmAgentStopFlags;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.KeytabModel;
+import com.sequenceiq.cloudbreak.orchestrator.model.Memory;
+import com.sequenceiq.cloudbreak.orchestrator.model.MemoryInfo;
 import com.sequenceiq.cloudbreak.orchestrator.model.NodeReachabilityResult;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
 import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
@@ -161,4 +163,10 @@ public interface HostOrchestrator extends HostRecipeExecutor {
 
     void saveCustomPillars(SaltConfig saltConfig, ExitCriteriaModel exitModel, OrchestratorStateParams stateParams)
             throws CloudbreakOrchestratorFailedException;
+
+    Optional<MemoryInfo> getMemoryInfo(GatewayConfig gatewayConfig) throws CloudbreakOrchestratorFailedException;
+
+    Optional<Memory> getClusterManagerMemory(GatewayConfig gatewayConfig) throws CloudbreakOrchestratorFailedException;
+
+    void setClusterManagerMemory(GatewayConfig gatewayConfig, Memory memory) throws CloudbreakOrchestratorFailedException;
 }

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/Memory.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/Memory.java
@@ -1,0 +1,70 @@
+package com.sequenceiq.cloudbreak.orchestrator.model;
+
+import java.util.Objects;
+
+public class Memory {
+
+    private static final long KILO_BYTE = 1024;
+
+    private static final long MEGA_BYTE = (long) Math.pow(KILO_BYTE, 2);
+
+    private static final long GIGA_BYTE = (long) Math.pow(KILO_BYTE, 3);
+
+    private static final long TERA_BYTE = (long) Math.pow(KILO_BYTE, 4);
+
+    private final long valueInBytes;
+
+    public Memory(long valueInBytes) {
+        this.valueInBytes = valueInBytes;
+    }
+
+    public static Memory of(int value, String unit) {
+        if ("kb".equalsIgnoreCase(unit)) {
+            return new Memory(value * KILO_BYTE);
+        } else if ("mb".equalsIgnoreCase(unit)) {
+            return new Memory(value * MEGA_BYTE);
+        } else if ("gb".equalsIgnoreCase(unit)) {
+            return new Memory(value * GIGA_BYTE);
+        } else if ("tb".equalsIgnoreCase(unit)) {
+            return new Memory(value * TERA_BYTE);
+        }
+        throw new IllegalArgumentException("Unsupported unit '" + unit + "'");
+    }
+
+    public static Memory ofGigaBytes(int value) {
+        return of(value, "gb");
+    }
+
+    public double getValueInGigaBytes() {
+        return (double) valueInBytes / GIGA_BYTE;
+    }
+
+    public long getValueInBytes() {
+        return valueInBytes;
+    }
+
+    @Override
+    public String toString() {
+        return "Memory{" +
+                "valueInBytes=" + valueInBytes +
+                ", valueGB=" + String.format("%.2f", getValueInGigaBytes()) +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Memory memory = (Memory) o;
+        return valueInBytes == memory.valueInBytes;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(valueInBytes);
+    }
+}

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/MemoryInfo.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/MemoryInfo.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.cloudbreak.orchestrator.model;
+
+import java.util.Map;
+
+public class MemoryInfo {
+
+    private final Map<String, Map<String, String>> values;
+
+    public MemoryInfo(Map<String, Map<String, String>> values) {
+        this.values = values;
+    }
+
+    public Memory getTotalMemory() {
+        Map<String, String> memTotal = values.get("MemTotal");
+        int value = Integer.parseInt(memTotal.get("value"));
+        String unit = memTotal.get("unit").toLowerCase();
+        return Memory.of(value, unit);
+    }
+}

--- a/orchestrator-api/src/test/java/com/sequenceiq/cloudbreak/orchestrator/model/MemoryTest.java
+++ b/orchestrator-api/src/test/java/com/sequenceiq/cloudbreak/orchestrator/model/MemoryTest.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.orchestrator.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class MemoryTest {
+
+    @Test
+    public void testKiloByteConversion() {
+        assertEquals(1024, Memory.of(1, "kB").getValueInBytes());
+    }
+
+    @Test
+    public void testMegaByteConversion() {
+        assertEquals(1048576, Memory.of(1, "MB").getValueInBytes());
+    }
+
+    @Test
+    public void testGigaByteConversion() {
+        assertEquals(1073741824, Memory.of(1, "GB").getValueInBytes());
+    }
+
+    @Test
+    public void testTeraByteConversion() {
+        assertEquals(1099511627776L, Memory.of(1, "TB").getValueInBytes());
+    }
+}

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -65,6 +65,8 @@ import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.GenericResponse;
 import com.sequenceiq.cloudbreak.orchestrator.model.GenericResponses;
 import com.sequenceiq.cloudbreak.orchestrator.model.KeytabModel;
+import com.sequenceiq.cloudbreak.orchestrator.model.Memory;
+import com.sequenceiq.cloudbreak.orchestrator.model.MemoryInfo;
 import com.sequenceiq.cloudbreak.orchestrator.model.NodeReachabilityResult;
 import com.sequenceiq.cloudbreak.orchestrator.model.RecipeModel;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
@@ -523,6 +525,36 @@ public class SaltOrchestrator implements HostOrchestrator {
             saveCustomPillars(saltConfig, exitModel, stateParams.getTargetHostNames(), sc);
         } catch (Exception e) {
             LOGGER.info("Error occurred during save custom pillars", e);
+            throw new CloudbreakOrchestratorFailedException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Optional<MemoryInfo> getMemoryInfo(GatewayConfig gatewayConfig) throws CloudbreakOrchestratorFailedException {
+        try (SaltConnector sc = saltService.createSaltConnector(gatewayConfig)) {
+            return saltStateService.getMemoryInfo(sc, gatewayConfig.getHostname());
+        } catch (Exception e) {
+            LOGGER.info("Error occurred during requesting memory information", e);
+            throw new CloudbreakOrchestratorFailedException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Optional<Memory> getClusterManagerMemory(GatewayConfig gatewayConfig) throws CloudbreakOrchestratorFailedException {
+        try (SaltConnector sc = saltService.createSaltConnector(gatewayConfig)) {
+            return saltStateService.getClouderaManagerMemory(sc, gatewayConfig);
+        } catch (Exception e) {
+            LOGGER.info("Error occurred during requesting memory information", e);
+            throw new CloudbreakOrchestratorFailedException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void setClusterManagerMemory(GatewayConfig gatewayConfig, Memory memory) throws CloudbreakOrchestratorFailedException {
+        try (SaltConnector sc = saltService.createSaltConnector(gatewayConfig)) {
+            saltStateService.setClouderaManagerMemory(sc, gatewayConfig, memory);
+        } catch (Exception e) {
+            LOGGER.info("Error occurred during setting cluster manager memory", e);
             throw new CloudbreakOrchestratorFailedException(e.getMessage(), e);
         }
     }


### PR DESCRIPTION
Adjust Cloudera Manager jvm memory in case of data hub clusters based on the cluster size.

The logic works as follows:

- We get the current memory from /etc/default/cloudera-scm/server config.
- Calculate the required value based on the node count.
- If more memory is needed than the current value then we check the available memory with salt status.meminfo.
- We set CM's memory to min(available memory * 0.25, requiredMemory).
- If the required memory is less than the 25% of the available memory than we send a warning to the user to recommend a vertical scale on master host group.
- If the memory is changed than we restart CM and wait for it to become available.

Data lake clusters are not touched. CM's default 4GB memory starts to cause issues after 400+ node clusters which is not the case for any data lake shape (not even EDL).