### PR TITLE
CB-21564 Set providerclass for keytool in setup-autotls

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/setup-autotls.sh.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/setup-autotls.sh.j2
@@ -39,11 +39,25 @@ rm -f ${CACERTS_DIR}/cacerts.p12
 rm -f ${CACERTS_DIR}/cacerts.pem
 rm -f ${CACERTS_DIR}/cacerts.bcfks
 
-keytool -importkeystore -srckeystore ${JAVA_HOME}/jre/lib/security/cacerts -srcstorepass changeit -destkeystore ${CACERTS_DIR}/cacerts.p12 -deststorepass changeit -deststoretype PKCS12
+keytool -importkeystore \
+  -srckeystore ${JAVA_HOME}/jre/lib/security/cacerts \
+  -srcstorepass changeit \
+  -providerclass sun.security.pkcs11.SunPKCS11 \
+  -providerarg ${JAVA_HOME}/jre/lib/security/nss.cfg \
+  -destkeystore ${CACERTS_DIR}/cacerts.p12 \
+  -deststorepass changeit \
+  -deststoretype PKCS12
 openssl pkcs12 -in ${CACERTS_DIR}/cacerts.p12 -passin pass:changeit -out ${CACERTS_DIR}/cacerts.pem
 {% if gov_cloud == True %}
 # ideally we would generate the pem from bcfks on gov cloud, but it is not possible until SafeLogic openssl is installed
-keytool -importkeystore -srckeystore ${JAVA_HOME}/jre/lib/security/cacerts -srcstorepass changeit -destkeystore ${CACERTS_DIR}/cacerts.bcfks -deststorepass changeit -deststoretype BCFKS
+keytool -importkeystore \
+  -srckeystore ${JAVA_HOME}/jre/lib/security/cacerts \
+  -srcstorepass changeit \
+  -providerclass sun.security.pkcs11.SunPKCS11 \
+  -providerarg ${JAVA_HOME}/jre/lib/security/nss.cfg \
+  -destkeystore ${CACERTS_DIR}/cacerts.bcfks \
+  -deststorepass changeit \
+  -deststoretype BCFKS
 rm -f ${CACERTS_DIR}/cacerts.p12
 {% endif %}
 


### PR DESCRIPTION
In FIPS mode the pkcs11 provider is not configured by default, so it has to be passed as an argument to keytool

See detailed description in the commit message.