### PR TITLE
CB-21006 - DataHub - Flow changes to support mounting Ephemeral volumes

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
@@ -93,4 +93,12 @@ public interface ClusterModificationService {
     default void restartClusterServices() {
         throw new UnsupportedOperationException("Interface not implemented.");
     }
+
+    void stopClouderaManagerService(String serviceType) throws Exception;
+
+    void startClouderaManagerService(String serviceType) throws Exception;
+
+    Map<String, String> fetchServiceStatuses() throws Exception;
+
+    void updateServiceConfig(String serviceName, Map<String, String> config, List<String> roleGroupNames) throws CloudbreakException;
 }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerConfigService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerConfigService.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.cm;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -27,8 +28,10 @@ import com.cloudera.api.swagger.model.ApiServiceConfig;
 import com.cloudera.api.swagger.model.ApiServiceList;
 import com.cloudera.api.swagger.model.ApiVersionInfo;
 import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.type.Versioned;
+import com.sequenceiq.cloudbreak.dto.StackDtoDelegate;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 
 @Service
@@ -42,6 +45,9 @@ public class ClouderaManagerConfigService {
 
     @Inject
     private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    @Inject
+    private ClouderaManagerPollingServiceProvider clouderaManagerPollingServiceProvider;
 
     private boolean isVersionAtLeast(Versioned requiredVersion, ClouderaManagerResourceApi resourceApiInstance) throws ApiException {
         ApiVersionInfo versionInfo = resourceApiInstance.getVersion();
@@ -202,5 +208,96 @@ public class ClouderaManagerConfigService {
                 .findFirst()
                 .orElseThrow(() -> new NotFoundException(String.format("No role found with %s role type", roleType)))
                 .getName();
+    }
+
+    public ApiServiceList readServices(ApiClient client, String clusterName) throws ApiException {
+        try {
+            ServicesResourceApi servicesResourceApi = clouderaManagerApiFactory.getServicesResourceApi(client);
+            return servicesResourceApi.readServices(clusterName, DataView.SUMMARY.name());
+        } catch (ApiException e) {
+            LOGGER.error("Failed to get %s service name from Cloudera Manager.", e);
+            return new ApiServiceList();
+        }
+    }
+
+    public void stopClouderaManagerService(ApiClient client, StackDtoDelegate stack, String serviceType) throws CloudbreakException {
+        ServicesResourceApi servicesResourceApi = clouderaManagerApiFactory.getServicesResourceApi(client);
+        LOGGER.info("Trying to stop services for service type: {} for cluster {}", serviceType, stack.getName());
+        getServiceName(stack.getName(), serviceType, servicesResourceApi)
+                .ifPresentOrElse(
+                        stopServices(stack, servicesResourceApi, client),
+                        () -> {
+                            LOGGER.info("{} service name is missing, skiping stop.", serviceType);
+                            throw new ClouderaManagerOperationFailedException(String.format("Service of type: %s is not found", serviceType));
+                        });
+    }
+
+    private Consumer<String> stopServices(StackDtoDelegate stack, ServicesResourceApi servicesResourceApi, ApiClient client) {
+        ApiServiceConfig apiServiceConfig = new ApiServiceConfig();
+        return serviceName -> {
+            try {
+                servicesResourceApi.stopCommand(stack.getName(), serviceName);
+            } catch (Exception e) {
+                LOGGER.error("Failed to stop services for service type: {} for cluster {}", serviceName, stack.getName(), e);
+                throw new ClouderaManagerOperationFailedException(e.getMessage(), e);
+            }
+        };
+    }
+
+    public void startClouderaManagerService(ApiClient client, StackDtoDelegate stack, String serviceType) throws CloudbreakException {
+        ServicesResourceApi servicesResourceApi = clouderaManagerApiFactory.getServicesResourceApi(client);
+        LOGGER.info("Trying to start services for service type: {} for cluster {}", serviceType, stack.getName());
+        getServiceName(stack.getName(), serviceType, servicesResourceApi)
+                .ifPresentOrElse(
+                        startServices(stack, servicesResourceApi, client),
+                        () -> {
+                            LOGGER.info("{} service name is missing, skiping start.", serviceType);
+                            throw new ClouderaManagerOperationFailedException(String.format("Service of type: %s is not found", serviceType));
+                        });
+    }
+
+    private Consumer<String> startServices(StackDtoDelegate stack, ServicesResourceApi servicesResourceApi, ApiClient client) {
+        ApiServiceConfig apiServiceConfig = new ApiServiceConfig();
+        return serviceName -> {
+            try {
+                LOGGER.debug("Executing start command on stack {} and service {}", stack.getName(), serviceName);
+                servicesResourceApi.startCommand(stack.getName(), serviceName);
+            } catch (Exception e) {
+                LOGGER.error("Failed to start services for service type: {} for cluster {}", serviceName, stack.getName(), e);
+                throw new ClouderaManagerOperationFailedException(e.getMessage(), e);
+            }
+        };
+    }
+
+    public void modifyRoleBasedConfig(ApiClient client, String clusterName, String serviceType, Map<String, String> config,
+            List<String> roleConfigGroupName) throws CloudbreakException {
+        ServicesResourceApi servicesResourceApi = clouderaManagerApiFactory.getServicesResourceApi(client);
+        RoleConfigGroupsResourceApi roleConfigGroupsResourceApi = clouderaManagerApiFactory.getRoleConfigGroupsResourceApi(client);
+        LOGGER.info("Trying to modify config: {} for service {}", Arrays.asList(config), serviceType);
+        getServiceName(clusterName, serviceType, servicesResourceApi)
+                .ifPresentOrElse(
+                        modifyRoleBasedConfig(clusterName, roleConfigGroupsResourceApi, config, roleConfigGroupName),
+                        () -> {
+                            LOGGER.info("{} service name is missing, skip modification.", serviceType);
+                            throw new ClouderaManagerOperationFailedException(String.format("Service of type: %s is not found", serviceType));
+                        });
+    }
+
+    private Consumer<String> modifyRoleBasedConfig(String clusterName, RoleConfigGroupsResourceApi roleConfigGroupsResourceApi,
+            Map<String, String> config, List<String> roleConfigGroupNames) throws CloudbreakException  {
+        ApiConfigList apiConfigList = new ApiConfigList();
+        return serviceName -> {
+            config.forEach((key, value) -> {
+                apiConfigList.addItemsItem(new ApiConfig().name(key).value(value));
+            });
+            roleConfigGroupNames.forEach(role -> {
+                try {
+                    roleConfigGroupsResourceApi.updateConfig(clusterName, role, serviceName, "", apiConfigList);
+                } catch (ApiException e) {
+                    LOGGER.error("Failed to set configs {} for service {}", Arrays.asList(config), serviceName, e);
+                    throw new ClouderaManagerOperationFailedException(e.getMessage(), e);
+                }
+            });
+        };
     }
 }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -59,6 +59,7 @@ import com.cloudera.api.swagger.model.ApiHostNameList;
 import com.cloudera.api.swagger.model.ApiHostRef;
 import com.cloudera.api.swagger.model.ApiHostRefList;
 import com.cloudera.api.swagger.model.ApiService;
+import com.cloudera.api.swagger.model.ApiServiceList;
 import com.cloudera.api.swagger.model.ApiServiceState;
 import com.cloudera.api.swagger.model.HTTPMethod;
 import com.google.common.annotations.VisibleForTesting;
@@ -1084,5 +1085,27 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
         } else {
             LOGGER.warn("Don't run start roles command because hosts are empty");
         }
+    }
+
+    @Override
+    public void stopClouderaManagerService(String serviceType) throws Exception {
+        configService.stopClouderaManagerService(apiClient, stack, serviceType);
+    }
+
+    @Override
+    public void startClouderaManagerService(String serviceType) throws Exception {
+        configService.startClouderaManagerService(apiClient, stack, serviceType);
+    }
+
+    @Override
+    public Map<String, String> fetchServiceStatuses() throws Exception {
+        ApiServiceList serviceSummary = configService.readServices(apiClient, stack.getName());
+        return serviceSummary.getItems().stream()
+                .collect(Collectors.toMap(ApiService::getName, item -> item.getServiceState().getValue()));
+    }
+
+    @Override
+    public void updateServiceConfig(String serviceName, Map<String, String> config, List<String> roleGroupNames) throws CloudbreakException {
+        configService.modifyRoleBasedConfig(apiClient, stack.getName(), serviceName, config, roleGroupNames);
     }
 }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerConfigServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerConfigServiceTest.java
@@ -1,10 +1,14 @@
 package com.sequenceiq.cloudbreak.cm;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_1_0;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -18,15 +22,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.api.swagger.ClouderaManagerResourceApi;
 import com.cloudera.api.swagger.RoleConfigGroupsResourceApi;
@@ -42,8 +44,10 @@ import com.cloudera.api.swagger.model.ApiServiceConfig;
 import com.cloudera.api.swagger.model.ApiServiceList;
 import com.cloudera.api.swagger.model.ApiVersionInfo;
 import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
+import com.sequenceiq.cloudbreak.dto.StackDtoDelegate;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ClouderaManagerConfigServiceTest {
 
     private static final String VERSION_7_0_1 = "7.0.1";
@@ -76,6 +80,9 @@ public class ClouderaManagerConfigServiceTest {
 
     @Mock
     private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    @Mock
+    private ClouderaManagerPollingServiceProvider clouderaManagerPollingServiceProvider;
 
     @InjectMocks
     private ClouderaManagerConfigService underTest;
@@ -206,10 +213,10 @@ public class ClouderaManagerConfigServiceTest {
         when(serviceResourceApi.readServices(TEST_CLUSTER_NAME, DataView.SUMMARY.name())).thenReturn(apiServiceList);
         when(clouderaManagerApiFactory.getServicesResourceApi(any())).thenReturn(serviceResourceApi);
 
-        Exception exception = Assertions.assertThrows(
+        Exception exception = assertThrows(
                 ClouderaManagerOperationFailedException.class, ()
                         -> underTest.modifyServiceConfig(new ApiClient(), TEST_CLUSTER_NAME, hueType, Collections.singletonMap(configName, configValue)));
-        Assert.assertEquals("Service of type: HUE is not found", exception.getMessage());
+        assertEquals("Service of type: HUE is not found", exception.getMessage());
     }
 
     @Test
@@ -363,5 +370,117 @@ public class ClouderaManagerConfigServiceTest {
         configGroup.setName(configGroupName);
         configGroup.setRoleType(roleType);
         return configGroup;
+    }
+
+    @Test
+    public void testStopServiceSuccess() throws Exception {
+        String serviceType = "YARN";
+        String yarnName = "yarn-1";
+        ServicesResourceApi serviceResourceApi = mock(ServicesResourceApi.class);
+        ApiServiceList apiServiceList = new ApiServiceList().addItemsItem(new ApiService().name(yarnName).type(serviceType));
+        StackDtoDelegate stack = mock(StackDtoDelegate.class);
+        doReturn(TEST_CLUSTER_NAME).when(stack).getName();
+        when(serviceResourceApi.readServices(TEST_CLUSTER_NAME, DataView.SUMMARY.name())).thenReturn(apiServiceList);
+        when(clouderaManagerApiFactory.getServicesResourceApi(any())).thenReturn(serviceResourceApi);
+
+        underTest.stopClouderaManagerService(new ApiClient(), stack, serviceType);
+
+        verify(serviceResourceApi, times(1)).stopCommand(eq(TEST_CLUSTER_NAME), eq(yarnName));
+    }
+
+    @Test
+    public void testStopServiceNoServiceFound() throws Exception {
+        String serviceType = "YARN";
+        String yarnName = "yarn-1";
+        ServicesResourceApi serviceResourceApi = mock(ServicesResourceApi.class);
+        ApiServiceList apiServiceList = new ApiServiceList().addItemsItem(new ApiService().name(yarnName).type("HUE"));
+        StackDtoDelegate stack = mock(StackDtoDelegate.class);
+        doReturn(TEST_CLUSTER_NAME).when(stack).getName();
+        when(serviceResourceApi.readServices(TEST_CLUSTER_NAME, DataView.SUMMARY.name())).thenReturn(apiServiceList);
+        when(clouderaManagerApiFactory.getServicesResourceApi(any())).thenReturn(serviceResourceApi);
+
+        ClouderaManagerOperationFailedException exception = assertThrows(ClouderaManagerOperationFailedException.class,
+                () -> underTest.stopClouderaManagerService(new ApiClient(), stack, serviceType));
+
+        assertEquals("Service of type: YARN is not found", exception.getMessage());
+    }
+
+    @Test
+    public void testReadServices() throws ApiException {
+        ServicesResourceApi serviceResourceApi = mock(ServicesResourceApi.class);
+        ApiServiceList apiServiceList = new ApiServiceList().addItemsItem(new ApiService().name("HUE-1").type("HUE"));
+
+        when(serviceResourceApi.readServices(TEST_CLUSTER_NAME, DataView.SUMMARY.name())).thenReturn(apiServiceList);
+        when(clouderaManagerApiFactory.getServicesResourceApi(any())).thenReturn(serviceResourceApi);
+
+        ApiServiceList result = underTest.readServices(new ApiClient(), TEST_CLUSTER_NAME);
+        assertEquals("HUE-1", result.getItems().get(0).getName());
+    }
+
+    @Test
+    public void testReadServicesException() throws ApiException {
+        ServicesResourceApi serviceResourceApi = mock(ServicesResourceApi.class);
+
+        doThrow(new ApiException("TEST")).when(serviceResourceApi).readServices(TEST_CLUSTER_NAME, DataView.SUMMARY.name());
+        when(clouderaManagerApiFactory.getServicesResourceApi(any())).thenReturn(serviceResourceApi);
+
+        ApiServiceList result = underTest.readServices(new ApiClient(), TEST_CLUSTER_NAME);
+        assertNull(result.getItems());
+    }
+
+    @Test
+    public void testStartServiceSuccess() throws Exception {
+        String serviceType = "YARN";
+        String yarnName = "yarn-1";
+        ServicesResourceApi serviceResourceApi = mock(ServicesResourceApi.class);
+        ApiServiceList apiServiceList = new ApiServiceList().addItemsItem(new ApiService().name(yarnName).type(serviceType));
+        StackDtoDelegate stack = mock(StackDtoDelegate.class);
+        doReturn(TEST_CLUSTER_NAME).when(stack).getName();
+        when(serviceResourceApi.readServices(TEST_CLUSTER_NAME, DataView.SUMMARY.name())).thenReturn(apiServiceList);
+        when(clouderaManagerApiFactory.getServicesResourceApi(any())).thenReturn(serviceResourceApi);
+
+        underTest.startClouderaManagerService(new ApiClient(), stack, serviceType);
+
+        verify(serviceResourceApi, times(1)).startCommand(eq(TEST_CLUSTER_NAME), eq(yarnName));
+    }
+
+    @Test
+    public void testStartServiceNoServiceFound() throws Exception {
+        String serviceType = "YARN";
+        String yarnName = "yarn-1";
+        ServicesResourceApi serviceResourceApi = mock(ServicesResourceApi.class);
+        ApiServiceList apiServiceList = new ApiServiceList().addItemsItem(new ApiService().name(yarnName).type("HUE"));
+        StackDtoDelegate stack = mock(StackDtoDelegate.class);
+        doReturn(TEST_CLUSTER_NAME).when(stack).getName();
+        when(serviceResourceApi.readServices(TEST_CLUSTER_NAME, DataView.SUMMARY.name())).thenReturn(apiServiceList);
+        when(clouderaManagerApiFactory.getServicesResourceApi(any())).thenReturn(serviceResourceApi);
+
+        ClouderaManagerOperationFailedException exception = assertThrows(ClouderaManagerOperationFailedException.class,
+                () -> underTest.startClouderaManagerService(new ApiClient(), stack, serviceType));
+
+        assertEquals("Service of type: YARN is not found", exception.getMessage());
+    }
+
+    @Test
+    public void tesModifyRoleBasedConfigSuccess() throws Exception {
+        String serviceType = "YARN";
+        String yarnName = "yarn-1";
+        String roleName = "yarn-NODEMANAGER-WORKER";
+        ServicesResourceApi serviceResourceApi = mock(ServicesResourceApi.class);
+        RoleConfigGroupsResourceApi roleConfigGroupsResourceApi = mock(RoleConfigGroupsResourceApi.class);
+        ApiServiceList apiServiceList = new ApiServiceList().addItemsItem(new ApiService().name(yarnName).type(serviceType));
+        StackDtoDelegate stack = mock(StackDtoDelegate.class);
+        when(serviceResourceApi.readServices(TEST_CLUSTER_NAME, DataView.SUMMARY.name())).thenReturn(apiServiceList);
+        when(clouderaManagerApiFactory.getServicesResourceApi(any())).thenReturn(serviceResourceApi);
+        when(clouderaManagerApiFactory.getRoleConfigGroupsResourceApi(any())).thenReturn(roleConfigGroupsResourceApi);
+        Map<String, String> config = new HashMap<>();
+        config.put("test-config", "test-config-property");
+        ApiConfigList apiConfigList = new ApiConfigList();
+        apiConfigList.addItemsItem(new ApiConfig().name("test-config").value("test-config-property"));
+
+        underTest.modifyRoleBasedConfig(new ApiClient(), TEST_CLUSTER_NAME, serviceType, config, List.of(roleName));
+
+        verify(roleConfigGroupsResourceApi, times(1)).updateConfig(eq(TEST_CLUSTER_NAME), eq(roleName),
+                eq(yarnName), eq(""), eq(apiConfigList));
     }
 }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
@@ -1412,4 +1412,21 @@ class ClouderaManagerModificationServiceTest {
         when(clouderaManagerPollingServiceProvider.startPollingCmClientConfigDeployment(eq(stack), eq(apiClientMock), eq(deployClientCommandId)))
                 .thenReturn(success);
     }
+
+    @Test
+    public void testReadServices() throws Exception {
+        List<ApiService> services = List.of(
+                new ApiService().name("RANGER_RAZ").serviceState(ApiServiceState.STOPPED),
+                new ApiService().name("ATLAS").serviceState(ApiServiceState.STOPPED),
+                new ApiService().name("TEZ").serviceState(ApiServiceState.NA),
+                new ApiService().name("HDFS").serviceState(ApiServiceState.STOPPING));
+        when(configService.readServices(any(), anyString())).thenReturn(new ApiServiceList().items(services));
+
+        Map<String, String> results = underTest.fetchServiceStatuses();
+
+        assertEquals(4, results.size());
+        assertEquals("STOPPED", results.get("ATLAS"));
+        assertEquals("STOPPING", results.get("HDFS"));
+        assertEquals("NA", results.get("TEZ"));
+    }
 }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/InstanceStorageInfo.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/InstanceStorageInfo.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.cloudbreak.domain.stack.cluster;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class InstanceStorageInfo {
+
+    private int instanceStorageCount;
+
+    private int instanceStorageSize;
+
+    private boolean instanceStorageSupport;
+
+    @JsonCreator
+    public InstanceStorageInfo(@JsonProperty("instanceStorageSupport") boolean instanceStorageSupport,
+            @JsonProperty("instanceStorageCount") int instanceStorageCount,
+            @JsonProperty("instanceStorageSize") int instanceStorageSize) {
+        this.instanceStorageSupport = instanceStorageSupport;
+        this.instanceStorageCount = instanceStorageCount;
+        this.instanceStorageSize = instanceStorageSize;
+    }
+
+    public int getInstanceStorageCount() {
+        return instanceStorageCount;
+    }
+
+    public void setInstanceStorageCount(int instanceStorageCount) {
+        this.instanceStorageCount = instanceStorageCount;
+    }
+
+    public int getInstanceStorageSize() {
+        return instanceStorageSize;
+    }
+
+    public void setInstanceStorageSize(int instanceStorageSize) {
+        this.instanceStorageSize = instanceStorageSize;
+    }
+
+    public boolean isInstanceStorageSupport() {
+        return instanceStorageSupport;
+    }
+
+    public void setInstanceStorageSupport(boolean instanceStorageSupport) {
+        this.instanceStorageSupport = instanceStorageSupport;
+    }
+
+    public String toString() {
+        return "InstaceStorageInfo{" +
+                "instanceStorageCount=" + instanceStorageCount +
+                "instanceStorageSize=" + instanceStorageSize +
+                "instanceStorageSupport=" + instanceStorageSupport + '}';
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/StackDto.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/StackDto.java
@@ -163,6 +163,10 @@ public class StackDto implements OrchestratorAware, StackDtoDelegate, MdcContext
         return network;
     }
 
+    public Map<String, InstanceGroupDto> getInstanceGroups() {
+        return instanceGroups;
+    }
+
     public Set<Resource> getResources() {
         if (resources == null) {
             throw new NotImplementedException("Resource fetch are disabled");

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/PillarConfigUpdateService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/PillarConfigUpdateService.java
@@ -53,7 +53,7 @@ public class PillarConfigUpdateService {
                 .fireEventAndLog(stackId, UPDATE_IN_PROGRESS.name(),
                         CLUSTER_PILLAR_CONFIG_UPDATE_STARTED);
         StackDto stackDto = stackDtoService.getById(stackId);
-        clusterHostServiceRunner.updateClusterConfigs(stackDto);
+        clusterHostServiceRunner.updateClusterConfigs(stackDto, false);
     }
 
     public void configUpdateFinished(Long stackId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/verticalscale/BlackListedLoadBasedVerticalScaleRole.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/verticalscale/BlackListedLoadBasedVerticalScaleRole.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale;
+
+public enum BlackListedLoadBasedVerticalScaleRole {
+    DATANODE,
+    ZEPPELIN_SERVER,
+    KAFKA_BROKER,
+    SCHEMA_REGISTRY_SERVER,
+    STREAMS_MESSAGING_MANAGER_SERVER,
+    // The following item means Zookeeper server.
+    SERVER,
+    NIFI_NODE,
+    NAMENODE,
+    STATESTORE,
+    CATALOGSERVER,
+    KUDU_MASTER,
+    KUDU_TSERVER,
+    SOLR_SERVER,
+    NIFI_REGISTRY_SERVER,
+    HUE_LOAD_BALANCER,
+    KNOX_GATEWAY
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/verticalscale/CoreVerticalScaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/verticalscale/CoreVerticalScaleActions.java
@@ -36,13 +36,17 @@ import com.sequenceiq.cloudbreak.core.flow2.stack.AbstractStackFailureAction;
 import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
 import com.sequenceiq.cloudbreak.core.flow2.stack.StackFailureContext;
 import com.sequenceiq.cloudbreak.domain.Resource;
+import com.sequenceiq.cloudbreak.dto.InstanceGroupDto;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.resource.CoreVerticalScalePreparationRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.resource.CoreVerticalScalePreparationResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.CoreVerticalScaleRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.CoreVerticalScaleResult;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.util.StackUtil;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @Configuration
 public class CoreVerticalScaleActions {
@@ -66,20 +70,24 @@ public class CoreVerticalScaleActions {
     @Inject
     private ResourceToCloudResourceConverter cloudResourceConverter;
 
-    @Bean(name = "STACK_VERTICALSCALE_STATE")
-    public Action<?, ?> stackVerticalScale() {
+    @Bean(name = "STACK_PREPARATION_STATE")
+    public Action<?, ?> stackPreparation() {
         return new AbstractClusterAction<>(CoreVerticalScalingTriggerEvent.class) {
             @Override
-            protected void doExecute(ClusterViewContext ctx, CoreVerticalScalingTriggerEvent payload, Map<Object, Object> variables) {
+            protected void doExecute(ClusterViewContext ctx, CoreVerticalScalingTriggerEvent payload, Map<Object, Object> variables)
+                    throws Exception {
                 StackVerticalScaleV4Request stackVerticalScaleV4Request = payload.getRequest();
-                coreVerticalScaleService.verticalScale(ctx.getStackId(), stackVerticalScaleV4Request);
                 StackDto stack = stackDtoService.getById(payload.getResourceId());
-                Set<Resource> resources = stack.getResources();
-                List<CloudResource> cloudResources =
-                        resources.stream().map(resource -> cloudResourceConverter.convert(resource)).collect(Collectors.toList());
+                InstanceGroupDto instanceGroup = stack.getInstanceGroupDtos().stream()
+                        .filter(instance -> null != instance.getInstanceGroup().getGroupName() &&
+                                instance.getInstanceGroup().getGroupName().equals(stackVerticalScaleV4Request.getGroup()))
+                        .findFirst().get();
+                LOGGER.debug("Updating status of stack for vertical scale.");
+                coreVerticalScaleService.verticalScale(ctx.getStackId(), stackVerticalScaleV4Request);
+                List<CloudResource> cloudResources = stack.getResources().stream().map(s -> cloudResourceConverter.convert(s))
+                        .collect(Collectors.toList());
                 CloudCredential cloudCredential = stackUtil.getCloudCredential(stack.getEnvironmentCrn());
-                CloudStack cloudStack = cloudStackConverter.convert(stack);
-                cloudStack = cloudStackConverter.updateWithVerticalScaleRequest(cloudStack, stackVerticalScaleV4Request);
+
                 Location location = location(region(stack.getRegion()), availabilityZone(stack.getAvailabilityZone()));
                 CloudContext cloudContext = CloudContext.Builder.builder()
                         .withId(stack.getId())
@@ -91,12 +99,57 @@ public class CoreVerticalScaleActions {
                         .withWorkspaceId(stack.getWorkspace().getId())
                         .withAccountId(Crn.safeFromString(stack.getResourceCrn()).getAccountId())
                         .build();
+                CoreVerticalScalePreparationRequest request = new CoreVerticalScalePreparationRequest(
+                        cloudContext,
+                        cloudCredential,
+                        null,
+                        stack,
+                        instanceGroup,
+                        cloudResources,
+                        stackVerticalScaleV4Request);
+                sendEvent(ctx, request);
+            }
+        };
+    }
 
-                CoreVerticalScaleRequest request = new CoreVerticalScaleRequest(cloudContext,
+    @Bean(name = "STACK_VERTICALSCALE_STATE")
+    public Action<?, ?> stackVerticalScale() {
+        return new AbstractClusterAction<>(CoreVerticalScalePreparationResult.class) {
+            @Override
+            protected void doExecute(ClusterViewContext ctx, CoreVerticalScalePreparationResult payload, Map<Object, Object> variables)
+                    throws Exception {
+                StackVerticalScaleV4Request stackVerticalScaleV4Request = payload.getStackVerticalScaleV4Request();
+                StackDto stack = stackDtoService.getById(payload.getResourceId());
+                InstanceGroupDto instanceGroup = stack.getInstanceGroupDtos().stream()
+                        .filter(instance -> null != instance.getInstanceGroup().getGroupName() &&
+                                instance.getInstanceGroup().getGroupName().equals(stackVerticalScaleV4Request.getGroup()))
+                        .findFirst().get();
+                Set<Resource> resources = stack.getResources();
+                LOGGER.debug("Converting stack resources to cloud resources.");
+                List<CloudResource> cloudResources =
+                        resources.stream().map(resource -> cloudResourceConverter.convert(resource)).collect(Collectors.toList());
+                CloudCredential cloudCredential = payload.getCloudCredential();
+                if (!stack.isStackInStopPhase()) {
+                    LOGGER.debug("Removing groups that aren't being vertically scaled from stack to convert to cloud stack.");
+                    stack.getInstanceGroupDtos().stream()
+                            .filter(instance -> !instance.getInstanceGroup().getGroupName().equals(stackVerticalScaleV4Request.getGroup())
+                                    && !instance.getInstanceGroup().getInstanceGroupType().equals(InstanceGroupType.GATEWAY))
+                            .map(instance -> instance.getInstanceGroup().getGroupName()).forEach(group -> stack.getInstanceGroups().remove(group));
+                }
+                CloudStack cloudStack = cloudStackConverter.convert(stack);
+                cloudStack = cloudStackConverter.updateWithVerticalScaleRequest(cloudStack, stackVerticalScaleV4Request);
+                CloudContext cloudContext = payload.getCloudContext();
+
+                CoreVerticalScaleRequest request = new CoreVerticalScaleRequest(stack,
+                        instanceGroup,
+                        payload.getGroupServiceComponents(),
+                        payload.getInstanceStorageInfo(),
+                        cloudContext,
                         cloudCredential,
                         cloudStack,
                         cloudResources,
-                        stackVerticalScaleV4Request);
+                        stackVerticalScaleV4Request,
+                        payload.getHostTemplateRoleGroupNames());
                 sendEvent(ctx, request);
             }
         };
@@ -107,8 +160,10 @@ public class CoreVerticalScaleActions {
         return new AbstractClusterAction<>(CoreVerticalScaleResult.class) {
             @Override
             protected void doExecute(ClusterViewContext context, CoreVerticalScaleResult payload, Map<Object, Object> variables) {
-                coreVerticalScaleService.updateTemplateWithVerticalScaleInformation(context.getStackId(), payload.getStackVerticalScaleV4Request());
-                coreVerticalScaleService.finishVerticalScale(context.getStackId(), payload.getStackVerticalScaleV4Request());
+                coreVerticalScaleService.updateTemplateWithVerticalScaleInformation(context.getStackId(), payload.getStackVerticalScaleV4Request(),
+                        payload.getInstanceStoreInfo());
+                StackDto stack = stackDtoService.getById(payload.getResourceId());
+                coreVerticalScaleService.finishVerticalScale(context.getStackId(), payload.getStackVerticalScaleV4Request(), stack.isStackInStopPhase());
                 sendEvent(context);
             }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/verticalscale/CoreVerticalScaleEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/verticalscale/CoreVerticalScaleEvent.java
@@ -1,11 +1,16 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale;
 
+import com.sequenceiq.cloudbreak.reactor.api.event.resource.CoreVerticalScalePreparationRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.resource.CoreVerticalScalePreparationResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.CoreVerticalScaleResult;
 import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 
 public enum CoreVerticalScaleEvent implements FlowEvent {
     STACK_VERTICALSCALE_EVENT("STACK_VERTICAL_SCALE_TRIGGER_EVENT"),
+    STACK_VERTICALSCALE_PREPARATION_EVENT(EventSelectorUtil.selector(CoreVerticalScalePreparationRequest.class)),
+    STACK_VERTICALSCALE_PREPARATION_FINISHED_EVENT(EventSelectorUtil.selector(CoreVerticalScalePreparationResult.class)),
+    STACK_VERTICALSCALE_PREPARATION_FAILURE_EVENT(EventSelectorUtil.failureSelector(CoreVerticalScalePreparationResult.class)),
     STACK_VERTICALSCALE_FINISHED_EVENT(EventSelectorUtil.selector(CoreVerticalScaleResult.class)),
     STACK_VERTICALSCALE_FINISHED_FAILURE_EVENT(EventSelectorUtil.failureSelector(CoreVerticalScaleResult.class)),
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/verticalscale/CoreVerticalScaleFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/verticalscale/CoreVerticalScaleFlowConfig.java
@@ -10,8 +10,11 @@ import static com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.CoreVer
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.CoreVerticalScaleEvent.STACK_VERTICALSCALE_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.CoreVerticalScaleEvent.STACK_VERTICALSCALE_FINISHED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.CoreVerticalScaleEvent.STACK_VERTICALSCALE_FINISHED_FAILURE_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.CoreVerticalScaleEvent.STACK_VERTICALSCALE_PREPARATION_FAILURE_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.CoreVerticalScaleEvent.STACK_VERTICALSCALE_PREPARATION_FINISHED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.CoreVerticalScaleState.FINAL_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.CoreVerticalScaleState.INIT_STATE;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.CoreVerticalScaleState.STACK_PREPARATION_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.CoreVerticalScaleState.STACK_VERTICALSCALE_FAILED_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.CoreVerticalScaleState.STACK_VERTICALSCALE_FINISHED_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.CoreVerticalScaleState.STACK_VERTICALSCALE_STATE;
@@ -34,9 +37,14 @@ public class CoreVerticalScaleFlowConfig extends StackStatusFinalizerAbstractFlo
             new Builder<CoreVerticalScaleState, CoreVerticalScaleEvent>()
 
                     .from(INIT_STATE)
-                    .to(STACK_VERTICALSCALE_STATE)
+                    .to(STACK_PREPARATION_STATE)
                     .event(STACK_VERTICALSCALE_EVENT)
                     .noFailureEvent()
+
+                    .from(STACK_PREPARATION_STATE)
+                    .to(STACK_VERTICALSCALE_STATE)
+                    .event(STACK_VERTICALSCALE_PREPARATION_FINISHED_EVENT)
+                    .failureEvent(STACK_VERTICALSCALE_PREPARATION_FAILURE_EVENT)
 
                     .from(STACK_VERTICALSCALE_STATE)
                     .to(STACK_VERTICALSCALE_FINISHED_STATE)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/verticalscale/CoreVerticalScaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/verticalscale/CoreVerticalScaleService.java
@@ -3,29 +3,69 @@ package com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_VERTICALSCALED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_VERTICALSCALING;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.dyngr.Polling;
+import com.dyngr.core.AttemptResults;
 import com.google.common.base.Strings;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackVerticalScaleV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.template.InstanceTemplateV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.template.volume.VolumeV4Request;
+import com.sequenceiq.cloudbreak.cloud.CloudConnector;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
+import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
+import com.sequenceiq.cloudbreak.converter.spi.InstanceMetaDataToCloudInstanceConverter;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
 import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
 import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.InstanceStorageInfo;
+import com.sequenceiq.cloudbreak.dto.InstanceGroupDto;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
 import com.sequenceiq.cloudbreak.service.template.TemplateService;
+import com.sequenceiq.cloudbreak.template.model.ServiceComponent;
 import com.sequenceiq.cloudbreak.view.InstanceGroupView;
+import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
 
 @Service
 public class CoreVerticalScaleService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CoreVerticalScaleService.class);
+
+    private static final int MAX_READ_COUNT = 15;
+
+    private static final int SLEEP_INTERVAL = 10;
+
+    private static final String YARN_LOCAL_DIR = "yarn_nodemanager_local_dirs";
+
+    private static final String YARN_LOG_DIR = "yarn_nodemanager_log_dirs";
+
+    private static final String IMPALA_SCRATCH_DIR = "scratch_dirs";
+
+    private static final String IMPALA_DATACACHE_DIR = "datacache_dirs";
+
     @Inject
     private ClusterService clusterService;
 
@@ -38,7 +78,17 @@ public class CoreVerticalScaleService {
     @Inject
     private CloudbreakFlowMessageService flowMessageService;
 
+    @Inject
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Inject
+    private InstanceMetaDataToCloudInstanceConverter instanceMetaDataToCloudInstanceConverter;
+
+    @Inject
+    private ClusterHostServiceRunner clusterHostServiceRunner;
+
     public void verticalScale(Long stackId, StackVerticalScaleV4Request payload) {
+        LOGGER.debug("Updating stack status to Update in Progress.");
         flowMessageService.fireEventAndLog(stackId,
                 Status.UPDATE_IN_PROGRESS.name(),
                 CLUSTER_VERTICALSCALING,
@@ -46,8 +96,9 @@ public class CoreVerticalScaleService {
                 payload.getTemplate().getInstanceType());
     }
 
-    public void finishVerticalScale(Long stackId, StackVerticalScaleV4Request payload) {
-        clusterService.updateClusterStatusByStackId(stackId, DetailedStackStatus.STOPPED);
+    public void finishVerticalScale(Long stackId, StackVerticalScaleV4Request payload, boolean stackStopped) {
+        DetailedStackStatus statusToUpdate = stackStopped ? DetailedStackStatus.STOPPED : DetailedStackStatus.AVAILABLE;
+        clusterService.updateClusterStatusByStackId(stackId, statusToUpdate);
         flowMessageService.fireEventAndLog(stackId,
                 Status.STOPPED.name(),
                 CLUSTER_VERTICALSCALED,
@@ -55,7 +106,9 @@ public class CoreVerticalScaleService {
                 payload.getTemplate().getInstanceType());
     }
 
-    public void updateTemplateWithVerticalScaleInformation(Long stackId, StackVerticalScaleV4Request stackVerticalScaleV4Request) {
+    public void updateTemplateWithVerticalScaleInformation(Long stackId, StackVerticalScaleV4Request stackVerticalScaleV4Request,
+            List<InstanceStorageInfo> instanceStoreInfo) {
+        LOGGER.debug("Updating stack template and saving it to CBDB.");
         Optional<InstanceGroupView> optionalGroup = instanceGroupService
                 .findInstanceGroupViewByStackIdAndGroupName(stackId, stackVerticalScaleV4Request.getGroup());
         if (optionalGroup.isPresent() && stackVerticalScaleV4Request.getTemplate() != null) {
@@ -70,6 +123,7 @@ public class CoreVerticalScaleService {
                 Integer rootVolumeSize = requestedTemplate.getRootVolume().getSize();
                 template.setRootVolumeSize(rootVolumeSize);
             }
+            setTemporaryStorageOnTemplate(template, instanceStoreInfo);
             Set<VolumeV4Request> requestedAttachedVolumes = requestedTemplate.getAttachedVolumes();
             if (requestedAttachedVolumes != null) {
                 for (VolumeTemplate volumeTemplateInTheDatabase : template.getVolumeTemplates()) {
@@ -83,5 +137,135 @@ public class CoreVerticalScaleService {
             }
             templateService.savePure(template);
         }
+    }
+
+    public void stopClouderaManagerServicesAndUpdateClusterConfigs(StackDto stackDto, Set<ServiceComponent> hostTemplateServiceComponents,
+            List<InstanceStorageInfo> instanceStorageInfo) throws Exception {
+        ClusterApi clusterApi = clusterApiConnectors.getConnector(stackDto);
+        for (ServiceComponent serviceComponent : hostTemplateServiceComponents) {
+            try {
+                LOGGER.debug("Stopping CM service {}, in stack {}", serviceComponent.getService(), stackDto.getId());
+                clusterApi.clusterModificationService().stopClouderaManagerService(serviceComponent.getService());
+                pollClouderaManagerServices(clusterApi, serviceComponent.getService(), "STOPPED");
+            } catch (Exception e) {
+                LOGGER.error("Unable to stop CM services for service {}, in stack {}", serviceComponent.getService(), stackDto.getId());
+                throw new Exception(String.format("Unable to stop CM services for " +
+                        "service %s, in stack %s: %s", serviceComponent.getService(), stackDto.getId(), e.getMessage()));
+            }
+        }
+        InMemoryStateStore.putStack(stackDto.getId(), PollGroup.POLLABLE);
+        LOGGER.debug("Redeploying states to the gateway node.");
+        clusterHostServiceRunner.redeployStates(stackDto);
+        LOGGER.debug("Updating salt, pillar configs for the stack and pushing it to the group nodes.");
+        clusterHostServiceRunner.updateClusterConfigs(stackDto, true);
+        InMemoryStateStore.deleteStack(stackDto.getId());
+    }
+
+    public void updateClouderaManagerConfigsForComputeGroupAndStartServices(StackDto stackDto, Set<ServiceComponent> hostTemplateServiceComponents,
+            List<InstanceStorageInfo> instanceStorageInfo, List<String> roleGroupNames) throws Exception {
+        ClusterApi clusterApi = clusterApiConnectors.getConnector(stackDto);
+        for (ServiceComponent serviceComponent : hostTemplateServiceComponents) {
+            try {
+                LOGGER.debug("Updating CM service config for service {}, in stack {} for roles {}", serviceComponent.getService(),
+                        stackDto.getId(), roleGroupNames);
+                clusterApi.clusterModificationService().updateServiceConfig(serviceComponent.getService(),
+                    getConfigsForService(instanceStorageInfo, stackDto, serviceComponent.getService()), roleGroupNames);
+                LOGGER.debug("Starting CM service {}, in stack {}", serviceComponent.getService(), stackDto.getId());
+                clusterApi.clusterModificationService().startClouderaManagerService(serviceComponent.getService());
+                pollClouderaManagerServices(clusterApi, serviceComponent.getService(), "STARTED");
+            } catch (Exception e) {
+                LOGGER.error("Unable to start CM services for service {}, in stack {}", serviceComponent.getService(), stackDto.getId());
+                throw new Exception(String.format("Unable to start CM services for " +
+                        "service %s, in stack %s: %s", serviceComponent.getService(), stackDto.getId(), e.getMessage()));
+            }
+        }
+    }
+
+    public void stopInstances(CloudConnector connector, List<CloudResource> resources, InstanceGroupDto instanceGroup,
+            StackDto stackDto, AuthenticatedContext ac) {
+        List<String> instancesToBeStopped = instanceGroup.getInstanceMetadataViews().stream()
+                .map(InstanceMetadataView::getInstanceId).collect(Collectors.toList());
+        List<CloudInstance> cloudInstancesToBeStopped = instanceMetaDataToCloudInstanceConverter.convert(List.of(instanceGroup),
+                stackDto.getEnvironmentCrn(), stackDto.getStackAuthentication());
+        List<CloudResource> resourceToBeStopped = resources.stream()
+                .filter(cr -> instancesToBeStopped.contains(cr.getInstanceId()))
+                .collect(Collectors.toList());
+        LOGGER.debug("Stopping cloud resources {}, in stack {}", resources, stackDto.getId());
+        connector.instances().stop(ac, resourceToBeStopped, cloudInstancesToBeStopped);
+    }
+
+    public void startInstances(CloudConnector connector, List<CloudResource> resources, InstanceGroupDto instanceGroup,
+            StackDto stackDto, AuthenticatedContext ac) {
+        List<String> instancesToBeStarted = instanceGroup.getInstanceMetadataViews().stream()
+                .map(InstanceMetadataView::getInstanceId).collect(Collectors.toList());
+        List<CloudInstance> cloudInstancesToBeStarted = instanceMetaDataToCloudInstanceConverter.convert(List.of(instanceGroup),
+                stackDto.getEnvironmentCrn(), stackDto.getStackAuthentication());
+        List<CloudResource> resourceToBeStarted = resources.stream()
+                .filter(cr -> instancesToBeStarted.contains(cr.getInstanceId()))
+                .collect(Collectors.toList());
+        LOGGER.debug("Starting cloud resources {}, in stack {}", resources, stackDto.getId());
+        connector.instances().start(ac, resourceToBeStarted, cloudInstancesToBeStarted);
+    }
+
+    private Map<String, String> getConfigsForService(List<InstanceStorageInfo> instanceStorageInfo,
+            StackDto stackDto, String service) {
+        LOGGER.debug("Building configs to be updated for service {} in CM", service);
+        Map<String, String> config = new HashMap<>();
+        StringBuilder localMountPaths = new StringBuilder();
+        StringBuilder logMountPaths = new StringBuilder();
+        if (instanceStorageInfo != null && !instanceStorageInfo.isEmpty()) {
+            int instanceStorageCount = instanceStorageInfo.get(0).getInstanceStorageCount();
+            int count = 1;
+            while (instanceStorageCount > 0) {
+                if ("YARN".equalsIgnoreCase(service)) {
+                    localMountPaths.append("/hadoopfs/ephfs").append(count).append("/nodemanager");
+                    logMountPaths.append("/hadoopfs/ephfs").append(count).append("/nodemanager/log");
+                } else if ("IMPALA".equalsIgnoreCase(service)) {
+                    localMountPaths.append("/hadoopfs/ephfs").append(count).append("/impala/scratch");
+                    logMountPaths.append("/hadoopfs/ephfs").append(count).append("/impala/datacache");
+                }
+                if (instanceStorageCount - 1 > 0) {
+                    localMountPaths.append(',');
+                    logMountPaths.append(',');
+                }
+                count++;
+                instanceStorageCount--;
+            }
+        }
+        if ("YARN".equalsIgnoreCase(service)) {
+            config.put(YARN_LOCAL_DIR, localMountPaths.toString());
+            config.put(YARN_LOG_DIR, logMountPaths.toString());
+        } else if ("IMPALA".equalsIgnoreCase(service)) {
+            config.put(IMPALA_SCRATCH_DIR, localMountPaths.toString());
+            config.put(IMPALA_DATACACHE_DIR, logMountPaths.toString());
+        }
+        LOGGER.debug("Configs {} to be updated for service {} in CM", config, service);
+        return config;
+    }
+
+    private void setTemporaryStorageOnTemplate(Template template, List<InstanceStorageInfo> instanceStoreInfo) {
+        LOGGER.debug("Setting temporary storage on stack and attached number of disks.");
+        if (instanceStoreInfo != null && !instanceStoreInfo.isEmpty()) {
+            template.setTemporaryStorage(TemporaryStorage.EPHEMERAL_VOLUMES);
+            template.setInstanceStorageCount(instanceStoreInfo.get(0).getInstanceStorageCount());
+            template.setInstanceStorageSize(instanceStoreInfo.get(0).getInstanceStorageSize());
+        } else {
+            template.setTemporaryStorage(TemporaryStorage.ATTACHED_VOLUMES);
+            template.setInstanceStorageCount(0);
+            template.setInstanceStorageSize(0);
+        }
+    }
+
+    private void pollClouderaManagerServices(ClusterApi clusterApi, String service, String status) throws Exception {
+        LOGGER.debug("Starting polling on CM Service {} to check if {}", service, status);
+        Polling.waitPeriodly(SLEEP_INTERVAL, TimeUnit.SECONDS).stopIfException(true).stopAfterAttempt(MAX_READ_COUNT)
+            .run(() -> {
+                LOGGER.debug("Polling CM Service {} to check if {}", service, status);
+                Map<String, String> readResults = clusterApi.clusterModificationService().fetchServiceStatuses();
+                if (status.equals(readResults.get(service.toLowerCase()))) {
+                    return AttemptResults.justFinish();
+                }
+                return AttemptResults.justContinue();
+            });
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/verticalscale/CoreVerticalScaleState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/verticalscale/CoreVerticalScaleState.java
@@ -6,8 +6,8 @@ import com.sequenceiq.flow.core.RestartAction;
 
 public enum CoreVerticalScaleState implements FlowState {
     INIT_STATE,
+    STACK_PREPARATION_STATE,
     STACK_VERTICALSCALE_FAILED_STATE,
-
     STACK_VERTICALSCALE_STATE,
     STACK_VERTICALSCALE_FINISHED_STATE,
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/CoreVerticalScaleHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/CoreVerticalScaleHandler.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.reactor;
 
 import java.util.List;
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -17,11 +18,15 @@ import com.sequenceiq.cloudbreak.cloud.handler.CloudPlatformEventHandler;
 import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.CoreVerticalScaleService;
 import com.sequenceiq.cloudbreak.core.flow2.stack.upscale.StackUpscaleService;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.InstanceStorageInfo;
+import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.eventbus.Event;
 import com.sequenceiq.cloudbreak.eventbus.EventBus;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.CoreVerticalScaleRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.CoreVerticalScaleResult;
+import com.sequenceiq.cloudbreak.template.model.ServiceComponent;
 
 @Component
 public class CoreVerticalScaleHandler implements CloudPlatformEventHandler<CoreVerticalScaleRequest> {
@@ -37,6 +42,9 @@ public class CoreVerticalScaleHandler implements CloudPlatformEventHandler<CoreV
     @Inject
     private StackUpscaleService stackUpscaleService;
 
+    @Inject
+    private CoreVerticalScaleService coreVerticalScaleService;
+
     @Override
     public Class<CoreVerticalScaleRequest> type() {
         return CoreVerticalScaleRequest.class;
@@ -46,18 +54,29 @@ public class CoreVerticalScaleHandler implements CloudPlatformEventHandler<CoreV
     public void accept(Event<CoreVerticalScaleRequest> stackVerticalScaleRequestEvent) {
         LOGGER.debug("Received event: {}", stackVerticalScaleRequestEvent);
         CoreVerticalScaleRequest<CoreVerticalScaleResult> request = stackVerticalScaleRequestEvent.getData();
+        StackDto stackDto = request.getStack();
         CloudContext cloudContext = request.getCloudContext();
         StackVerticalScaleV4Request stackVerticalScaleV4Request = request.getStackVerticalScaleV4Request();
+        String datahubCrn = cloudContext.getCrn();
         try {
             CloudConnector connector = cloudPlatformConnectors.get(cloudContext.getPlatformVariant());
             AuthenticatedContext ac = getAuthenticatedContext(request, cloudContext, connector);
             List<CloudResourceStatus> resourceStatus = stackUpscaleService.verticalScale(ac, request, connector);
+            List<InstanceStorageInfo> instanceStorageInfo = request.getInstanceStorageInfo();
+            if (!stackDto.isStackInStopPhase()) {
+                Set<ServiceComponent> hostTemplateServiceComponents = request.getGroupServiceComponents();
+                coreVerticalScaleService.startInstances(connector, request.getResourceList(), request.getInstanceGroup(),
+                        stackDto, ac);
+                coreVerticalScaleService.updateClouderaManagerConfigsForComputeGroupAndStartServices(stackDto, hostTemplateServiceComponents,
+                        instanceStorageInfo, request.getHostTemplateRoleGroupNames());
+            }
             LOGGER.info("Vertical scaling resource statuses: {}", resourceStatus);
             CoreVerticalScaleResult result = new CoreVerticalScaleResult(
                     request.getResourceId(),
                     ResourceStatus.UPDATED,
                     resourceStatus,
-                    stackVerticalScaleV4Request);
+                    stackVerticalScaleV4Request,
+                    instanceStorageInfo);
             request.getResult().onNext(result);
             eventBus.notify(result.selector(), new Event<>(stackVerticalScaleRequestEvent.getHeaders(), result));
             LOGGER.debug("Vertical scaling successfully finished for {}, and the result is: {}", cloudContext, result);
@@ -78,5 +97,4 @@ public class CoreVerticalScaleHandler implements CloudPlatformEventHandler<CoreV
             CloudContext cloudContext, CloudConnector connector) {
         return connector.authentication().authenticate(cloudContext, request.getCloudCredential());
     }
-
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CoreVerticalScalePreparationRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CoreVerticalScalePreparationRequest.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.resource;
+
+import java.util.List;
+import java.util.StringJoiner;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackVerticalScaleV4Request;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.event.resource.CloudStackRequest;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.dto.InstanceGroupDto;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+
+public class CoreVerticalScalePreparationRequest extends CloudStackRequest {
+
+    private final StackDto stack;
+
+    private final InstanceGroupDto instanceGroup;
+
+    private final List<CloudResource> cloudResources;
+
+    private final StackVerticalScaleV4Request stackVerticalScaleV4Request;
+
+    public CoreVerticalScalePreparationRequest(
+            @JsonProperty("cloudContext") CloudContext cloudContext,
+            @JsonProperty("cloudCredential") CloudCredential cloudCredential,
+            @JsonProperty("cloudStack") CloudStack cloudStack,
+            @JsonProperty("stack") StackDto stack,
+            @JsonProperty("instanceGroup") InstanceGroupDto instanceGroup,
+            @JsonProperty("cloudResources") List<CloudResource> cloudResources,
+            @JsonProperty("stackVerticalScaleV4Request") StackVerticalScaleV4Request stackVerticalScaleV4Request) {
+        super(cloudContext, cloudCredential, cloudStack);
+        this.stack = stack;
+        this.instanceGroup = instanceGroup;
+        this.cloudResources = cloudResources;
+        this.stackVerticalScaleV4Request = stackVerticalScaleV4Request;
+    }
+
+    public StackVerticalScaleV4Request getStackVerticalScaleV4Request() {
+        return stackVerticalScaleV4Request;
+    }
+
+    public InstanceGroupDto getInstanceGroup() {
+        return instanceGroup;
+    }
+
+    public List<CloudResource> getCloudResources() {
+        return cloudResources;
+    }
+
+    public StackDto getStack() {
+        return stack;
+    }
+
+    public String toString() {
+        return new StringJoiner(", ", CoreVerticalScalePreparationRequest.class.getSimpleName() + "[", "]")
+                .add("stackDto=" + stack)
+                .add("instanceGroup=" + instanceGroup)
+                .add("cloudResources=" + cloudResources)
+                .add("stackVerticalScaleV4Request=" + stackVerticalScaleV4Request)
+                .toString();
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CoreVerticalScalePreparationResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CoreVerticalScalePreparationResult.java
@@ -1,0 +1,105 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.resource;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringJoiner;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackVerticalScaleV4Request;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.InstanceStorageInfo;
+import com.sequenceiq.cloudbreak.template.model.ServiceComponent;
+
+public class CoreVerticalScalePreparationResult extends CloudPlatformResult implements FlowPayload {
+
+    private final List<InstanceStorageInfo> instanceStorageInfo;
+
+    private final StackVerticalScaleV4Request stackVerticalScaleV4Request;
+
+    private final Set<ServiceComponent> groupServiceComponents;
+
+    private final CloudContext cloudContext;
+
+    private final CloudCredential cloudCredential;
+
+    private final CloudStack cloudStack;
+
+    private final List<String> hostTemplateRoleGroupNames;
+
+    @JsonCreator
+    public CoreVerticalScalePreparationResult(
+            @JsonProperty("groupServiceComponents") Set<ServiceComponent> groupServiceComponents,
+            @JsonProperty("instanceStorageInfo") List<InstanceStorageInfo> instanceStorageInfo,
+            @JsonProperty("cloudContext") CloudContext cloudContext,
+            @JsonProperty("cloudCredential") CloudCredential cloudCredential,
+            @JsonProperty("cloudStack") CloudStack stack,
+            @JsonProperty("stackVerticalScaleV4Request") StackVerticalScaleV4Request stackVerticalScaleV4Request,
+            @JsonProperty("hostTemplateRoleGroupNames") List<String> hostTemplateRoleGroupNames) {
+        super(stackVerticalScaleV4Request.getStackId());
+        this.groupServiceComponents = groupServiceComponents;
+        this.instanceStorageInfo = instanceStorageInfo;
+        this.stackVerticalScaleV4Request = stackVerticalScaleV4Request;
+        this.cloudContext = cloudContext;
+        this.cloudCredential = cloudCredential;
+        this.cloudStack = stack;
+        this.hostTemplateRoleGroupNames = hostTemplateRoleGroupNames;
+    }
+
+    public CoreVerticalScalePreparationResult(String statusReason, Exception ex, StackVerticalScaleV4Request stackVerticalScaleV4Request) {
+        super(statusReason, ex, stackVerticalScaleV4Request.getStackId());
+        this.stackVerticalScaleV4Request = stackVerticalScaleV4Request;
+        groupServiceComponents = new HashSet<>();
+        instanceStorageInfo = new ArrayList<>();
+        hostTemplateRoleGroupNames = new ArrayList<>();
+        cloudContext = null;
+        cloudCredential = null;
+        cloudStack = null;
+    }
+
+    public StackVerticalScaleV4Request getStackVerticalScaleV4Request() {
+        return stackVerticalScaleV4Request;
+    }
+
+    public List<InstanceStorageInfo> getInstanceStorageInfo() {
+        return instanceStorageInfo;
+    }
+
+    public Set<ServiceComponent> getGroupServiceComponents() {
+        return groupServiceComponents;
+    }
+
+    public CloudContext getCloudContext() {
+        return cloudContext;
+    }
+
+    public CloudCredential getCloudCredential() {
+        return cloudCredential;
+    }
+
+    public CloudStack getCloudStack() {
+        return cloudStack;
+    }
+
+    public List<String> getHostTemplateRoleGroupNames() {
+        return hostTemplateRoleGroupNames;
+    }
+
+    public String toString() {
+        return new StringJoiner(", ", CoreVerticalScalePreparationResult.class.getSimpleName() + '[', "]")
+                .add("instanceStorageInfo=" + instanceStorageInfo)
+                .add("groupServiceComponents=" + groupServiceComponents)
+                .add("stackVerticalScaleV4Request=" + stackVerticalScaleV4Request)
+                .add("cloudStack=" + cloudStack)
+                .add("cloudCredential=" + cloudCredential)
+                .add("cloudContext=" + cloudContext)
+                .add("hostTemplateRoleGroupNames=" + hostTemplateRoleGroupNames)
+                .toString();
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CoreVerticalScaleRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CoreVerticalScaleRequest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
 import java.util.List;
+import java.util.Set;
 import java.util.StringJoiner;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -10,22 +11,45 @@ import com.sequenceiq.cloudbreak.cloud.event.resource.CloudStackRequest;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.InstanceStorageInfo;
+import com.sequenceiq.cloudbreak.dto.InstanceGroupDto;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.template.model.ServiceComponent;
 
 public class CoreVerticalScaleRequest<T> extends CloudStackRequest<T> {
+
+    private final StackDto stack;
+
+    private final Set<ServiceComponent> groupServiceComponents;
+
+    private final List<InstanceStorageInfo> instanceStorageInfo;
 
     private final List<CloudResource> resourceList;
 
     private final StackVerticalScaleV4Request stackVerticalScaleV4Request;
 
-    public CoreVerticalScaleRequest(
+    private final InstanceGroupDto instanceGroup;
+
+    private final List<String> hostTemplateRoleGroupNames;
+
+    public CoreVerticalScaleRequest(@JsonProperty("stack") StackDto stackDto,
+            @JsonProperty("instanceGroup") InstanceGroupDto instanceGroup,
+            @JsonProperty("groupServiceComponents") Set<ServiceComponent> groupServiceComponents,
+            @JsonProperty("instanceStorageInfo") List<InstanceStorageInfo> instanceStorageInfo,
             @JsonProperty("cloudContext") CloudContext cloudContext,
             @JsonProperty("cloudCredential") CloudCredential cloudCredential,
             @JsonProperty("stack") CloudStack stack,
             @JsonProperty("resourceList") List<CloudResource> resourceList,
-            @JsonProperty("stackVerticalScaleV4Request") StackVerticalScaleV4Request stackVerticalScaleV4Request) {
+            @JsonProperty("stackVerticalScaleV4Request") StackVerticalScaleV4Request stackVerticalScaleV4Request,
+            @JsonProperty("hostTemplateRoleGroupNames") List<String> hostTemplateRoleGroupNames) {
         super(cloudContext, cloudCredential, stack);
+        this.stack = stackDto;
+        this.groupServiceComponents = groupServiceComponents;
+        this.instanceStorageInfo = instanceStorageInfo;
         this.resourceList = resourceList;
         this.stackVerticalScaleV4Request = stackVerticalScaleV4Request;
+        this.instanceGroup = instanceGroup;
+        this.hostTemplateRoleGroupNames = hostTemplateRoleGroupNames;
     }
 
     public List<CloudResource> getResourceList() {
@@ -36,10 +60,35 @@ public class CoreVerticalScaleRequest<T> extends CloudStackRequest<T> {
         return stackVerticalScaleV4Request;
     }
 
+    public Set<ServiceComponent> getGroupServiceComponents() {
+        return groupServiceComponents;
+    }
+
+    public InstanceGroupDto getInstanceGroup() {
+        return instanceGroup;
+    }
+
+    public StackDto getStack() {
+        return stack;
+    }
+
+    public List<InstanceStorageInfo> getInstanceStorageInfo() {
+        return instanceStorageInfo;
+    }
+
+    public List<String> getHostTemplateRoleGroupNames() {
+        return hostTemplateRoleGroupNames;
+    }
+
     @Override
     public String toString() {
-        return new StringJoiner(", ", CoreVerticalScaleRequest.class.getSimpleName() + "[", "]")
+        return new StringJoiner(", ", CoreVerticalScaleRequest.class.getSimpleName() + '[', "]")
+                .add("stackDto=" + stack)
                 .add("resourceList=" + resourceList)
+                .add("groupServiceComponents=" + groupServiceComponents)
+                .add("instanceStorageInfo=" + instanceStorageInfo)
+                .add("instanceGroup=" + instanceGroup)
+                .add("hostTemplateRoleGroupNames=" + hostTemplateRoleGroupNames)
                 .toString();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CoreVerticalScaleResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CoreVerticalScaleResult.java
@@ -10,6 +10,7 @@ import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
 import com.sequenceiq.cloudbreak.common.event.FlowPayload;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.InstanceStorageInfo;
 
 public class CoreVerticalScaleResult extends CloudPlatformResult implements FlowPayload {
 
@@ -19,16 +20,20 @@ public class CoreVerticalScaleResult extends CloudPlatformResult implements Flow
 
     private final StackVerticalScaleV4Request stackVerticalScaleV4Request;
 
+    private final List<InstanceStorageInfo> instanceStoreInfo;
+
     @JsonCreator
     public CoreVerticalScaleResult(
             @JsonProperty("resourceId") Long resourceId,
             @JsonProperty("resourceStatus") ResourceStatus resourceStatus,
             @JsonProperty("results") List<CloudResourceStatus> results,
-            @JsonProperty("stackVerticalScaleV4Request") StackVerticalScaleV4Request stackVerticalScaleV4Request) {
+            @JsonProperty("stackVerticalScaleV4Request") StackVerticalScaleV4Request stackVerticalScaleV4Request,
+            @JsonProperty("instanceStoreInfo") List<InstanceStorageInfo> instanceStoreInfo) {
         super(resourceId);
         this.resourceStatus = resourceStatus;
         this.results = results;
         this.stackVerticalScaleV4Request = stackVerticalScaleV4Request;
+        this.instanceStoreInfo = instanceStoreInfo;
     }
 
     public CoreVerticalScaleResult(String statusReason, Exception errorDetails, Long resourceId,
@@ -37,6 +42,7 @@ public class CoreVerticalScaleResult extends CloudPlatformResult implements Flow
         this.resourceStatus = ResourceStatus.FAILED;
         this.stackVerticalScaleV4Request = stackVerticalScaleV4Request;
         this.results = new ArrayList<>();
+        this.instanceStoreInfo = new ArrayList<>();
     }
 
     public List<CloudResourceStatus> getResults() {
@@ -53,5 +59,9 @@ public class CoreVerticalScaleResult extends CloudPlatformResult implements Flow
 
     public StackVerticalScaleV4Request getStackVerticalScaleV4Request() {
         return stackVerticalScaleV4Request;
+    }
+
+    public List<InstanceStorageInfo> getInstanceStoreInfo() {
+        return instanceStoreInfo;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/UpdateServiceConfigHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/UpdateServiceConfigHandler.java
@@ -81,7 +81,7 @@ public class UpdateServiceConfigHandler extends ExceptionCatcherEventHandler<Upd
             ClusterApi clusterApi = clusterApiConnectors.getConnector(stackDto);
             clusterApi.clusterModificationService().updateServiceConfigAndRestartService(HUE_SERVICE, HUE_KNOX_PROXYHOSTS, String.join(",", proxyhosts));
             LOGGER.debug("Updating CM frontend URL with load balancer DNS");
-            clusterHostServiceRunner.updateClusterConfigs(stackDto);
+            clusterHostServiceRunner.updateClusterConfigs(stackDto, false);
             LOGGER.debug("Service config update was successful");
             return new UpdateServiceConfigSuccess(stack.getId());
         } catch (Exception e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/CoreVerticalScalePreparationHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/CoreVerticalScalePreparationHandler.java
@@ -1,0 +1,130 @@
+package com.sequenceiq.cloudbreak.reactor.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.CloudConnector;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.cloud.handler.CloudPlatformEventHandler;
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStoreMetadata;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.CoreVerticalScaleService;
+import com.sequenceiq.cloudbreak.domain.Template;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.InstanceStorageInfo;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.eventbus.Event;
+import com.sequenceiq.cloudbreak.eventbus.EventBus;
+import com.sequenceiq.cloudbreak.reactor.api.event.resource.CoreVerticalScalePreparationRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.resource.CoreVerticalScalePreparationResult;
+import com.sequenceiq.cloudbreak.template.model.ServiceComponent;
+
+@Component
+public class CoreVerticalScalePreparationHandler implements CloudPlatformEventHandler<CoreVerticalScalePreparationRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CoreVerticalScalePreparationHandler.class);
+
+    @Inject
+    private CmTemplateProcessorFactory cmTemplateProcessorFactory;
+
+    @Inject
+    private CloudPlatformConnectors cloudPlatformConnectors;
+
+    @Inject
+    private EventBus eventBus;
+
+    @Inject
+    private CoreVerticalScaleService coreVerticalScaleService;
+
+    @Override
+    public Class<CoreVerticalScalePreparationRequest> type() {
+        return CoreVerticalScalePreparationRequest.class;
+    }
+
+    @Override
+    public void accept(Event<CoreVerticalScalePreparationRequest> coreVerticalScalePreparationRequestEvent) {
+        CoreVerticalScalePreparationRequest request = coreVerticalScalePreparationRequestEvent.getData();
+        try {
+            CloudContext ctx = request.getCloudContext();
+            CloudConnector connector = cloudPlatformConnectors.get(ctx.getPlatformVariant());
+            AuthenticatedContext ac = getAuthenticatedContext(request.getCloudCredential(), ctx, connector);
+            String requestGroup = request.getStackVerticalScaleV4Request().getGroup();
+            String requestInstanceType = request.getStackVerticalScaleV4Request().getTemplate().getInstanceType();
+            InstanceStoreMetadata instanceStoreMetadata = connector.metadata().collectInstanceStorageCount(ac,
+                    List.of(requestInstanceType));
+            List<InstanceStorageInfo> instanceStorageInfoList = convert(instanceStoreMetadata, requestInstanceType);
+            StackDto stackDto = request.getStack();
+            Template template = stackDto.getInstanceGroupDtos().stream()
+                    .filter(instance -> instance.getInstanceGroup().getGroupName().equals(requestGroup))
+                    .findFirst().get().getInstanceGroup().getTemplate();
+            setTemporaryStorageOnTemplate(template, instanceStorageInfoList);
+            String blueprintText = stackDto.getBlueprint().getBlueprintText();
+            CmTemplateProcessor processor = cmTemplateProcessorFactory.get(blueprintText);
+            Set<ServiceComponent> hostTemplateServiceComponents = processor.getServiceComponentsByHostGroup().get(requestGroup);
+            List<String> hostTemplateRoleGroupNames = processor.getHostTemplateRoleNames(requestGroup);
+            if (!stackDto.isStackInStopPhase()) {
+                coreVerticalScaleService.stopClouderaManagerServicesAndUpdateClusterConfigs(stackDto, hostTemplateServiceComponents,
+                        instanceStorageInfoList);
+                coreVerticalScaleService.stopInstances(connector, request.getCloudResources(), request.getInstanceGroup(),
+                        stackDto, ac);
+            }
+            CoreVerticalScalePreparationResult result = new CoreVerticalScalePreparationResult(hostTemplateServiceComponents,
+                    instanceStorageInfoList,
+                    ctx,
+                    request.getCloudCredential(),
+                    request.getCloudStack(),
+                    request.getStackVerticalScaleV4Request(),
+                    hostTemplateRoleGroupNames);
+            request.getResult().onNext(result);
+            eventBus.notify(result.selector(), new Event<>(coreVerticalScalePreparationRequestEvent.getHeaders(), result));
+            LOGGER.debug("Vertical scaling Preparation successfully finished for {}, and the result is: {}", ctx, result);
+        } catch (Exception e) {
+            LOGGER.error("Vertical scaling Preparation error: ", e);
+            CoreVerticalScalePreparationResult result = new CoreVerticalScalePreparationResult(
+                    e.getMessage(),
+                    e,
+                    request.getStackVerticalScaleV4Request());
+            request.getResult().onNext(result);
+            eventBus.notify(CloudPlatformResult.failureSelector(CoreVerticalScalePreparationResult.class),
+                    new Event<>(coreVerticalScalePreparationRequestEvent.getHeaders(), result));
+        }
+    }
+
+    private AuthenticatedContext getAuthenticatedContext(CloudCredential cloudCredential,
+            CloudContext cloudContext, CloudConnector connector) {
+        return connector.authentication().authenticate(cloudContext, cloudCredential);
+    }
+
+    private void setTemporaryStorageOnTemplate(Template template, List<InstanceStorageInfo> instanceStoreInfo) {
+        if (instanceStoreInfo != null && !instanceStoreInfo.isEmpty()) {
+            template.setTemporaryStorage(TemporaryStorage.EPHEMERAL_VOLUMES);
+            template.setInstanceStorageCount(instanceStoreInfo.get(0).getInstanceStorageCount());
+            template.setInstanceStorageSize(instanceStoreInfo.get(0).getInstanceStorageSize());
+        } else {
+            template.setTemporaryStorage(TemporaryStorage.ATTACHED_VOLUMES);
+            template.setInstanceStorageCount(0);
+            template.setInstanceStorageSize(0);
+        }
+    }
+
+    private List<InstanceStorageInfo> convert(InstanceStoreMetadata instanceStoreMetadata, String requestInstanceType) {
+        List<InstanceStorageInfo> instanceStorageInfoList = new ArrayList<>();
+        Integer instanceStorageCount = instanceStoreMetadata.mapInstanceTypeToInstanceStoreCountNullHandled(requestInstanceType);
+        Integer instanceStorageSize = instanceStoreMetadata.mapInstanceTypeToInstanceSizeNullHandled(requestInstanceType);
+        instanceStorageInfoList.add(new InstanceStorageInfo(instanceStorageCount > 0, instanceStorageCount,
+                instanceStorageSize));
+        return instanceStorageInfoList;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
@@ -317,7 +317,7 @@ public class StackCommonService {
     }
 
     private void validateVerticalScalingRequest(Stack stack, StackVerticalScaleV4Request verticalScaleV4Request) {
-        verticalScalingValidatorService.validateProvider(stack);
+        verticalScalingValidatorService.validateProvider(stack, verticalScaleV4Request);
         verticalScalingValidatorService.validateRequest(stack, verticalScaleV4Request);
         verticalScalingValidatorService.validateInstanceType(stack, verticalScaleV4Request);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/VerticalScalingValidatorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/VerticalScalingValidatorService.java
@@ -1,12 +1,14 @@
 package com.sequenceiq.cloudbreak.service;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Service;
 
+import com.google.common.base.Enums;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackVerticalScaleV4Request;
@@ -15,13 +17,16 @@ import com.sequenceiq.cloudbreak.cloud.model.ExtendedCloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.VmType;
 import com.sequenceiq.cloudbreak.cloud.service.CloudParameterCache;
 import com.sequenceiq.cloudbreak.cloud.service.CloudParameterService;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.converter.spi.CredentialToExtendedCloudCredentialConverter;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.BlackListedLoadBasedVerticalScaleRole;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.dto.credential.Credential;
 import com.sequenceiq.cloudbreak.service.environment.credential.CredentialClientService;
 import com.sequenceiq.cloudbreak.service.verticalscale.VerticalScaleInstanceProvider;
+import com.sequenceiq.cloudbreak.template.processor.BlueprintTextProcessor;
 import com.sequenceiq.common.api.type.CdpResourceType;
 
 @Service
@@ -42,13 +47,30 @@ public class VerticalScalingValidatorService {
     @Inject
     private CloudParameterCache cloudParameterCache;
 
-    public void validateProvider(Stack stack) {
+    @Inject
+    private CmTemplateProcessorFactory cmTemplateProcessorFactory;
+
+    public void validateProvider(Stack stack, StackVerticalScaleV4Request verticalScaleV4Request) {
         if (!cloudParameterCache.isVerticalScalingSupported(stack.getCloudPlatform())) {
             throw new BadRequestException(String.format("Vertical scaling is not supported on %s cloudplatform", stack.getCloudPlatform()));
         }
-        if (!stack.isStopped()) {
+        if (!stack.isStopped() && !validateHostGroup(stack, verticalScaleV4Request)) {
             throw new BadRequestException(String.format("You must stop %s to be able to vertically scale it.", stack.getName()));
         }
+    }
+
+    public boolean validateHostGroup(Stack stack, StackVerticalScaleV4Request stackVerticalScaleV4Request) {
+        String blueprintText = stack.getBlueprint().getBlueprintText();
+        BlueprintTextProcessor processor = cmTemplateProcessorFactory.get(blueprintText);
+        Set<String> hostTemplateComponents = processor.getComponentsInHostGroup(stackVerticalScaleV4Request.getGroup());
+        for (String service : hostTemplateComponents) {
+            com.google.common.base.Optional<BlackListedLoadBasedVerticalScaleRole> enumValue =
+                    Enums.getIfPresent(BlackListedLoadBasedVerticalScaleRole.class, service);
+            if (enumValue.isPresent()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public void validateRequest(Stack stack, StackVerticalScaleV4Request verticalScaleV4Request) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/verticalscale/CoreVerticalScaleServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/verticalscale/CoreVerticalScaleServiceTest.java
@@ -1,0 +1,167 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterModificationService;
+import com.sequenceiq.cloudbreak.converter.spi.InstanceMetaDataToCloudInstanceConverter;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
+import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.InstanceStorageInfo;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
+import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
+import com.sequenceiq.cloudbreak.service.template.TemplateService;
+import com.sequenceiq.cloudbreak.template.model.ServiceComponent;
+
+@ExtendWith(MockitoExtension.class)
+public class CoreVerticalScaleServiceTest {
+
+    private static final String YARN_LOCAL_DIR = "yarn_nodemanager_local_dirs";
+
+    private static final String YARN_LOG_DIR = "yarn_nodemanager_log_dirs";
+
+    private static final String IMPALA_SCRATCH_DIR = "scratch_dirs";
+
+    private static final String IMPALA_DATACACHE_DIR = "datacache_dirs";
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private InstanceGroupService instanceGroupService;
+
+    @Mock
+    private TemplateService templateService;
+
+    @Mock
+    private CloudbreakFlowMessageService flowMessageService;
+
+    @Mock
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Mock
+    private InstanceMetaDataToCloudInstanceConverter instanceMetaDataToCloudInstanceConverter;
+
+    @Mock
+    private ClusterHostServiceRunner clusterHostServiceRunner;
+
+    @InjectMocks
+    private CoreVerticalScaleService underTest;
+
+    @Mock
+    private StackDto stackDto;
+
+    @Mock
+    private ClusterApi clusterApi;
+
+    @Mock
+    private ClusterModificationService clusterModificationService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        doReturn(clusterApi).when(clusterApiConnectors).getConnector(stackDto);
+        doReturn(clusterModificationService).when(clusterApi).clusterModificationService();
+    }
+
+    @Test
+    public void testStopClouderaManagerServicesAndUpdateClusterConfigsSuccess() throws Exception {
+        Map<String, String> serviceStatuses = new HashMap<>();
+        serviceStatuses.put("yarn", "STOPPED");
+        doReturn(serviceStatuses).when(clusterModificationService).fetchServiceStatuses();
+        Set<ServiceComponent> hostTemplateServiceComponents = new HashSet<>();
+        ServiceComponent serviceComponent = ServiceComponent.of("yarn", "yarn");
+        hostTemplateServiceComponents.add(serviceComponent);
+        doReturn(1L).when(stackDto).getId();
+
+        underTest.stopClouderaManagerServicesAndUpdateClusterConfigs(stackDto, hostTemplateServiceComponents,
+                new ArrayList<>());
+
+        verify(clusterModificationService, times(1)).stopClouderaManagerService(eq("yarn"));
+        verify(clusterModificationService, times(1)).fetchServiceStatuses();
+        verify(clusterHostServiceRunner, times(1)).updateClusterConfigs(eq(stackDto), eq(true));
+    }
+
+    @Test
+    public void testStopClouderaManagerServicesAndUpdateClusterConfigsException() throws Exception {
+        Set<ServiceComponent> hostTemplateServiceComponents = new HashSet<>();
+        ServiceComponent serviceComponent = ServiceComponent.of("yarn", "yarn");
+        hostTemplateServiceComponents.add(serviceComponent);
+        doThrow(new Exception("Test")).when(clusterModificationService).stopClouderaManagerService(eq("yarn"));
+        doReturn(1L).when(stackDto).getId();
+
+        Exception exception = assertThrows(Exception.class, () -> underTest.stopClouderaManagerServicesAndUpdateClusterConfigs(stackDto,
+                hostTemplateServiceComponents, new ArrayList<>()));
+
+        assertEquals("Unable to stop CM services for service yarn, in stack 1: Test", exception.getMessage());
+    }
+
+    @Test
+    public void testUpdateClouderaManagerConfigsForComputeGroupAndStartServices() throws Exception {
+        Map<String, String> serviceStatuses = new HashMap<>();
+        serviceStatuses.put("yarn", "STARTED");
+        doReturn(serviceStatuses).when(clusterModificationService).fetchServiceStatuses();
+
+        Set<ServiceComponent> hostTemplateServiceComponents = new HashSet<>();
+        ServiceComponent serviceComponent = ServiceComponent.of("yarn", "yarn");
+        hostTemplateServiceComponents.add(serviceComponent);
+
+        Map<String, String> config = new HashMap<>();
+        config.put(YARN_LOCAL_DIR, "/hadoopfs/ephfs1/nodemanager");
+        config.put(YARN_LOG_DIR, "/hadoopfs/ephfs1/nodemanager/log");
+
+        List<InstanceStorageInfo> instanceStorageInfo = List.of(new InstanceStorageInfo(true, 1, 100));
+        List<String> roleGroupNames = List.of("YARN");
+
+        underTest.updateClouderaManagerConfigsForComputeGroupAndStartServices(stackDto, hostTemplateServiceComponents, instanceStorageInfo,
+                roleGroupNames);
+
+        verify(clusterModificationService, times(1)).updateServiceConfig(eq("yarn"), eq(config), eq(roleGroupNames));
+        verify(clusterModificationService, times(1)).startClouderaManagerService("yarn");
+        verify(clusterModificationService, times(1)).fetchServiceStatuses();
+    }
+
+    @Test
+    public void testUpdateClouderaManagerConfigsForComputeException() throws Exception {
+        doReturn(1L).when(stackDto).getId();
+        Set<ServiceComponent> hostTemplateServiceComponents = new HashSet<>();
+        ServiceComponent serviceComponent = ServiceComponent.of("yarn", "yarn");
+        hostTemplateServiceComponents.add(serviceComponent);
+
+        Map<String, String> config = new HashMap<>();
+        config.put(YARN_LOCAL_DIR, "/hadoopfs/ephfs1/nodemanager");
+        config.put(YARN_LOG_DIR, "/hadoopfs/ephfs1/nodemanager/log");
+
+        doThrow(new Exception("Test")).when(clusterModificationService).startClouderaManagerService("yarn");
+
+        List<InstanceStorageInfo> instanceStorageInfo = List.of(new InstanceStorageInfo(true, 1, 100));
+        List<String> roleGroupNames = List.of("YARN");
+
+        Exception exception = assertThrows(Exception.class, () -> underTest.updateClouderaManagerConfigsForComputeGroupAndStartServices(stackDto,
+                hostTemplateServiceComponents, instanceStorageInfo, roleGroupNames));
+
+        verify(clusterModificationService, times(1)).updateServiceConfig(eq("yarn"), eq(config), eq(roleGroupNames));
+        assertEquals("Unable to start CM services for service yarn, in stack 1: Test", exception.getMessage());
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/CoreVerticalScaleHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/CoreVerticalScaleHandlerTest.java
@@ -1,0 +1,161 @@
+package com.sequenceiq.cloudbreak.reactor.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackVerticalScaleV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.template.InstanceTemplateV4Request;
+import com.sequenceiq.cloudbreak.cloud.Authenticator;
+import com.sequenceiq.cloudbreak.cloud.CloudConnector;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.CoreVerticalScaleService;
+import com.sequenceiq.cloudbreak.core.flow2.stack.upscale.StackUpscaleService;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.InstanceStorageInfo;
+import com.sequenceiq.cloudbreak.dto.InstanceGroupDto;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.eventbus.Event;
+import com.sequenceiq.cloudbreak.eventbus.EventBus;
+import com.sequenceiq.cloudbreak.reactor.CoreVerticalScaleHandler;
+import com.sequenceiq.cloudbreak.reactor.api.event.resource.CoreVerticalScaleRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.resource.CoreVerticalScaleResult;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+
+@ExtendWith(MockitoExtension.class)
+public class CoreVerticalScaleHandlerTest {
+
+    @Mock
+    private CloudPlatformConnectors cloudPlatformConnectors;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private StackUpscaleService stackUpscaleService;
+
+    @Mock
+    private CoreVerticalScaleService coreVerticalScaleService;
+
+    @InjectMocks
+    private CoreVerticalScaleHandler underTest;
+
+    @Mock
+    private CloudContext cloudContext;
+
+    @Mock
+    private CloudCredential cloudCredential;
+
+    @Mock
+    private StackDto stackDto;
+
+    @Mock
+    private InstanceGroupDto instanceGroupDto;
+
+    @Mock
+    private CloudResource cloudResource;
+
+    @Mock
+    private CloudConnector cloudConnector;
+
+    @Mock
+    private Authenticator authenticator;
+
+    @Mock
+    private AuthenticatedContext authenticatedContext;
+
+    @Mock
+    private CloudStack cloudStack;
+
+    @Test
+    public void testSuccessfulVerticalScale() throws Exception {
+        StackVerticalScaleV4Request stackVerticalScaleV4Request = new StackVerticalScaleV4Request();
+        InstanceTemplateV4Request instanceTemplate = new InstanceTemplateV4Request();
+        instanceTemplate.setInstanceType("r5ad.4xlarge");
+        stackVerticalScaleV4Request.setGroup("compute");
+        stackVerticalScaleV4Request.setTemplate(instanceTemplate);
+        InstanceStorageInfo instanceStorageInfo = new InstanceStorageInfo(true, 2, 100);
+        CoreVerticalScaleRequest request = new CoreVerticalScaleRequest(stackDto,
+                instanceGroupDto,
+                Set.of("r5ad.4xlarge"),
+                List.of(instanceStorageInfo),
+                cloudContext,
+                cloudCredential,
+                cloudStack,
+                List.of(cloudResource),
+                stackVerticalScaleV4Request,
+                List.of("compute"));
+
+        doReturn("RESOURCE_CRN").when(cloudContext).getCrn();
+
+        doReturn(cloudConnector).when(cloudPlatformConnectors).get(any());
+        doReturn(authenticator).when(cloudConnector).authentication();
+        doReturn(authenticatedContext).when(authenticator).authenticate(any(), any());
+        CloudResourceStatus resourceStatus = mock(CloudResourceStatus.class);
+        doReturn(List.of(resourceStatus)).when(stackUpscaleService).verticalScale(authenticatedContext, request, cloudConnector);
+        doReturn(false).when(stackDto).isStackInStopPhase();
+
+        underTest.accept(new Event<>(request));
+
+        verify(coreVerticalScaleService).updateClouderaManagerConfigsForComputeGroupAndStartServices(eq(stackDto), any(), any(), any());
+        verify(coreVerticalScaleService).startInstances(eq(cloudConnector), eq(List.of(cloudResource)), eq(request.getInstanceGroup()),
+                eq(stackDto), eq(authenticatedContext));
+        verify(eventBus).notify(eq(EventSelectorUtil.selector(CoreVerticalScaleResult.class)), any());
+    }
+
+    @Test
+    public void testFailureVerticalScale() throws Exception {
+        StackVerticalScaleV4Request stackVerticalScaleV4Request = new StackVerticalScaleV4Request();
+        InstanceTemplateV4Request instanceTemplate = new InstanceTemplateV4Request();
+        instanceTemplate.setInstanceType("r5ad.4xlarge");
+        stackVerticalScaleV4Request.setGroup("compute");
+        stackVerticalScaleV4Request.setTemplate(instanceTemplate);
+        InstanceStorageInfo instanceStorageInfo = new InstanceStorageInfo(true, 2, 100);
+        CoreVerticalScaleRequest request = new CoreVerticalScaleRequest(stackDto,
+                instanceGroupDto,
+                Set.of("r5ad.4xlarge"),
+                List.of(instanceStorageInfo),
+                cloudContext,
+                cloudCredential,
+                cloudStack,
+                List.of(cloudResource),
+                stackVerticalScaleV4Request,
+                List.of("compute"));
+
+        doReturn("RESOURCE_CRN").when(cloudContext).getCrn();
+
+        doReturn(cloudConnector).when(cloudPlatformConnectors).get(any());
+        doReturn(authenticator).when(cloudConnector).authentication();
+        doReturn(authenticatedContext).when(authenticator).authenticate(any(), any());
+        CloudResourceStatus resourceStatus = mock(CloudResourceStatus.class);
+        doReturn(List.of(resourceStatus)).when(stackUpscaleService).verticalScale(authenticatedContext, request, cloudConnector);
+        doReturn(false).when(stackDto).isStackInStopPhase();
+
+        doThrow(new Exception("TEST")).when(coreVerticalScaleService).updateClouderaManagerConfigsForComputeGroupAndStartServices(eq(stackDto),
+                any(), any(), any());
+
+        underTest.accept(new Event<>(request));
+
+        verify(coreVerticalScaleService).updateClouderaManagerConfigsForComputeGroupAndStartServices(eq(stackDto), any(), any(), any());
+        verify(eventBus).notify(eq(CloudPlatformResult.failureSelector(CoreVerticalScaleResult.class)), any());
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/CoreVerticalScalePreparationHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/CoreVerticalScalePreparationHandlerTest.java
@@ -1,0 +1,177 @@
+package com.sequenceiq.cloudbreak.reactor.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackVerticalScaleV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.template.InstanceTemplateV4Request;
+import com.sequenceiq.cloudbreak.cloud.Authenticator;
+import com.sequenceiq.cloudbreak.cloud.CloudConnector;
+import com.sequenceiq.cloudbreak.cloud.MetadataCollector;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStoreMetadata;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.verticalscale.CoreVerticalScaleService;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.Template;
+import com.sequenceiq.cloudbreak.dto.InstanceGroupDto;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.eventbus.Event;
+import com.sequenceiq.cloudbreak.eventbus.EventBus;
+import com.sequenceiq.cloudbreak.reactor.api.event.resource.CoreVerticalScalePreparationRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.resource.CoreVerticalScalePreparationResult;
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+import com.sequenceiq.cloudbreak.view.InstanceGroupView;
+import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+
+@ExtendWith(MockitoExtension.class)
+public class CoreVerticalScalePreparationHandlerTest {
+
+    @Mock
+    private CmTemplateProcessorFactory cmTemplateProcessorFactory;
+
+    @Mock
+    private CloudPlatformConnectors cloudPlatformConnectors;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private CoreVerticalScaleService coreVerticalScaleService;
+
+    @InjectMocks
+    private CoreVerticalScalePreparationHandler underTest;
+
+    @Mock
+    private CloudContext cloudContext;
+
+    @Mock
+    private CloudCredential cloudCredential;
+
+    @Mock
+    private StackDto stackDto;
+
+    @Mock
+    private InstanceGroupDto instanceGroupDto;
+
+    @Mock
+    private CloudResource cloudResource;
+
+    @Mock
+    private CloudConnector cloudConnector;
+
+    @Mock
+    private Authenticator authenticator;
+
+    @Mock
+    private AuthenticatedContext authenticatedContext;
+
+    @Mock
+    private MetadataCollector metadataCollector;
+
+    @Mock
+    private InstanceStoreMetadata instanceStoreMetadata;
+
+    @Test
+    public void testSuccessfulPreparation() throws Exception {
+        StackVerticalScaleV4Request stackVerticalScaleV4Request = new StackVerticalScaleV4Request();
+        InstanceTemplateV4Request instanceTemplate = new InstanceTemplateV4Request();
+        instanceTemplate.setInstanceType("r5ad.4xlarge");
+        stackVerticalScaleV4Request.setGroup("compute");
+        stackVerticalScaleV4Request.setTemplate(instanceTemplate);
+        CoreVerticalScalePreparationRequest request = new CoreVerticalScalePreparationRequest(cloudContext, cloudCredential, null, stackDto,
+                instanceGroupDto, List.of(cloudResource), stackVerticalScaleV4Request);
+        doReturn(cloudConnector).when(cloudPlatformConnectors).get(any());
+        doReturn(authenticator).when(cloudConnector).authentication();
+        doReturn(authenticatedContext).when(authenticator).authenticate(any(), any());
+        doReturn(metadataCollector).when(cloudConnector).metadata();
+        doReturn(instanceStoreMetadata).when(metadataCollector).collectInstanceStorageCount(authenticatedContext, List.of("r5ad.4xlarge"));
+        doReturn(2).when(instanceStoreMetadata).mapInstanceTypeToInstanceStoreCountNullHandled("r5ad.4xlarge");
+        doReturn(100).when(instanceStoreMetadata).mapInstanceTypeToInstanceSizeNullHandled("r5ad.4xlarge");
+        doReturn(false).when(stackDto).isStackInStopPhase();
+
+        InstanceGroupView instanceGroupView = mock(InstanceGroupView.class);
+        InstanceMetadataView instanceMetadataView = mock(InstanceMetadataView.class);
+        InstanceGroupDto instanceGroup = new InstanceGroupDto(instanceGroupView, List.of(instanceMetadataView));
+        doReturn(List.of(instanceGroup)).when(stackDto).getInstanceGroupDtos();
+        doReturn("compute").when(instanceGroupView).getGroupName();
+
+        Template template = new Template();
+        doReturn(template).when(instanceGroupView).getTemplate();
+
+        Blueprint bp = mock(Blueprint.class);
+        doReturn(bp).when(stackDto).getBlueprint();
+        String blueprintText = FileReaderUtils.readFileFromClasspathQuietly("test/defaults/blueprints/blueprint-with-instantiator.bp");
+        doReturn(blueprintText).when(bp).getBlueprintText();
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(blueprintText);
+        doReturn(cmTemplateProcessor).when(cmTemplateProcessorFactory).get(eq(blueprintText));
+
+        underTest.accept(new Event<>(request));
+
+        verify(coreVerticalScaleService).stopClouderaManagerServicesAndUpdateClusterConfigs(eq(stackDto), any(), any());
+        verify(coreVerticalScaleService).stopInstances(eq(cloudConnector), eq(List.of(cloudResource)), eq(request.getInstanceGroup()),
+                eq(stackDto), eq(authenticatedContext));
+        verify(eventBus).notify(eq(EventSelectorUtil.selector(CoreVerticalScalePreparationResult.class)), any());
+    }
+
+    @Test
+    public void testFailurePreparation() throws Exception {
+        StackVerticalScaleV4Request stackVerticalScaleV4Request = new StackVerticalScaleV4Request();
+        InstanceTemplateV4Request instanceTemplate = new InstanceTemplateV4Request();
+        instanceTemplate.setInstanceType("r5ad.4xlarge");
+        stackVerticalScaleV4Request.setGroup("compute");
+        stackVerticalScaleV4Request.setTemplate(instanceTemplate);
+        CoreVerticalScalePreparationRequest request = new CoreVerticalScalePreparationRequest(cloudContext, cloudCredential, null, stackDto,
+                instanceGroupDto, List.of(cloudResource), stackVerticalScaleV4Request);
+        doReturn(cloudConnector).when(cloudPlatformConnectors).get(any());
+        doReturn(authenticator).when(cloudConnector).authentication();
+        doReturn(authenticatedContext).when(authenticator).authenticate(any(), any());
+        doReturn(metadataCollector).when(cloudConnector).metadata();
+        doReturn(instanceStoreMetadata).when(metadataCollector).collectInstanceStorageCount(authenticatedContext, List.of("r5ad.4xlarge"));
+        doReturn(2).when(instanceStoreMetadata).mapInstanceTypeToInstanceStoreCountNullHandled("r5ad.4xlarge");
+        doReturn(100).when(instanceStoreMetadata).mapInstanceTypeToInstanceSizeNullHandled("r5ad.4xlarge");
+        doReturn(false).when(stackDto).isStackInStopPhase();
+
+        InstanceGroupView instanceGroupView = mock(InstanceGroupView.class);
+        InstanceMetadataView instanceMetadataView = mock(InstanceMetadataView.class);
+        InstanceGroupDto instanceGroup = new InstanceGroupDto(instanceGroupView, List.of(instanceMetadataView));
+        doReturn(List.of(instanceGroup)).when(stackDto).getInstanceGroupDtos();
+        doReturn("compute").when(instanceGroupView).getGroupName();
+
+        Template template = new Template();
+        doReturn(template).when(instanceGroupView).getTemplate();
+
+        Blueprint bp = mock(Blueprint.class);
+        doReturn(bp).when(stackDto).getBlueprint();
+        String blueprintText = FileReaderUtils.readFileFromClasspathQuietly("test/defaults/blueprints/blueprint-with-instantiator.bp");
+        doReturn(blueprintText).when(bp).getBlueprintText();
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(blueprintText);
+        doReturn(cmTemplateProcessor).when(cmTemplateProcessorFactory).get(eq(blueprintText));
+
+        doThrow(new Exception("TEST")).when(coreVerticalScaleService).stopClouderaManagerServicesAndUpdateClusterConfigs(eq(stackDto), any(), any());
+        underTest.accept(new Event<>(request));
+
+        verify(coreVerticalScaleService).stopClouderaManagerServicesAndUpdateClusterConfigs(eq(stackDto), any(), any());
+
+        verify(eventBus).notify(eq(CloudPlatformResult.failureSelector(CoreVerticalScalePreparationResult.class)), any());
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXVerticalScaleAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXVerticalScaleAction.java
@@ -28,16 +28,12 @@ public class DistroXVerticalScaleAction implements Action<DistroXTestDto, Cloudb
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
         if (testContext.getCloudProvider().verticalScalingSupported()) {
-            try {
-                FlowIdentifier flowIdentifier = client.getDefaultClient()
-                        .distroXV1Endpoint()
-                        .verticalScalingByCrn(
-                                testDto.getResponse().getCrn(),
-                                convertVerticalScaleTestDtoToStackV4VerticalScaleRequest(testContext));
-                testDto.setFlow("DistroX put vertical scaling", flowIdentifier);
-            } catch (Exception e) {
-                Log.whenJson(LOGGER, format("DistroX vertical scaling failed reason %s, %n", e.getMessage()), testDto.getCrn());
-            }
+            FlowIdentifier flowIdentifier = client.getDefaultClient()
+                    .distroXV1Endpoint()
+                    .verticalScalingByCrn(
+                            testDto.getResponse().getCrn(),
+                            convertVerticalScaleTestDtoToStackV4VerticalScaleRequest(testContext));
+            testDto.setFlow("DistroX put vertical scaling", flowIdentifier);
             Log.whenJson(LOGGER, format("DistroX put vertical scaling: %n"), testDto.getCrn());
         } else {
             Log.when(LOGGER, "DataHub vertical scale is not supported by now for the following cloud provider: " + testContext.getCloudPlatform());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXVerticalScaleAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXVerticalScaleAction.java
@@ -28,12 +28,16 @@ public class DistroXVerticalScaleAction implements Action<DistroXTestDto, Cloudb
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
         if (testContext.getCloudProvider().verticalScalingSupported()) {
-            FlowIdentifier flowIdentifier = client.getDefaultClient()
-                    .distroXV1Endpoint()
-                    .verticalScalingByCrn(
-                            testDto.getResponse().getCrn(),
-                            convertVerticalScaleTestDtoToStackV4VerticalScaleRequest(testContext));
-            testDto.setFlow("DistroX put vertical scaling", flowIdentifier);
+            try {
+                FlowIdentifier flowIdentifier = client.getDefaultClient()
+                        .distroXV1Endpoint()
+                        .verticalScalingByCrn(
+                                testDto.getResponse().getCrn(),
+                                convertVerticalScaleTestDtoToStackV4VerticalScaleRequest(testContext));
+                testDto.setFlow("DistroX put vertical scaling", flowIdentifier);
+            } catch (Exception e) {
+                Log.whenJson(LOGGER, format("DistroX vertical scaling failed reason %s, %n", e.getMessage()), testDto.getCrn());
+            }
             Log.whenJson(LOGGER, format("DistroX put vertical scaling: %n"), testDto.getCrn());
         } else {
             Log.when(LOGGER, "DataHub vertical scale is not supported by now for the following cloud provider: " + testContext.getCloudPlatform());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
@@ -283,21 +283,10 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
                 .given("dx1", DistroXTestDto.class)
                 .await(STACK_AVAILABLE, RunningParameter.key("dx1"))
                 .then(cloudProviderSideTagAssertion.verifyDistroxTags(DX1_TAGS))
-                .given(EnvironmentTestDto.class)
-                .when(environmentTestClient.stop())
-                .await(EnvironmentStatus.ENV_STOPPED)
-
-                .when(this::executeDatahubVerticalScaleIfSupported)
-
-                .given(EnvironmentTestDto.class)
-                .when(environmentTestClient.start())
-                .await(EnvironmentStatus.AVAILABLE)
-                .then(this::validateClusterLogsArePresent)
-                .then(this::validateClusterBackupsArePresent)
-                .given("dx1", DistroXTestDto.class)
-                .await(STACK_AVAILABLE, RunningParameter.key("dx1"))
                 .awaitForHealthyInstances()
                 .then(this::verifyCmServicesStartedSuccessfully)
+
+                .when(this::executeDatahubVerticalScaleIfSupported)
 
                 .then(this::verifyFailedVerticalScaleOutputsIfSupported)
                 .validate();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
@@ -74,18 +74,6 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
 
     private static final String MOCK_UMS_PASSWORD = "Password123!";
 
-    private static final String TARGET_INSTANCE_GROUP_TYPE = "master";
-
-    private static final String UPGRADED_FREEIPA_INSTANCE_TYPE = "m5.2xlarge";
-
-    private static final String DEFAULT_DATALAKE_INSTANCE_TYPE = "m5.2xlarge";
-
-    private static final String DEFAULT_DATAHUB_INSTANCE_TYPE = "m5.2xlarge";
-
-    private static final String UPGRADED_DATALAKE_INSTANCE_TYPE = "m5.4xlarge";
-
-    private static final String UPGRADED_DATAHUB_INSTANCE_TYPE = "m5.4xlarge";
-
     private static final String FREEIPA_VERTICAL_SCALE_KEY = "freeipaVerticalScaleKey";
 
     private static final String SDX_VERTICAL_SCALE_KEY = "sdxVerticalScaleKey";
@@ -227,73 +215,6 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
         LOGGER.info("Environment stop-start test execution has been finished....");
     }
 
-    @Test(dataProvider = TEST_CONTEXT, timeOut = 9000000)
-    @Description(
-            given = "there is a running cloudbreak",
-            when = "create an attached SDX and Datahubs (in case of AWS, create one of the Datahub with external database)",
-            then = "should be stopped first and started after it, fails to vertically scale the datahub cluster " +
-                    "and required services should be in running state in CM")
-    public void testVerticallyScaleDatahubClusterFail(TestContext testContext) {
-        LOGGER.info("Environment stop-start test execution has been started....");
-        DistroXDatabaseRequest distroXDatabaseRequest = new DistroXDatabaseRequest();
-        distroXDatabaseRequest.setAvailabilityType(DistroXDatabaseAvailabilityType.NON_HA);
-        String recipeName = resourcePropertyProvider().getName();
-        String filePath = "/pre-service-deployment";
-        String fileName = "pre-service-deployment";
-
-        testContext
-                .given(RecipeTestDto.class)
-                .withName(recipeName)
-                .withContent(recipeUtil.generatePreDeploymentRecipeContent(applicationContext))
-                .withRecipeType(PRE_SERVICE_DEPLOYMENT)
-                .when(recipeTestClient.createV4())
-                .given(CredentialTestDto.class)
-                .when(credentialTestClient.create())
-                .given("telemetry", TelemetryTestDto.class)
-                .withLogging()
-                .withReportClusterLogs()
-                .given(EnvironmentTestDto.class)
-                .withNetwork()
-                .withTelemetry("telemetry")
-                .withCreateFreeIpa(Boolean.TRUE)
-                .withOneFreeIpaNode()
-                .withFreeIpaRecipe(Set.of(recipeName))
-                .addTags(ENV_TAGS)
-                .when(environmentTestClient.create())
-                .then(this::getTelemetryStorageLocation)
-                .given(SdxInternalTestDto.class)
-                .withTelemetry("telemetry")
-                .addTags(SDX_TAGS)
-                .withCloudStorage(getCloudStorageRequest(testContext))
-                .when(sdxTestClient.createInternal())
-                .given(EnvironmentTestDto.class)
-                .await(EnvironmentStatus.AVAILABLE)
-                .then(cloudProviderSideTagAssertion.verifyEnvironmentTags(ENV_TAGS))
-                .init(FreeIpaTestDto.class)
-                .when(freeIpaTestClient.describe())
-                .then(validateFilesOnFreeIpa(filePath, fileName, 1, sshJUtil))
-                .given(SdxInternalTestDto.class)
-                .withTelemetry("telemetry")
-                .await(SdxClusterStatusResponse.RUNNING)
-                .then(cloudProviderSideTagAssertion.verifyInternalSdxTags(SDX_TAGS))
-                .given("dx1", DistroXTestDto.class)
-                .withExternalDatabaseOnAws(distroXDatabaseRequest)
-                .addTags(DX1_TAGS)
-                .when(distroXTestClient.create(), RunningParameter.key("dx1"))
-                .given("dx1", DistroXTestDto.class)
-                .await(STACK_AVAILABLE, RunningParameter.key("dx1"))
-                .then(cloudProviderSideTagAssertion.verifyDistroxTags(DX1_TAGS))
-                .awaitForHealthyInstances()
-                .then(this::verifyCmServicesStartedSuccessfully)
-
-                .when(this::executeDatahubVerticalScaleIfSupported)
-
-                .then(this::verifyFailedVerticalScaleOutputsIfSupported)
-                .validate();
-
-        LOGGER.info("Environment stop-start test execution has been finished....");
-    }
-
     private <O extends CloudbreakTestDto, C extends MicroserviceClient<?, ?, ?, ?>> O executeVerticalScaleIfSupported(TestContext testContext, O testDto,
             C client) {
         if (testContext.getCloudProvider().verticalScalingSupported()) {
@@ -325,24 +246,6 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
             datahubRequestedInstanceType = datahubVerticalScalingTestDto.getInstanceType();
             datahubRequestedGroupName = datahubVerticalScalingTestDto.getGroupName();
             datahubVerticalScalingTestDto.withDistroXVerticalScale()
-                    .given("dx1", DistroXTestDto.class)
-                    .when(distroXTestClient.verticalScale(DISTROX_VERTICAL_SCALE_KEY))
-                    .await(STACK_STOPPED, RunningParameter.key("dx1"));
-        } else {
-            LOGGER.debug("No vertical scale will happen this case because at this point Cloudbreak does not support vertical scale in case of the following " +
-                    "cloud platform: {}", testContext.getCloudPlatform());
-        }
-        return testDto;
-    }
-
-    private <O extends CloudbreakTestDto, C extends MicroserviceClient<?, ?, ?, ?>> O executeDatahubVerticalScaleIfSupported(TestContext testContext,
-            O testDto, C client) {
-        if (testContext.getCloudProvider().verticalScalingSupported()) {
-            testContext
-                    .given(DISTROX_VERTICAL_SCALE_KEY, VerticalScalingTestDto.class)
-                    .withDistroXVerticalScale()
-                    .withInstanceType("m5ad.2xlarge")
-                    .withGroup(TARGET_INSTANCE_GROUP_TYPE)
                     .given("dx1", DistroXTestDto.class)
                     .when(distroXTestClient.verticalScale(DISTROX_VERTICAL_SCALE_KEY))
                     .await(STACK_STOPPED, RunningParameter.key("dx1"));
@@ -439,24 +342,6 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
         return datalake;
     }
 
-    private DistroXTestDto verifyFailedVerticalScaleOutputsIfSupported(TestContext testContext, DistroXTestDto testDto, CloudbreakClient cloudbreakClient) {
-        if (testContext.getCloudProvider().verticalScalingSupported()) {
-            LOGGER.debug("Vertical scaling verification result initiated since the cloud platform '{}' suppots such operation.",
-                    testContext.getCloudPlatform());
-            testContext
-                    .given("telemetry", TelemetryTestDto.class)
-                    .withLogging()
-                    .withReportClusterLogs()
-                    .given("dx1", DistroXTestDto.class)
-                    .when(distroXTestClient.get())
-                    .then(this::validateDataHubInstanceTypeNotChanged);
-        } else {
-            LOGGER.debug("Since Cloudbreak right now does not support vertical scaling for cloud platform {}, hence no need for verification.",
-                    testContext.getCloudPlatform());
-        }
-        return testDto;
-    }
-
     private DistroXTestDto verifyCmServicesStartedSuccessfully(TestContext testContext, DistroXTestDto testDto, CloudbreakClient cloudbreakClient) {
         String username = testContext.getActingUserCrn().getResource();
         String sanitizedUserName = SanitizerUtil.sanitizeWorkloadUsername(username);
@@ -507,12 +392,6 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
 
     private EnvironmentTestDto validateClusterBackupsArePresent(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient client) {
         testContext.getCloudProvider().getCloudFunctionality().cloudStorageListContainer(telemetryStorageLocation, "cluster-backups", true);
-        return testDto;
-    }
-
-    private DistroXTestDto validateDataHubInstanceTypeNotChanged(TestContext testContext1, DistroXTestDto testDto, CloudbreakClient client) {
-        validateInstanceType(testDto.findInstanceGroupByName(TARGET_INSTANCE_GROUP_TYPE).getTemplate().getInstanceType(), DEFAULT_DATAHUB_INSTANCE_TYPE,
-                "Data Hub");
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
@@ -74,6 +74,18 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
 
     private static final String MOCK_UMS_PASSWORD = "Password123!";
 
+    private static final String TARGET_INSTANCE_GROUP_TYPE = "master";
+
+    private static final String UPGRADED_FREEIPA_INSTANCE_TYPE = "m5.2xlarge";
+
+    private static final String DEFAULT_DATALAKE_INSTANCE_TYPE = "m5.2xlarge";
+
+    private static final String DEFAULT_DATAHUB_INSTANCE_TYPE = "m5.2xlarge";
+
+    private static final String UPGRADED_DATALAKE_INSTANCE_TYPE = "m5.4xlarge";
+
+    private static final String UPGRADED_DATAHUB_INSTANCE_TYPE = "m5.4xlarge";
+
     private static final String FREEIPA_VERTICAL_SCALE_KEY = "freeipaVerticalScaleKey";
 
     private static final String SDX_VERTICAL_SCALE_KEY = "sdxVerticalScaleKey";
@@ -215,6 +227,84 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
         LOGGER.info("Environment stop-start test execution has been finished....");
     }
 
+    @Test(dataProvider = TEST_CONTEXT, timeOut = 9000000)
+    @Description(
+            given = "there is a running cloudbreak",
+            when = "create an attached SDX and Datahubs (in case of AWS, create one of the Datahub with external database)",
+            then = "should be stopped first and started after it, fails to vertically scale the datahub cluster " +
+                    "and required services should be in running state in CM")
+    public void testVerticallyScaleDatahubClusterFail(TestContext testContext) {
+        LOGGER.info("Environment stop-start test execution has been started....");
+        DistroXDatabaseRequest distroXDatabaseRequest = new DistroXDatabaseRequest();
+        distroXDatabaseRequest.setAvailabilityType(DistroXDatabaseAvailabilityType.NON_HA);
+        String recipeName = resourcePropertyProvider().getName();
+        String filePath = "/pre-service-deployment";
+        String fileName = "pre-service-deployment";
+
+        testContext
+                .given(RecipeTestDto.class)
+                .withName(recipeName)
+                .withContent(recipeUtil.generatePreDeploymentRecipeContent(applicationContext))
+                .withRecipeType(PRE_SERVICE_DEPLOYMENT)
+                .when(recipeTestClient.createV4())
+                .given(CredentialTestDto.class)
+                .when(credentialTestClient.create())
+                .given("telemetry", TelemetryTestDto.class)
+                .withLogging()
+                .withReportClusterLogs()
+                .given(EnvironmentTestDto.class)
+                .withNetwork()
+                .withTelemetry("telemetry")
+                .withCreateFreeIpa(Boolean.TRUE)
+                .withOneFreeIpaNode()
+                .withFreeIpaRecipe(Set.of(recipeName))
+                .addTags(ENV_TAGS)
+                .when(environmentTestClient.create())
+                .then(this::getTelemetryStorageLocation)
+                .given(SdxInternalTestDto.class)
+                .withTelemetry("telemetry")
+                .addTags(SDX_TAGS)
+                .withCloudStorage(getCloudStorageRequest(testContext))
+                .when(sdxTestClient.createInternal())
+                .given(EnvironmentTestDto.class)
+                .await(EnvironmentStatus.AVAILABLE)
+                .then(cloudProviderSideTagAssertion.verifyEnvironmentTags(ENV_TAGS))
+                .init(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.describe())
+                .then(validateFilesOnFreeIpa(filePath, fileName, 1, sshJUtil))
+                .given(SdxInternalTestDto.class)
+                .withTelemetry("telemetry")
+                .await(SdxClusterStatusResponse.RUNNING)
+                .then(cloudProviderSideTagAssertion.verifyInternalSdxTags(SDX_TAGS))
+                .given("dx1", DistroXTestDto.class)
+                .withExternalDatabaseOnAws(distroXDatabaseRequest)
+                .addTags(DX1_TAGS)
+                .when(distroXTestClient.create(), RunningParameter.key("dx1"))
+                .given("dx1", DistroXTestDto.class)
+                .await(STACK_AVAILABLE, RunningParameter.key("dx1"))
+                .then(cloudProviderSideTagAssertion.verifyDistroxTags(DX1_TAGS))
+                .given(EnvironmentTestDto.class)
+                .when(environmentTestClient.stop())
+                .await(EnvironmentStatus.ENV_STOPPED)
+
+                .when(this::executeDatahubVerticalScaleIfSupported)
+
+                .given(EnvironmentTestDto.class)
+                .when(environmentTestClient.start())
+                .await(EnvironmentStatus.AVAILABLE)
+                .then(this::validateClusterLogsArePresent)
+                .then(this::validateClusterBackupsArePresent)
+                .given("dx1", DistroXTestDto.class)
+                .await(STACK_AVAILABLE, RunningParameter.key("dx1"))
+                .awaitForHealthyInstances()
+                .then(this::verifyCmServicesStartedSuccessfully)
+
+                .then(this::verifyFailedVerticalScaleOutputsIfSupported)
+                .validate();
+
+        LOGGER.info("Environment stop-start test execution has been finished....");
+    }
+
     private <O extends CloudbreakTestDto, C extends MicroserviceClient<?, ?, ?, ?>> O executeVerticalScaleIfSupported(TestContext testContext, O testDto,
             C client) {
         if (testContext.getCloudProvider().verticalScalingSupported()) {
@@ -246,6 +336,24 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
             datahubRequestedInstanceType = datahubVerticalScalingTestDto.getInstanceType();
             datahubRequestedGroupName = datahubVerticalScalingTestDto.getGroupName();
             datahubVerticalScalingTestDto.withDistroXVerticalScale()
+                    .given("dx1", DistroXTestDto.class)
+                    .when(distroXTestClient.verticalScale(DISTROX_VERTICAL_SCALE_KEY))
+                    .await(STACK_STOPPED, RunningParameter.key("dx1"));
+        } else {
+            LOGGER.debug("No vertical scale will happen this case because at this point Cloudbreak does not support vertical scale in case of the following " +
+                    "cloud platform: {}", testContext.getCloudPlatform());
+        }
+        return testDto;
+    }
+
+    private <O extends CloudbreakTestDto, C extends MicroserviceClient<?, ?, ?, ?>> O executeDatahubVerticalScaleIfSupported(TestContext testContext,
+            O testDto, C client) {
+        if (testContext.getCloudProvider().verticalScalingSupported()) {
+            testContext
+                    .given(DISTROX_VERTICAL_SCALE_KEY, VerticalScalingTestDto.class)
+                    .withDistroXVerticalScale()
+                    .withInstanceType("m5ad.2xlarge")
+                    .withGroup(TARGET_INSTANCE_GROUP_TYPE)
                     .given("dx1", DistroXTestDto.class)
                     .when(distroXTestClient.verticalScale(DISTROX_VERTICAL_SCALE_KEY))
                     .await(STACK_STOPPED, RunningParameter.key("dx1"));
@@ -342,6 +450,24 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
         return datalake;
     }
 
+    private DistroXTestDto verifyFailedVerticalScaleOutputsIfSupported(TestContext testContext, DistroXTestDto testDto, CloudbreakClient cloudbreakClient) {
+        if (testContext.getCloudProvider().verticalScalingSupported()) {
+            LOGGER.debug("Vertical scaling verification result initiated since the cloud platform '{}' suppots such operation.",
+                    testContext.getCloudPlatform());
+            testContext
+                    .given("telemetry", TelemetryTestDto.class)
+                    .withLogging()
+                    .withReportClusterLogs()
+                    .given("dx1", DistroXTestDto.class)
+                    .when(distroXTestClient.get())
+                    .then(this::validateDataHubInstanceTypeNotChanged);
+        } else {
+            LOGGER.debug("Since Cloudbreak right now does not support vertical scaling for cloud platform {}, hence no need for verification.",
+                    testContext.getCloudPlatform());
+        }
+        return testDto;
+    }
+
     private DistroXTestDto verifyCmServicesStartedSuccessfully(TestContext testContext, DistroXTestDto testDto, CloudbreakClient cloudbreakClient) {
         String username = testContext.getActingUserCrn().getResource();
         String sanitizedUserName = SanitizerUtil.sanitizeWorkloadUsername(username);
@@ -392,6 +518,12 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
 
     private EnvironmentTestDto validateClusterBackupsArePresent(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient client) {
         testContext.getCloudProvider().getCloudFunctionality().cloudStorageListContainer(telemetryStorageLocation, "cluster-backups", true);
+        return testDto;
+    }
+
+    private DistroXTestDto validateDataHubInstanceTypeNotChanged(TestContext testContext1, DistroXTestDto testDto, CloudbreakClient client) {
+        validateInstanceType(testDto.findInstanceGroupByName(TARGET_INSTANCE_GROUP_TYPE).getTemplate().getInstanceType(), DEFAULT_DATAHUB_INSTANCE_TYPE,
+                "Data Hub");
         return testDto;
     }
 }

--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -57,7 +57,7 @@ auth:
     datahub:
       runtime.upgrade.enable: true
       os.upgrade.enable: true
-      instancetypes.enable: false
+      instancetypes.enable: true
     ccmv2.enable: false
     ccmv2jumpgate.enable: false
     ccmv2.useOneWayTls: false

--- a/orchestrator-salt/src/main/resources/salt/salt/disks/service/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/disks/service/init.sls
@@ -5,6 +5,7 @@ mount_instance_storage_script:
     - template: jinja
     - makedirs: True
     - mode: 755
+    - replace: True
 
 mount_instance_storage_service_file:
   file.managed:

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
@@ -961,4 +961,14 @@ public class CmTemplateProcessor implements BlueprintTextProcessor {
                         .filter(config -> configName.equals(config.getName()))
                         .findAny());
     }
+
+    public List<String> getHostTemplateRoleNames(String groupName) {
+        return Optional.ofNullable(cmTemplate.getHostTemplates())
+                .orElse(List.of())
+                .stream()
+                .filter(apiTemplate -> apiTemplate.getRefName().equals(groupName))
+                .map(ApiClusterTemplateHostTemplate::getRoleConfigGroupsRefNames)
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+    }
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessorTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessorTest.java
@@ -653,6 +653,13 @@ public class CmTemplateProcessorTest {
     }
 
     @Test
+    public void getHostTemplateRoleNames() {
+        underTest = new CmTemplateProcessor(getBlueprintText("input/cdp-invalid-multi-host-template-name.bp"));
+        assertEquals(5, underTest.getHostTemplateRoleNames("worker").size());
+        assertEquals(1, underTest.getHostTemplateRoleNames("worker").stream().filter("hdfs-DATANODE-BASE"::equals).count());
+    }
+
+    @Test
     public void testGetComputeHostGroups() {
         Versioned blueprintVersion = () -> "7.2.11";
 

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/model/ServiceComponent.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/model/ServiceComponent.java
@@ -6,13 +6,18 @@ import javax.annotation.Nonnull;
 
 import org.apache.commons.lang3.tuple.Pair;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class ServiceComponent implements Comparable<ServiceComponent> {
 
     private static final String UNKNOWN_SERVICE = "";
 
     private final Pair<String, String> serviceComponent;
 
-    private ServiceComponent(String service, String component) {
+    @JsonCreator
+    private ServiceComponent(@JsonProperty("service") String service,
+            @JsonProperty("component") String component) {
         serviceComponent = Pair.of(service, component);
     }
 

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/processor/BlueprintTextProcessor.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/processor/BlueprintTextProcessor.java
@@ -77,4 +77,6 @@ public interface BlueprintTextProcessor {
 
     List<String> getHostTemplateNames();
 
+    List<String> getHostTemplateRoleNames(String groupName);
+
 }


### PR DESCRIPTION
The current flow for changing the instance type (CoreVerticalScaleFlowConfig) doesn't mount the ephemeral volumes under the right mount path. 

Modify the vertical scale logic to update the template table with the right temporary storage and the count and size of instance stores.
Remove condition logic from mount-instance-storage.j2 file mount_all_sequential method, as this file is only used to mount ephemeral storage and we have to mount ephemral storage to only /ephfs path. 
 

1. skip cluster stop validation if node roles are not blacklisted
2. stop compute service in CM
3. update salt grain properties
4. stop group
5. change instance type
6. start instance group
7. update CM config
8. update cbdb