### PR TITLE
CDPSDX-4064 Add logging for flowChain handling

### DIFF
--- a/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
@@ -320,6 +320,7 @@ public class Flow2Handler implements Consumer<Event<? extends Payload>> {
         String flowId = UUID.randomUUID().toString();
         addFlowParameters(flowParameters, flowId, flowChainId, flowConfig);
         Flow flow = flowConfig.createFlow(flowId, flowChainId, payload.getResourceId(), flowChainType);
+        LOGGER.debug("Creating new flow {}", flow.getFlowId());
         try {
             flow.initialize(contextParams);
             runningFlows.put(flow, flowChainId);
@@ -328,6 +329,7 @@ public class Flow2Handler implements Consumer<Event<? extends Payload>> {
             transactionService.required(() -> {
                 flowLogService.save(flowParameters, flowChainId, key, payload, contextParams, flowConfig.getClass(), flow.getCurrentState());
                 if (flowChainId != null) {
+                    LOGGER.debug("Updating FlowChain [{}] when creating new flow", flowChainId);
                     flowChains.saveAllUnsavedFlowChains(flowChainId, flowParameters.getFlowTriggerUserCrn());
                     flowChains.removeLastTriggerEvent(flowChainId, flowParameters.getFlowTriggerUserCrn());
                 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/FlowChains.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/FlowChains.java
@@ -121,6 +121,7 @@ public class FlowChains {
 
     public void removeLastTriggerEvent(String flowChainId, String flowTriggerUserCrn) {
         FlowTriggerEventQueue flowTriggerEventQueue = flowChainMap.get(flowChainId);
+        LOGGER.debug("Removing LastTriggerEvent in [{}] with EventQueue: {}", flowChainId, flowTriggerEventQueue);
         if (flowTriggerEventQueue != null) {
             Queue<Selectable> queue = flowTriggerEventQueue.getQueue();
             if (queue != null) {
@@ -134,6 +135,7 @@ public class FlowChains {
 
     public void cleanFlowChain(String flowChainId, String flowTriggerUserCrn) {
         FlowTriggerEventQueue flowTriggerEventQueue = flowChainMap.get(flowChainId);
+        LOGGER.debug("Cleaning FlowChain [{}] with EventQueue: {}", flowChainId, flowTriggerEventQueue);
         if (flowTriggerEventQueue != null) {
             Queue<Selectable> queue = flowTriggerEventQueue.getQueue();
             if (queue != null) {
@@ -149,6 +151,7 @@ public class FlowChains {
             Optional<Runnable> finalizerCallback) {
         FlowTriggerEventQueue flowTriggerEventQueue = flowChainMap.get(flowChainId);
         if (flowTriggerEventQueue != null) {
+            LOGGER.info("Triggering the next flow in FlowChain [{}] with EventQueue: {}", flowChainId, flowTriggerEventQueue);
             Queue<Selectable> queue = flowTriggerEventQueue.getQueue();
             if (queue != null) {
                 Selectable selectable = queue.peek();
@@ -184,6 +187,7 @@ public class FlowChains {
     private void triggerParentFlowChain(String flowChainId, String flowTriggerUserCrn, Map<Object, Object> contextParams, String operationType,
             Optional<Runnable> finalizerCallback) {
         String parentFlowChainId = getParentFlowChainId(flowChainId);
+        LOGGER.debug("Triggering ParentFlowChain [{}] with flowChainId [{}]", parentFlowChainId, flowChainId);
         removeFlowChain(flowChainId, true);
         if (parentFlowChainId != null) {
             triggerNextFlow(parentFlowChainId, flowTriggerUserCrn, contextParams, operationType, finalizerCallback);
@@ -193,6 +197,7 @@ public class FlowChains {
     }
 
     public void saveAllUnsavedFlowChains(String flowChainId, String flowTriggerUserCrn) {
+        LOGGER.debug("Saving all unsaved FlowChains for [{}]", flowChainId);
         List<Pair<String, FlowTriggerEventQueue>> flowTriggerEventQueues = new ArrayList<>();
         while (flowChainId != null && notSavedFlowChains.contains(flowChainId)) {
             String parentFlowChainId = getParentFlowChainId(flowChainId);

--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowChainLogService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowChainLogService.java
@@ -117,7 +117,7 @@ public class FlowChainLogService {
                     .findFirst()
                     .get();
             LOGGER.debug("Checking if chain with id {} has any event in it's queue", latestFlowChain.getFlowChainId());
-            LOGGER.trace("Chain string in db: {}", latestFlowChain.getChainJackson());
+            LOGGER.debug("Chain string in db: {}", latestFlowChain.getChainJackson());
             Queue<Selectable> chain = latestFlowChain.getChainAsQueue();
             return !chain.isEmpty();
         });

--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
@@ -154,6 +154,7 @@ public class FlowLogDBService implements FlowLogService {
 
     @Override
     public void saveChain(String flowChainId, String parentFlowChainId, FlowTriggerEventQueue chain, String flowTriggerUserCrn) {
+        LOGGER.debug("Saving the FlowChain info into FlowChainLog with chain: {}", chain);
         String chainType = chain.getFlowChainName();
         String chainJackson = TypedJsonUtil.writeValueAsStringSilent(chain.getQueue());
         String triggerEventJackson = null;


### PR DESCRIPTION
JIRA: [CDPSDX-4064](https://jira.cloudera.com/browse/CDPSDX-4064)

**ISSUE:** We got database backup timeout error on mow-dev -- this only happens a few times. From the dev log in Kibana we can tell the issue is the backup is finished, but the flowchain is still active because the `chainJackson` column in `flowChainLog` is not empty (but it should be empty when backup is done). However we don't know why that column is not empty and what is in there since we don't have enough logging and we can not reproduce this error locally. Therefore, we are adding some logging there which could help us debug next time the issue happens on mow-dev. Also, it would be helpful for future debugging about flow and flowchain handling with logs.

Some log examples (using local test):

`Removing LastTriggerEvent in [76b3c4ac-b7a2-40bd-870e-696fe491050a] with EventQueue: FlowTriggerEventQueue{parentFlowChainId='null', flowChainName='BackupDatalakeDatabaseFlowEventChainFactory', triggerEvent=StackEvent{selector='DATALAKE_DATABASE_BACKUP_CHAIN_TRIGGER_EVENT', stackId=1, accepted=com.sequenceiq.cloudbreak.eventbus.Promise@2e9ce6f2}, queue=[StackEvent{selector='DATABASE_BACKUP_EVENT', stackId=1, accepted=com.sequenceiq.cloudbreak.eventbus.Promise@2e9ce6f2}]}

Triggering the next flow in FlowChain [76b3c4ac-b7a2-40bd-870e-696fe491050a] with EventQueue: FlowTriggerEventQueue{parentFlowChainId='null', flowChainName='BackupDatalakeDatabaseFlowEventChainFactory', triggerEvent=StackEvent{selector='DATALAKE_DATABASE_BACKUP_CHAIN_TRIGGER_EVENT', stackId=1, accepted=com.sequenceiq.cloudbreak.eventbus.Promise@2e9ce6f2}, queue=[StackEvent{selector='SALT_UPDATE_TRIGGER_EVENT', stackId=1, accepted=com.sequenceiq.cloudbreak.eventbus.Promise@2e9ce6f2}, StackEvent{selector='DATABASE_BACKUP_EVENT', stackId=1, accepted=com.sequenceiq.cloudbreak.eventbus.Promise@2e9ce6f2}]}

Saving all unsaved FlowChains for [76b3c4ac-b7a2-40bd-870e-696fe491050a]

Creating new flow ca35a3f9-ff0d-404f-8fe5-aacab8d6483b

Updating FlowChain [76b3c4ac-b7a2-40bd-870e-696fe491050a] when creating new flow

Chain string in db: []

Saving the FlowChain info into FlowChainLog with chain: FlowTriggerEventQueue{parentFlowChainId='null', flowChainName='BackupDatalakeDatabaseFlowEventChainFactory', triggerEvent=StackEvent{selector='DATALAKE_DATABASE_BACKUP_CHAIN_TRIGGER_EVENT', stackId=1, accepted=com.sequenceiq.cloudbreak.eventbus.Promise@2e9ce6f2}, queue=[]}
`
