### PR TITLE
Revert "CB-20813 Fix the double slashes issue for permission precheck failure message"

### DIFF
--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsIamService.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsIamService.java
@@ -154,10 +154,6 @@ public class AwsIamService {
         if (replacedTemplate != null) {
             for (Entry<String, String> replacement : replacements.entrySet()) {
                 String replacementValue = replacement.getValue() != null ? replacement.getValue() : "";
-                // Remove the ending "/" of a backup location so path with "*" will not have duplicated "/".
-                if (replacement.getKey().equals("${BACKUP_LOCATION_BASE}") && replacementValue.endsWith("/")) {
-                    replacementValue = replacementValue.substring(0, replacementValue.length() - 1);
-                }
                 replacedTemplate = replacedTemplate.replace(replacement.getKey(), replacementValue);
             }
         }

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsIamServiceTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsIamServiceTest.java
@@ -212,19 +212,6 @@ public class AwsIamServiceTest {
                 Map.entry("ghi", "jkl")
         );
         assertThat(awsIamService.handleTemplateReplacements("abc ghi", replacements)).isEqualTo("def jkl");
-
-        // Test for backup/restore having location with/without ending slash.
-        assertThat(awsIamService.handleTemplateReplacements("${BACKUP_LOCATION_BASE}/*",
-                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc/"))).isEqualTo("abc/*");
-        assertThat(awsIamService.handleTemplateReplacements("${BACKUP_LOCATION_BASE}/",
-                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc/"))).isEqualTo("abc/");
-        assertThat(awsIamService.handleTemplateReplacements("${BACKUP_LOCATION_BASE}",
-                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc/"))).isEqualTo("abc");
-        assertThat(awsIamService.handleTemplateReplacements("${BACKUP_LOCATION_BASE}",
-                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc"))).isEqualTo("abc");
-        // Non-backup/restore policy is not be impacted on if the ending slash will be removed or not.
-        assertThat(awsIamService.handleTemplateReplacements("${TEST}/*", Collections.singletonMap("${TEST}", "abc/")))
-                .isEqualTo("abc//*");
     }
 
     @Test


### PR DESCRIPTION
Reverts hortonworks/cloudbreak#14243

**JIRA:** https://jira.cloudera.com/browse/CDPSDX-4103

**ISSUE:** In [CDPSDX-3700](https://jira.cloudera.com/browse/CDPSDX-3700) (PR https://github.com/hortonworks/cloudbreak/pull/14243), to fix the double slash format issue, we introduced the code to always remove the slash at the end of the backup location. If the backup location set up by the user is just "s3://bucket" or "s3://bucket/", the aws-datalake-restore-policy will always have resources "bucket/*" and "bucket", without the slash because we remove it, which introduces a bug - when the user only sets up resources in their policy with "bucket/" and "bucket/*", they may fail at storage validation because the role has no authorization to "bucket", because the program is using aws-datalake-restore-policy to check if the role has authorization to each of the resources listed in there.

**SOLUTION:** This PR reverts the change in CDPSDX-3700. 

**NOTICE:** We will not make changes to fix the double slash format issue mentioned in  [CDPSDX-3700](https://jira.cloudera.com/browse/CDPSDX-3700) because currently we are actually checking authorization to location with "//\*" on everything, including read/write to AWS and the storage validation. So far we don't see any issues with that and so showing "//\*" in the UI or response is representing what we are actually doing