### PR TITLE
CDPSDX-4126; disable atlas entity differential 

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-enterprise.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-enterprise.bp
@@ -186,7 +186,7 @@
                 "value":"2"
               },
               {
-                "name":"ranger.audit.solr.config.ttl",
+                "name":"ranger_audit_solr_config_ttl",
                 "value":"30"
               }
             ]

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/atlas/AtlasKnoxRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/atlas/AtlasKnoxRoleConfigProvider.java
@@ -33,6 +33,8 @@ public class AtlasKnoxRoleConfigProvider extends AbstractRoleConfigProvider {
 
     public static final String MIN_VERSION_FOR_DIFFERENCIAL_BACKUP = "7.2.7";
 
+    public static final String MAX_VERSION_FOR_DIFFERENCIAL_BACKUP = "7.2.16";
+
     private static final String ATLAS_KNOX_CONFIG = "atlas_authentication_method_trustedproxy";
 
     private static final String ATLAS_DIFFERENTIAL_AUDIT_CONFIG = "atlas.entity.audit.differential";
@@ -108,7 +110,9 @@ public class AtlasKnoxRoleConfigProvider extends AbstractRoleConfigProvider {
 
     private boolean isShapeVersionSupportedByRuntime(String runtime) {
         Comparator<Versioned> versionComparator = new VersionComparator();
-        return versionComparator.compare(() -> runtime, () -> MIN_VERSION_FOR_DIFFERENCIAL_BACKUP) > -1;
+        int maxVersionCheck = versionComparator.compare(() -> runtime, () -> MAX_VERSION_FOR_DIFFERENCIAL_BACKUP);
+        return versionComparator.compare(() -> runtime, () -> MIN_VERSION_FOR_DIFFERENCIAL_BACKUP) > -1
+                && maxVersionCheck < 1;
     }
 
     @VisibleForTesting


### PR DESCRIPTION
CDPSDX-4126; disable atlas entity differential where the runtime is higher than 7.2.16, reason: this value is default with the newer runtimes. Change the ranger  audit ttl to 30, reason: this value already exists, but the name has typo.

See detailed description in the commit message.