### PR TITLE
CDPSDX-4103 Backup location slash not removed in policy template and …

### DIFF
--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsIamService.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsIamService.java
@@ -154,11 +154,11 @@ public class AwsIamService {
         if (replacedTemplate != null) {
             for (Entry<String, String> replacement : replacements.entrySet()) {
                 String replacementValue = replacement.getValue() != null ? replacement.getValue() : "";
-                // Remove the ending "/" of a backup location so path with "*" will not have duplicated "/".
-                if (replacement.getKey().equals("${BACKUP_LOCATION_BASE}") && replacementValue.endsWith("/")) {
-                    replacementValue = replacementValue.substring(0, replacementValue.length() - 1);
-                }
                 replacedTemplate = replacedTemplate.replace(replacement.getKey(), replacementValue);
+            }
+            if (replacedTemplate.contains("LimitedAccessToDataLakeBackupBucket")
+                    || replacedTemplate.contains("DatalakeBackupPermissions")) {
+                replacedTemplate = replacedTemplate.replace("//*", "/*");
             }
         }
         return replacedTemplate;

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsIamServiceTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsIamServiceTest.java
@@ -213,18 +213,20 @@ public class AwsIamServiceTest {
         );
         assertThat(awsIamService.handleTemplateReplacements("abc ghi", replacements)).isEqualTo("def jkl");
 
-        // Test for backup/restore having location with/without ending slash.
-        assertThat(awsIamService.handleTemplateReplacements("${BACKUP_LOCATION_BASE}/*",
-                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc/"))).isEqualTo("abc/*");
-        assertThat(awsIamService.handleTemplateReplacements("${BACKUP_LOCATION_BASE}/",
-                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc/"))).isEqualTo("abc/");
-        assertThat(awsIamService.handleTemplateReplacements("${BACKUP_LOCATION_BASE}",
-                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc/"))).isEqualTo("abc");
-        assertThat(awsIamService.handleTemplateReplacements("${BACKUP_LOCATION_BASE}",
-                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc"))).isEqualTo("abc");
-        // Non-backup/restore policy is not be impacted on if the ending slash will be removed or not.
-        assertThat(awsIamService.handleTemplateReplacements("${TEST}/*", Collections.singletonMap("${TEST}", "abc/")))
-                .isEqualTo("abc//*");
+        assertThat(awsIamService.handleTemplateReplacements("DatalakeBackupPermissions, ${BACKUP_LOCATION_BASE}/*",
+                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc/"))).contains("abc/*");
+        assertThat(awsIamService.handleTemplateReplacements("DatalakeBackupPermissions, ${BACKUP_LOCATION_BASE}",
+                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc/"))).contains("abc/");
+        assertThat(awsIamService.handleTemplateReplacements("DatalakeBackupPermissions, ${BACKUP_LOCATION_BASE}",
+                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc"))).contains("abc");
+        assertThat(awsIamService.handleTemplateReplacements("LimitedAccessToDataLakeBackupBucket, ${BACKUP_LOCATION_BASE}/*",
+                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc/"))).contains("abc/*");
+        assertThat(awsIamService.handleTemplateReplacements("LimitedAccessToDataLakeBackupBucket, ${BACKUP_LOCATION_BASE}",
+                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc/"))).contains("abc/");
+        assertThat(awsIamService.handleTemplateReplacements("LimitedAccessToDataLakeBackupBucket, ${BACKUP_LOCATION_BASE}",
+                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc"))).contains("abc");
+        assertThat(awsIamService.handleTemplateReplacements("TEST, ${TEST}/*", Collections.singletonMap("${TEST}", "abc/")))
+                .contains("abc//*");
     }
 
     @Test


### PR DESCRIPTION
…keep the fix of double slash issue

JIRA: https://jira.cloudera.com/browse/CDPSDX-4103 

**ISSUE:** In CB-20813 (PR https://github.com/hortonworks/cloudbreak/pull/14243), to fix the double slash format issue, we introduced the code to always remove the slash at the end of the backup location. If the backup location set up by the user is just "s3://bucket" or "s3://bucket/", the aws-datalake-restore-policy will always have resources "bucket/\*" and "bucket", without the slash because we remove it,  which **introduces a bug** - when the user only sets up resources in their policy with "bucket/" and "bucket/*", they may fail at storage validation because the role has no authorization to "bucket", because the program is using aws-datalake-restore-policy to check if the role has authorization to each of the resources listed in there.

**SOLUTION:** This PR reverts the change in CB-20813 and uses another way to fix the double slash format issue: when the template is the backup or restore template, always replace "//\*" with "/\*".

**Local Test:**
Before: Validation failed. 
<img width="1424" alt="Screen Shot 2023-05-02 at 6 51 43 PM" src="https://user-images.githubusercontent.com/39275944/235802212-77767458-1c8e-4d30-9fb2-db912e86014b.png">

After: Validation succeeded. 
<img width="615" alt="Screen Shot 2023-05-02 at 6 52 33 PM" src="https://user-images.githubusercontent.com/39275944/235802299-eb163e85-67e4-4358-a073-10543b63e585.png">

The double slash format error is still fixed:
With format error:
<img width="1140" alt="Screen Shot 2023-05-02 at 6 53 47 PM" src="https://user-images.githubusercontent.com/39275944/235802447-7420fc86-ba0d-420b-8ac8-11d88db15b20.png">

Without format error:
<img width="1083" alt="Screen Shot 2023-05-02 at 6 54 18 PM" src="https://user-images.githubusercontent.com/39275944/235802533-8193447a-c0bf-404b-9668-c30bc9b953f0.png">
