### PR TITLE
CB-15423 adding exception mapper to json parse exception which has stronger priority than the mapper of jackson

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/exception/mapper/JsonParseExceptionMapper.java
+++ b/environment/src/main/java/com/sequenceiq/environment/exception/mapper/JsonParseExceptionMapper.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.environment.exception.mapper;
+
+import javax.annotation.Priority;
+import javax.ws.rs.core.Response.Status;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonParseException;
+
+@Component
+@Priority(1)
+public class JsonParseExceptionMapper extends EnvironmentBaseExceptionMapper<JsonParseException> {
+
+    @Override
+    public Status getResponseStatus(JsonParseException exception) {
+        return Status.BAD_REQUEST;
+    }
+
+    @Override
+    public Class<JsonParseException> getExceptionType() {
+        return JsonParseException.class;
+    }
+}


### PR DESCRIPTION
The error on prod was about the jackson's own JsonParseException which couldn't be returned in SearchCauseExceptionMapper:41 as BaseExceptionMapper (CastException was thrown).