### PR TITLE
CB-21727: Rolling upgrade is not allowed for Enterprise shape.

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeService.java
@@ -38,7 +38,6 @@ import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.flow.SdxReactorFlowManager;
 import com.sequenceiq.datalake.service.sdx.SdxService;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
-import com.sequenceiq.sdx.api.model.SdxClusterShape;
 import com.sequenceiq.sdx.api.model.SdxUpgradeReplaceVms;
 import com.sequenceiq.sdx.api.model.SdxUpgradeRequest;
 import com.sequenceiq.sdx.api.model.SdxUpgradeResponse;
@@ -174,10 +173,9 @@ public class SdxRuntimeUpgradeService {
     }
 
     private void validateRollingUpgrade(SdxUpgradeRequest request, SdxCluster cluster) {
-        if (Boolean.TRUE.equals(request.getRollingUpgradeEnabled()) && !SdxClusterShape.MEDIUM_DUTY_HA.equals(cluster.getClusterShape())) {
-            String message = String.format("The rolling upgrade is not allowed for %s cluster shape. "
-                    + "If you want to use rolling upgrade you need to launch a Data Lake with %s cluster shape.",
-                    cluster.getClusterShape().name(), SdxClusterShape.MEDIUM_DUTY_HA.name());
+        if (Boolean.TRUE.equals(request.getRollingUpgradeEnabled()) && !cluster.getClusterShape().isHA()) {
+            String message = String.format("The rolling upgrade is not allowed for %s cluster shape.",
+                    cluster.getClusterShape().name());
             LOGGER.warn(message);
             throw new BadRequestException(message);
         }


### PR DESCRIPTION
The current code restricted rolling upgrade to Mediumduty datalake.