### PR TITLE
CB-21346: Change the TTL for ranger audits to 30 days.

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-enterprise.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-enterprise.bp
@@ -177,6 +177,10 @@
               {
                 "name":"ranger.audit.solr.max.shards.per.node",
                 "value":"2"
+              },
+              {
+                "name":"ranger.audit.solr.config.ttl",
+                "value":"30"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.18/cdp-sdx-enterprise.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.18/cdp-sdx-enterprise.bp
@@ -177,7 +177,11 @@
               {
                 "name":"ranger.audit.solr.max.shards.per.node",
                 "value":"2"
-              }
+              },
+             {
+               "name":"ranger.audit.solr.config.ttl",
+               "value":"30"
+             }
             ]
           }
         ],


### PR DESCRIPTION
Changed the blueprint for enterprise data lake to hold ranger audits for last 30 days.