### PR TITLE
CB-21778 Append "/backups" to backupLocation on Upgrade/Resize if RAZ…

### DIFF
--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreServiceTest.java
@@ -444,6 +444,76 @@ public class SdxBackupRestoreServiceTest {
         assertFalse(sdxBackupRestoreService.isDatalakeInRestoreProgress(sdxCluster.getClusterName(), USER_CRN));
     }
 
+    @Test
+    public void testModifyBackupLocationWithAWS() {
+        DetailedEnvironmentResponse detailedEnvironmentResponse = new DetailedEnvironmentResponse();
+        detailedEnvironmentResponse.setCloudPlatform("AWS");
+        when(environmentClientService.getByName(anyString())).thenReturn(detailedEnvironmentResponse);
+        SdxCluster sdxCluster = getValidSdxCluster();
+        sdxCluster.setRangerRazEnabled(true);
+        assertEquals("s3://bucket/backups", sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "s3://bucket"));
+        assertEquals("s3://bucket/backups", sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "s3://bucket/"));
+        assertEquals("s3://bucket/test", sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "s3://bucket/test"));
+        assertEquals("s3://bucket/test/test1", sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "s3://bucket/test/test1"));
+        assertEquals("s3:/bucket", sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "s3:/bucket"));
+        assertEquals("s3://", sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "s3://"));
+
+        sdxCluster.setRangerRazEnabled(false);
+        assertEquals("s3://bucket", sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "s3://bucket"));
+        assertEquals("s3://bucket/", sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "s3://bucket/"));
+        assertEquals("s3://bucket/test", sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "s3://bucket/test"));
+        assertEquals("s3://bucket/test/test1", sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "s3://bucket/test/test1"));
+    }
+
+    @Test
+    public void testModifyBackupLocationWithAzure() {
+        DetailedEnvironmentResponse detailedEnvironmentResponse = new DetailedEnvironmentResponse();
+        detailedEnvironmentResponse.setCloudPlatform("AZURE");
+        when(environmentClientService.getByName(anyString())).thenReturn(detailedEnvironmentResponse);
+        SdxCluster sdxCluster = getValidSdxCluster();
+        sdxCluster.setRangerRazEnabled(true);
+        assertEquals("abfs://test@mydatalake.dfs.core.windows.net/backups",
+                sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "abfs://test@mydatalake.dfs.core.windows.net"));
+        assertEquals("abfs://test@mydatalake.dfs.core.windows.net/backups",
+                sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "abfs://test@mydatalake.dfs.core.windows.net/"));
+        assertEquals("abfs://test@mydatalake.dfs.core.windows.net/test",
+                sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "abfs://test@mydatalake.dfs.core.windows.net/test"));
+        assertEquals("abfs://test@mydatalake.dfs.core.windows.net/test/test1",
+                sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "abfs://test@mydatalake.dfs.core.windows.net/test/test1"));
+        assertEquals("abfs:/test@mydatalake.dfs.core.windows.net",
+                sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "abfs:/test@mydatalake.dfs.core.windows.net"));
+        assertEquals("abfs://",
+                sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "abfs://"));
+
+        sdxCluster.setRangerRazEnabled(false);
+        assertEquals("abfs://test@mydatalake.dfs.core.windows.net",
+                sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "abfs://test@mydatalake.dfs.core.windows.net"));
+        assertEquals("abfs://test@mydatalake.dfs.core.windows.net/",
+                sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "abfs://test@mydatalake.dfs.core.windows.net/"));
+        assertEquals("abfs://test@mydatalake.dfs.core.windows.net/test",
+                sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "abfs://test@mydatalake.dfs.core.windows.net/test"));
+        assertEquals("abfs://test@mydatalake.dfs.core.windows.net/test/test1",
+                sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "abfs://test@mydatalake.dfs.core.windows.net/test/test1"));
+    }
+
+    @Test
+    public void testModifyBackupLocationWithGCP() {
+        DetailedEnvironmentResponse detailedEnvironmentResponse = new DetailedEnvironmentResponse();
+        detailedEnvironmentResponse.setCloudPlatform("GCP");
+        when(environmentClientService.getByName(anyString())).thenReturn(detailedEnvironmentResponse);
+        SdxCluster sdxCluster = getValidSdxCluster();
+        sdxCluster.setRangerRazEnabled(true);
+        assertEquals("gs://bucket", sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "gs://bucket"));
+        assertEquals("gs://bucket/", sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "gs://bucket/"));
+        assertEquals("gs://bucket/test", sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "gs://bucket/test"));
+
+        sdxCluster.setRangerRazEnabled(false);
+        assertEquals("gs://bucket", sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "gs://bucket"));
+        assertEquals("gs://bucket/", sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "gs://bucket/"));
+        assertEquals("gs://bucket/test", sdxBackupRestoreService.modifyBackupLocation(sdxCluster, "gs://bucket/test"));
+
+    }
+
     private SdxCluster getValidSdxCluster() {
         sdxCluster = new SdxCluster();
         sdxCluster.setClusterName(CLUSTER_NAME);


### PR DESCRIPTION
… and root dir

**ISSUE:** RAZ environment has an automatic backup location appended with "/backups", so we need to manually append that "/backups" to the backup location when we are doing a backup if the location itself is a root directory, otherwise we may have access issues that fails the backup. We have fixed that by adding "/backups" to the AWS/Azure ranger raz env's backup location if it is a root directory location through [CDPSDX-4069 ](https://jira.cloudera.com/browse/CDPSDX-4069)& [CDPSDX-3814](https://jira.cloudera.com/browse/CDPSDX-3814). However, when we are running upgrade/resize, the backup is triggered from CB rather than TH, and database backup is triggered at the same time in CB with the default backup location, which happens before TH, so the backup location for database is not added with "/backups".

**SOLUTION:** We need to add "/backups" to this type of backup location for database backup in CB as well.

***We want to merge this to 2.71 so it can reach to prod faster to fix this issue.**

**Local Tests:**
**Before:**


When running an upgrade, database is only backed up to "bucket/" even if others are backed to "bucket/backups":
![Screen Shot 2023-05-05 at 3 32 31 PM](https://user-images.githubusercontent.com/39275944/236555417-ca28e5a1-68e6-4a20-bafb-41bbbea8137e.png)

![Screen Shot 2023-05-05 at 3 32 44 PM](https://user-images.githubusercontent.com/39275944/236555355-3564488b-e1c6-49e2-92ea-88090d80cee6.png)

**After:**
AZURE RAZ upgrade: all backed up to bucket/backups:
![Screen Shot 2023-05-05 at 12 35 27 PM](https://user-images.githubusercontent.com/39275944/236520555-fb5b96d0-ce46-4c83-8e58-32be656b2f42.png)
AZURE RAZ resize: all backed up to bucket/backups:
![Screen Shot 2023-05-05 at 8 08 29 PM](https://user-images.githubusercontent.com/39275944/236587314-ade3622c-6ec4-49ec-bbaa-83319762264b.png)
AZURE RAZ normal backup using CDP CLI: all backed up to bucket/backups (this has been like this before in TH)
![Screen Shot 2023-05-05 at 12 41 23 PM](https://user-images.githubusercontent.com/39275944/236520616-1181cd9a-916f-4c8e-a0bf-9714f565e806.png)

AWS RAZ upgrade: all backed up to bucket/backups:
![Screen Shot 2023-05-05 at 12 25 11 PM](https://user-images.githubusercontent.com/39275944/236520340-53acdfd1-c190-4d78-b0fb-e890e1caf143.png)
AWS RAZ normal backup using CDP CLI: all backed up to bucket/backups (this has been like this before in TH)
![Screen Shot 2023-05-05 at 12 25 11 PM](https://user-images.githubusercontent.com/39275944/236520437-2d14ff49-0f82-4fbe-894f-08f9fa758819.png)

AWS NON-RAZ Upgrade: backup location not impacted, still back up to the root directory if the input is a root dir:
![Screen Shot 2023-05-05 at 2 40 10 PM](https://user-images.githubusercontent.com/39275944/236542343-b10f4980-540b-430b-8103-277b3b35024e.png)

