### PR TITLE
CB-14698 FreeIpa sync should recognise available nodes after DELETED_…

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/statuschecker/service/StatusCheckerJobService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/statuschecker/service/StatusCheckerJobService.java
@@ -12,6 +12,7 @@ import javax.inject.Inject;
 import org.quartz.JobBuilder;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
 import org.quartz.JobKey;
 import org.quartz.SimpleScheduleBuilder;
 import org.quartz.Trigger;
@@ -103,6 +104,10 @@ public class StatusCheckerJobService implements JobSchedulerService {
         }
     }
 
+    public boolean isLongSyncJob(JobExecutionContext context) {
+        return StatusCheckerJobService.LONG_SYNC_JOB_TYPE.equals(context.getMergedJobDataMap().get(StatusCheckerJobService.SYNC_JOB_TYPE));
+    }
+
     private void schedule(JobDetail jobDetail, Trigger trigger, JobResource jobResource) {
         try {
             JobKey jobKey = JobKey.jobKey(jobResource.getLocalId(), JOB_GROUP);
@@ -136,7 +141,7 @@ public class StatusCheckerJobService implements JobSchedulerService {
                 .build();
     }
 
-    private <T> String getResourceTypeFromCrnIfAvailable(JobResource jobResource) {
+    private String getResourceTypeFromCrnIfAvailable(JobResource jobResource) {
         String remoteResourceId = jobResource.getRemoteResourceId();
         String resourceType = "unknown";
         if (Crn.isCrn(remoteResourceId)) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
@@ -77,6 +76,73 @@ import com.sequenceiq.flow.domain.FlowLog;
 @DisallowConcurrentExecution
 @Component
 public class StackStatusCheckerJob extends StatusCheckerJob {
+
+    public static final EnumSet<Status> SYNCABLE_STATES = EnumSet.of(
+            Status.AVAILABLE,
+            Status.UPDATE_FAILED,
+            Status.ENABLE_SECURITY_FAILED,
+            Status.START_FAILED,
+            Status.STOPPED,
+            Status.STOP_FAILED,
+            Status.AMBIGUOUS,
+            Status.UNREACHABLE,
+            Status.NODE_FAILURE,
+            Status.RESTORE_FAILED,
+            Status.BACKUP_FAILED,
+            Status.BACKUP_FINISHED,
+            Status.RESTORE_FINISHED,
+            Status.DELETED_ON_PROVIDER_SIDE,
+            Status.EXTERNAL_DATABASE_START_FAILED,
+            Status.EXTERNAL_DATABASE_START_IN_PROGRESS,
+            Status.EXTERNAL_DATABASE_START_FINISHED,
+            Status.EXTERNAL_DATABASE_STOP_FAILED,
+            Status.EXTERNAL_DATABASE_STOP_IN_PROGRESS,
+            Status.EXTERNAL_DATABASE_STOP_FINISHED,
+            Status.EXTERNAL_DATABASE_UPGRADE_FINISHED,
+            Status.EXTERNAL_DATABASE_UPGRADE_FAILED,
+            Status.RECOVERY_FAILED,
+            Status.UPGRADE_CCM_FAILED,
+            Status.UPGRADE_CCM_FINISHED,
+            Status.UPGRADE_CCM_IN_PROGRESS
+    );
+
+    public static final EnumSet<Status> IGNORED_STATES = EnumSet.of(
+            Status.REQUESTED,
+            Status.CREATE_IN_PROGRESS,
+            Status.UPDATE_IN_PROGRESS,
+            Status.UPDATE_REQUESTED,
+            Status.STOP_REQUESTED,
+            Status.START_REQUESTED,
+            Status.STOP_IN_PROGRESS,
+            Status.START_IN_PROGRESS,
+            Status.WAIT_FOR_SYNC,
+            Status.MAINTENANCE_MODE_ENABLED,
+            Status.EXTERNAL_DATABASE_CREATION_IN_PROGRESS,
+            Status.EXTERNAL_DATABASE_UPGRADE_IN_PROGRESS,
+            Status.BACKUP_IN_PROGRESS,
+            Status.RESTORE_IN_PROGRESS,
+            Status.LOAD_BALANCER_UPDATE_IN_PROGRESS,
+            Status.RECOVERY_IN_PROGRESS,
+            Status.RECOVERY_REQUESTED,
+            Status.DETERMINE_DATALAKE_DATA_SIZES_IN_PROGRESS
+    );
+
+    public static final EnumSet<Status> LONG_SYNCABLE_STATES = EnumSet.of(Status.DELETED_ON_PROVIDER_SIDE);
+
+    public static final EnumSet<Status> STATES_FROM_AVAILABLE_ALLOWED = EnumSet.of(
+            Status.AMBIGUOUS,
+            Status.NODE_FAILURE,
+            Status.STOPPED,
+            Status.START_FAILED,
+            Status.STOP_FAILED,
+            Status.UPDATE_FAILED,
+            Status.ENABLE_SECURITY_FAILED);
+
+    private static final EnumSet<InstanceStatus> STATES_FROM_HEALTHY_ALLOWED = EnumSet.of(
+            SERVICES_UNHEALTHY,
+            SERVICES_RUNNING,
+            DECOMMISSION_FAILED,
+            FAILED);
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StackStatusCheckerJob.class);
 
@@ -159,9 +225,9 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
                     LOGGER.debug("Stack sync will be scheduled to long polling, stack state is {}", stackStatus);
                     jobService.unschedule(getLocalId());
                     jobService.scheduleLongIntervalCheck(getStackId(), StackJobAdapter.class);
-                } else if (null == stackStatus || ignoredStates().contains(stackStatus)) {
+                } else if (null == stackStatus || IGNORED_STATES.contains(stackStatus)) {
                     LOGGER.debug("Stack sync is skipped, stack state is {}", stackStatus);
-                } else if (syncableStates().contains(stackStatus)) {
+                } else if (SYNCABLE_STATES.contains(stackStatus)) {
                     RegionAwareInternalCrnGenerator dataHub = regionAwareInternalCrnGeneratorFactory.datahub();
                     ThreadBasedUserCrnProvider.doAs(dataHub.getInternalCrnForServiceAsString(), () -> doSync(stack));
                     switchToShortSyncIfNecessary(context, stack);
@@ -199,80 +265,16 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
     }
 
     private void switchToShortSyncIfNecessary(JobExecutionContext context, StackDto stackDto) {
-        if (isLongSyncJob(context)) {
+        if (jobService.isLongSyncJob(context)) {
             Status stackStatus = stackDto.getStatus();
-            if (!longSyncableStates().contains(stackStatus)) {
+            if (!LONG_SYNCABLE_STATES.contains(stackStatus)) {
                 jobService.schedule(getStackId(), StackJobAdapter.class);
             }
         }
     }
 
     private boolean shouldSwitchToLongSyncJob(Status stackStatus, JobExecutionContext context) {
-        return !isLongSyncJob(context) && longSyncableStates().contains(stackStatus);
-    }
-
-    private boolean isLongSyncJob(JobExecutionContext context) {
-        return StatusCheckerJobService.LONG_SYNC_JOB_TYPE.equals(context.getMergedJobDataMap().get(StatusCheckerJobService.SYNC_JOB_TYPE));
-    }
-
-    private Set<Status> longSyncableStates() {
-        return EnumSet.of(Status.DELETED_ON_PROVIDER_SIDE);
-    }
-
-    @VisibleForTesting
-    Set<Status> ignoredStates() {
-        return EnumSet.of(
-                Status.REQUESTED,
-                Status.CREATE_IN_PROGRESS,
-                Status.UPDATE_IN_PROGRESS,
-                Status.UPDATE_REQUESTED,
-                Status.STOP_REQUESTED,
-                Status.START_REQUESTED,
-                Status.STOP_IN_PROGRESS,
-                Status.START_IN_PROGRESS,
-                Status.WAIT_FOR_SYNC,
-                Status.MAINTENANCE_MODE_ENABLED,
-                Status.EXTERNAL_DATABASE_CREATION_IN_PROGRESS,
-                Status.EXTERNAL_DATABASE_UPGRADE_IN_PROGRESS,
-                Status.BACKUP_IN_PROGRESS,
-                Status.RESTORE_IN_PROGRESS,
-                Status.LOAD_BALANCER_UPDATE_IN_PROGRESS,
-                Status.RECOVERY_IN_PROGRESS,
-                Status.RECOVERY_REQUESTED,
-                Status.DETERMINE_DATALAKE_DATA_SIZES_IN_PROGRESS
-        );
-    }
-
-    @VisibleForTesting
-    Set<Status> syncableStates() {
-        return EnumSet.of(
-                Status.AVAILABLE,
-                Status.UPDATE_FAILED,
-                Status.ENABLE_SECURITY_FAILED,
-                Status.START_FAILED,
-                Status.STOPPED,
-                Status.STOP_FAILED,
-                Status.AMBIGUOUS,
-                Status.UNREACHABLE,
-                Status.NODE_FAILURE,
-                Status.RESTORE_FAILED,
-                Status.BACKUP_FAILED,
-                Status.BACKUP_FINISHED,
-                Status.RESTORE_FINISHED,
-                Status.DELETED_ON_PROVIDER_SIDE,
-                Status.EXTERNAL_DATABASE_START_FAILED,
-                Status.EXTERNAL_DATABASE_START_IN_PROGRESS,
-                Status.EXTERNAL_DATABASE_START_FINISHED,
-                Status.EXTERNAL_DATABASE_STOP_FAILED,
-                Status.EXTERNAL_DATABASE_STOP_IN_PROGRESS,
-                Status.EXTERNAL_DATABASE_STOP_FINISHED,
-                Status.EXTERNAL_DATABASE_UPGRADE_FINISHED,
-                Status.EXTERNAL_DATABASE_UPGRADE_FAILED,
-                Status.RECOVERY_FAILED,
-                Status.UPGRADE_CCM_FAILED,
-                Status.UPGRADE_CCM_FINISHED,
-                Status.UPGRADE_CCM_IN_PROGRESS
-        );
+        return !jobService.isLongSyncJob(context) && LONG_SYNCABLE_STATES.contains(stackStatus);
     }
 
     private void doSync(StackDto stack) {
@@ -287,11 +289,11 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
                 reportHealthAndSyncInstances(stack, runningInstances, getFailedInstancesInstanceMetadata(stack, extendedHostStatuses, runningInstances),
                         getNewHealthyHostNames(extendedHostStatuses, runningInstances), extendedHostStatuses.isAnyCertExpiring());
             } else {
-                syncInstances(stack, runningInstances, false);
+                syncInstances(stack, runningInstances);
             }
         } catch (RuntimeException e) {
             LOGGER.warn("Error during sync", e);
-            syncInstances(stack, runningInstances, false);
+            syncInstances(stack, runningInstances);
         }
     }
 
@@ -303,7 +305,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
                         .contains(e.getKey().getInstanceStatus()))
                 .filter(e -> e.getKey().getDiscoveryFQDN() != null)
                 .collect(Collectors.toMap(e -> e.getKey().getDiscoveryFQDN(), Map.Entry::getValue));
-        ifFlowNotRunning(() -> updateStates(stack, failedInstances.keySet(), newFailedNodeNamesWithReason, newHealthyHostNames, hostCertExpiring));
+        runIfFlowNotRunning(() -> updateStates(stack, failedInstances.keySet(), newFailedNodeNamesWithReason, newHealthyHostNames, hostCertExpiring));
         syncInstances(stack, runningInstances, failedInstances.keySet(), InstanceSyncState.RUNNING, true);
     }
 
@@ -330,28 +332,16 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
             } else {
                 clusterService.updateClusterStatusByStackId(stack.getId(), DetailedStackStatus.NODE_FAILURE);
             }
-        } else if (statesFromAvailableAllowed().contains(stack.getStatus())) {
+        } else if (STATES_FROM_AVAILABLE_ALLOWED.contains(stack.getStatus())) {
             clusterService.updateClusterStatusByStackId(stack.getId(), DetailedStackStatus.AVAILABLE);
         }
         clusterOperationService.reportHealthChange(stack.getResourceCrn(), newFailedNodeNamesWithReason, newHealthyHostNames);
     }
 
-    private void ifFlowNotRunning(Runnable function) {
-        if (flowLogService.isOtherFlowRunning(getStackId())) {
-            return;
+    private void runIfFlowNotRunning(Runnable function) {
+        if (!flowLogService.isOtherFlowRunning(getStackId())) {
+            function.run();
         }
-        function.run();
-    }
-
-    private EnumSet<Status> statesFromAvailableAllowed() {
-        return EnumSet.of(
-                Status.AMBIGUOUS,
-                Status.NODE_FAILURE,
-                Status.STOPPED,
-                Status.START_FAILED,
-                Status.STOP_FAILED,
-                Status.UPDATE_FAILED,
-                Status.ENABLE_SECURITY_FAILED);
     }
 
     private boolean isClusterManagerRunning(StackView stack, ClusterApi connector) {
@@ -360,8 +350,8 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
                 && isCMRunning(connector);
     }
 
-    private void syncInstances(StackDto stack, Collection<InstanceMetadataView> instanceMetaData, boolean cmServerRunning) {
-        syncInstances(stack, instanceMetaData, instanceMetaData, InstanceSyncState.DELETED_ON_PROVIDER_SIDE, cmServerRunning);
+    private void syncInstances(StackDto stack, Collection<InstanceMetadataView> instanceMetaData) {
+        syncInstances(stack, instanceMetaData, instanceMetaData, InstanceSyncState.DELETED_ON_PROVIDER_SIDE, false);
     }
 
     private void syncInstances(StackDto stack, Collection<InstanceMetadataView> runningInstances,
@@ -370,7 +360,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
         List<CloudVmInstanceStatus> instanceStatuses = stackInstanceStatusChecker.queryInstanceStatuses(stack, cloudInstances);
         LOGGER.debug("Cluster '{}' state check on provider, instances: {}", stack.getId(), instanceStatuses);
         SyncConfig syncConfig = new SyncConfig(true, cmServerRunning);
-        ifFlowNotRunning(() -> syncService.autoSync(stack.getStack(), runningInstances, instanceStatuses, defaultState, syncConfig));
+        runIfFlowNotRunning(() -> syncService.autoSync(stack.getStack(), runningInstances, instanceStatuses, defaultState, syncConfig));
     }
 
     private boolean isCMRunning(ClusterApi connector) {
@@ -392,19 +382,11 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
                 .map(HostName::value)
                 .collect(toSet());
         Set<String> unhealthyStoredHosts = runningInstances.stream()
-                .filter(i -> statesFromHealthyAllowed().contains(i.getInstanceStatus()))
+                .filter(i -> STATES_FROM_HEALTHY_ALLOWED.contains(i.getInstanceStatus()))
                 .filter(i -> i.getDiscoveryFQDN() != null)
                 .map(InstanceMetadataView::getDiscoveryFQDN)
                 .collect(toSet());
         return Sets.intersection(healthyHosts, unhealthyStoredHosts);
-    }
-
-    private EnumSet<InstanceStatus> statesFromHealthyAllowed() {
-        return EnumSet.of(
-                SERVICES_UNHEALTHY,
-                SERVICES_RUNNING,
-                DECOMMISSION_FAILED,
-                FAILED);
     }
 
     private Map<InstanceMetadataView, Optional<String>> getFailedInstancesInstanceMetadata(StackDto stack, ExtendedHostStatuses hostStatuses,

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
@@ -393,8 +393,8 @@ public class StackStatusCheckerJobTest {
     @Test
     public void testHandledAllStatesSeparately() {
         Set<Status> unschedulableStates = Status.getUnschedulableStatuses();
-        Set<Status> ignoredStates = underTest.ignoredStates();
-        Set<Status> syncableStates = underTest.syncableStates();
+        Set<Status> ignoredStates = StackStatusCheckerJob.IGNORED_STATES;
+        Set<Status> syncableStates = StackStatusCheckerJob.SYNCABLE_STATES;
 
         assertTrue(Sets.intersection(unschedulableStates, ignoredStates).isEmpty());
         assertTrue(Sets.intersection(unschedulableStates, syncableStates).isEmpty());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceMetaData.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceMetaData.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.freeipa.entity;
 
-import java.util.StringJoiner;
-
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
@@ -257,19 +255,26 @@ public class InstanceMetaData implements OrchestrationNode {
 
     @Override
     public String toString() {
-        return new StringJoiner(", ", InstanceMetaData.class.getSimpleName() + "[", "]")
-                .add("id=" + id)
-                .add("privateId=" + privateId)
-                .add("privateIp='" + privateIp + "'")
-                .add("publicIp='" + publicIp + "'")
-                .add("instanceId='" + instanceId + "'")
-                .add("discoveryFQDN='" + discoveryFQDN + "'")
-                .add("instanceName='" + instanceName + "'")
-                .add("instanceStatus='" + instanceStatus + "'")
-                .add("availabilityZone='" + availabilityZone + "'")
-                .add("subnetId='" + subnetId + "'")
-                .add("variant='" + variant + "'")
-                .toString();
+        return "InstanceMetaData{" +
+                "id=" + id +
+                ", privateId=" + privateId +
+                ", privateIp='" + privateIp + '\'' +
+                ", publicIp='" + publicIp + '\'' +
+                ", sshPort=" + sshPort +
+                ", instanceId='" + instanceId + '\'' +
+                ", discoveryFQDN='" + discoveryFQDN + '\'' +
+                ", instanceStatus=" + instanceStatus +
+                ", instanceMetadataType=" + instanceMetadataType +
+                ", localityIndicator='" + localityIndicator + '\'' +
+                ", startDate=" + startDate +
+                ", terminationDate=" + terminationDate +
+                ", subnetId='" + subnetId + '\'' +
+                ", availabilityZone='" + availabilityZone + '\'' +
+                ", instanceName='" + instanceName + '\'' +
+                ", instanceGroup=" + instanceGroup +
+                ", lifeCycle=" + lifeCycle +
+                ", variant='" + variant + '\'' +
+                '}';
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.freeipa.service.stack;
 
 import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.CREATE_IN_PROGRESS;
-import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DELETED_ON_PROVIDER_SIDE;
 import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DELETE_COMPLETED;
 import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DELETE_IN_PROGRESS;
 import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.REQUESTED;
@@ -68,8 +67,7 @@ public class StackService implements EnvironmentPropertyProvider, PayloadContext
                 CREATE_IN_PROGRESS,
                 STACK_AVAILABLE,
                 DELETE_IN_PROGRESS,
-                DELETE_COMPLETED,
-                DELETED_ON_PROVIDER_SIDE));
+                DELETE_COMPLETED));
     }
 
     public Stack getByIdWithListsInTransaction(Long id) {


### PR DESCRIPTION
…ON_PROVIDER_SIDE state

Switched to an implementation which behaves as we do for clusters:
- recognise if deleted on provider instance is alive
- if stack is deleted on provider switch to long sync
- if stack became available again then switch to normal sync
- schedule sync for deleted on provider stack on startup
- validate healthcheck result hostname against expected to mitigate clusterproxy failover mechanism which could hide node failure if instance is not registered to CP

See detailed description in the commit message.