### PR TITLE
CB-21803: Fixed failing enterprise e2e tests which require specific 7.2.17 image catalog.

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/HostGroupType.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/HostGroupType.java
@@ -5,14 +5,25 @@ import com.sequenceiq.it.util.TestParameter;
 
 public enum HostGroupType {
     MASTER("master", InstanceGroupType.GATEWAY, InstanceCountParameter.MASTER_INSTANCE_COUNT.getName()),
+    MASTER_ENT("master", InstanceGroupType.CORE, InstanceCountParameter.MASTER_INSTANCE_COUNT.getName(), 2),
     WORKER("worker", InstanceGroupType.CORE, InstanceCountParameter.WORKER_INSTANCE_COUNT.getName(), 3),
     IDBROKER("idbroker", InstanceGroupType.CORE, InstanceCountParameter.IDBROKER_INSTANCE_COUNT.getName()),
+    IDBROKER_ENT("idbroker", InstanceGroupType.CORE, InstanceCountParameter.IDBROKER_INSTANCE_COUNT.getName(), 2),
     GATEWAY("gateway", InstanceGroupType.CORE, InstanceCountParameter.GATEWAY_INSTANCE_COUNT.getName(), 0),
+    GATEWAY_ENT("gateway", InstanceGroupType.GATEWAY, InstanceCountParameter.GATEWAY_INSTANCE_COUNT.getName(), 2),
     COMPUTE("compute", InstanceGroupType.CORE, InstanceCountParameter.COMPUTE_INSTANCE_COUNT.getName()),
     SERVICES("Services", InstanceGroupType.GATEWAY, InstanceCountParameter.SERVICE_INSTANCE_COUNT.getName()),
     MESSAGING("Messaging", InstanceGroupType.CORE, InstanceCountParameter.NIFI_INSTANCE_COUNT.getName()),
     NIFI("NiFi", InstanceGroupType.CORE, InstanceCountParameter.NIFI_INSTANCE_COUNT.getName()),
-    ZOOKEEPER("ZooKeeper", InstanceGroupType.CORE, InstanceCountParameter.ZOOKEEPER_INSTANCE_COUNT.getName());
+    ZOOKEEPER("ZooKeeper", InstanceGroupType.CORE, InstanceCountParameter.ZOOKEEPER_INSTANCE_COUNT.getName()),
+    AUXILIARY("auxiliary", InstanceGroupType.CORE, InstanceCountParameter.AUXILIARY_INSTANCE_COUNT.getName(), 1),
+    CORE("core", InstanceGroupType.CORE, InstanceCountParameter.CORE_INSTANCE_COUNT.getName(), 3),
+    SOLRHG("solrhg", InstanceGroupType.CORE, InstanceCountParameter.SOLRHG_INSTANCE_COUNT.getName()),
+    STORAGEHG("storagehg", InstanceGroupType.CORE, InstanceCountParameter.STORAGEHG_INSTANCE_COUNT.getName()),
+    KAFKAHG("kafkahg", InstanceGroupType.CORE, InstanceCountParameter.KAFKAHG_INSTANCE_COUNT.getName()),
+    RAZHG("razhg", InstanceGroupType.CORE, InstanceCountParameter.RAZHG_INSTANCE_COUNT.getName(), 0),
+    ATLASHG("atlashg", InstanceGroupType.CORE, InstanceCountParameter.ATLASHG_INSTANCE_COUNT.getName()),
+    HMSHG("hmshg", InstanceGroupType.CORE, InstanceCountParameter.HMSHG_INSTANCE_COUNT.getName());
 
     private final String name;
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/InstanceCountParameter.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/InstanceCountParameter.java
@@ -8,7 +8,15 @@ public enum InstanceCountParameter {
     COMPUTE_INSTANCE_COUNT("computeInstanceCount"),
     SERVICE_INSTANCE_COUNT("serviceInstanceCount"),
     NIFI_INSTANCE_COUNT("nifiInstanceCount"),
-    ZOOKEEPER_INSTANCE_COUNT("zookeeperInstanceCount");
+    ZOOKEEPER_INSTANCE_COUNT("zookeeperInstanceCount"),
+    AUXILIARY_INSTANCE_COUNT("auxiliaryInstanceCount"),
+    CORE_INSTANCE_COUNT("coreInstanceCount"),
+    SOLRHG_INSTANCE_COUNT("solrhgInstanceCount"),
+    STORAGEHG_INSTANCE_COUNT("storagehgInstanceCount"),
+    KAFKAHG_INSTANCE_COUNT("kafkahgInstanceCount"),
+    RAZHG_INSTANCE_COUNT("razhgInstanceCount"),
+    ATLASHG_INSTANCE_COUNT("atlashgInstanceCount"),
+    HMSHG_INSTANCE_COUNT("hmshgInstanceCount");
 
     private final String name;
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractSdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractSdxTestDto.java
@@ -4,12 +4,14 @@ import static com.sequenceiq.it.cloudbreak.context.RunningParameter.emptyRunning
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 
 import org.apache.commons.lang3.NotImplementedException;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.assertion.Assertion;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
@@ -109,5 +111,13 @@ public abstract class AbstractSdxTestDto<R, S, T extends CloudbreakTestDto> exte
         }
         return getTestContext().then((T) this, SdxClient.class, assertions.get(assertions.size() - 1),
                 runningParameters.get(runningParameters.size() - 1));
+    }
+
+    public T awaitForInstance(Map<List<String>, InstanceStatus> statuses) {
+        return awaitForInstance(statuses, emptyRunningParameter());
+    }
+
+    public T awaitForInstance(Map<List<String>, InstanceStatus> statuses, RunningParameter runningParameter) {
+        return getTestContext().awaitForInstance((T) this, statuses, runningParameter);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/InstanceGroupTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/InstanceGroupTestDto.java
@@ -1,10 +1,21 @@
 package com.sequenceiq.it.cloudbreak.dto;
 
 import static com.sequenceiq.cloudbreak.doc.ModelDescriptions.HostGroupModelDescription.RECOVERY_MODE;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.ATLASHG;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.AUXILIARY;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.COMPUTE;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.CORE;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.GATEWAY;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.GATEWAY_ENT;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.HMSHG;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.IDBROKER;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.IDBROKER_ENT;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.KAFKAHG;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.MASTER;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.MASTER_ENT;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.RAZHG;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.SOLRHG;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.STORAGEHG;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.WORKER;
 
 import java.util.List;
@@ -75,6 +86,10 @@ public class InstanceGroupTestDto extends AbstractCloudbreakTestDto<InstanceGrou
 
     public static List<InstanceGroupTestDto> sdxHostGroup(TestContext testContext) {
         return withHostGroup(testContext, MASTER, IDBROKER);
+    }
+
+    public static List<InstanceGroupTestDto> sdxEnterpriseHostGroup(TestContext testContext) {
+        return withHostGroup(testContext, MASTER_ENT, IDBROKER_ENT, GATEWAY_ENT, CORE, AUXILIARY, SOLRHG, STORAGEHG, KAFKAHG, RAZHG, ATLASHG, HMSHG);
     }
 
     public static List<InstanceGroupTestDto> withHostGroup(TestContext testContext, HostGroupType... groupTypes) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -208,14 +208,6 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
         }
     }
 
-    public SdxTestDto awaitForInstance(Map<List<String>, InstanceStatus> statuses) {
-        return awaitForInstance(statuses, emptyRunningParameter());
-    }
-
-    public SdxTestDto awaitForInstance(Map<List<String>, InstanceStatus> statuses, RunningParameter runningParameter) {
-        return getTestContext().awaitForInstance(this, statuses, runningParameter);
-    }
-
     public SdxTestDto withCloudStorage() {
         SdxCloudStorageTestDto cloudStorage = getCloudProvider().cloudStorage(given(SdxCloudStorageTestDto.class));
         if (cloudStorage == null) {

--- a/integration-test/src/main/resources/testsuites/e2e/sdx-repair-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/sdx-repair-tests.yaml
@@ -3,3 +3,5 @@ tests:
   - name: "sdx_e2e_repair_tests"
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
+        includedMethods:
+          - testSDXEnterpriseRepair


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-21803

The tests were failing since the default QE image catalog does not have 7.2.17 on it. This change attempts to fix this by specifying a specific image catalog URL to be used for the SDX cluster which does have 7.2.17.