### PR TITLE
CB-13850  setup krb5.conf max_retrires=1

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/kerberos/config/krb5.conf-existing
+++ b/orchestrator-salt/src/main/resources/salt/salt/kerberos/config/krb5.conf-existing
@@ -23,6 +23,7 @@ includedir /var/lib/sss/pubconf/krb5.include.d/
   udp_preference_limit = 0
   default_ccache_name = /tmp/krb5cc_%{uid}
   renew_lifetime = 7d
+  max_retries = 1
 
 [realms]
   {{ salt['pillar.get']('kerberos:realm')|upper }} = {


### PR DESCRIPTION
The max total time = NUMBER_OF_KDCS x max_retries x kdc_timeout.

Default kdc_timeout is 3 sec.

See detailed description in the commit message.