### PR TITLE
Fix disappearing Gradle daemon with gradle settings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.parallel=true
 org.gradle.configureondemand=true
 org.gradle.caching=true
 org.gradle.logging.level=lifecycle
-org.gradle.jvmargs=-Xmx4096m
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.daemon=false
 
 # Version definitions have been moved to dependencies.gradle


### PR DESCRIPTION
Gradle build is called from the make file therefore we need this to be present in a central place rather than individually providing arguments to each ./gradlew call.

See detailed description in the commit message.