### PR TITLE
CB-21798 Public subnet info contains only ENDPOINT_ACCESS_GATEWAY in …

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/AwsEnvironmentNetworkConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/AwsEnvironmentNetworkConverter.java
@@ -15,7 +15,6 @@ import com.sequenceiq.cloudbreak.cloud.model.network.CreatedSubnet;
 import com.sequenceiq.cloudbreak.cloud.model.network.SubnetType;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.network.NetworkConstants;
-import com.sequenceiq.common.api.type.DeploymentRestriction;
 import com.sequenceiq.environment.environment.domain.EnvironmentViewConverter;
 import com.sequenceiq.environment.network.dao.domain.AwsNetwork;
 import com.sequenceiq.environment.network.dao.domain.BaseNetwork;
@@ -73,7 +72,7 @@ public class AwsEnvironmentNetworkConverter extends EnvironmentBaseNetworkConver
                                 subnet.isIgwAvailable(),
                                 subnet.getType(),
                                 subnet.isPublicSubnet()
-                                        ? DeploymentRestriction.ENDPOINT_ACCESS_GATEWAYS
+                                        ? getDeploymentRestrictionWhenPublicSubnet(createdCloudNetwork)
                                         : getDeploymentRestrictionForPrivateSubnet(subnet.getType()))
                         )
                 )

--- a/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/AzureEnvironmentNetworkConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/AzureEnvironmentNetworkConverter.java
@@ -75,7 +75,7 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
                                 subnet.isIgwAvailable(),
                                 subnet.getType(),
                                 subnet.isPublicSubnet()
-                                        ? DeploymentRestriction.ENDPOINT_ACCESS_GATEWAYS
+                                        ? getDeploymentRestrictionWhenPublicSubnet(createdCloudNetwork)
                                         : getDeploymentRestrictionForPrivateSubnet(subnet.getType()))
                         )
                 )

--- a/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/GcpEnvironmentNetworkConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/GcpEnvironmentNetworkConverter.java
@@ -20,7 +20,6 @@ import com.sequenceiq.cloudbreak.cloud.model.network.CreatedCloudNetwork;
 import com.sequenceiq.cloudbreak.cloud.model.network.CreatedSubnet;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.network.NetworkConstants;
-import com.sequenceiq.common.api.type.DeploymentRestriction;
 import com.sequenceiq.environment.environment.domain.EnvironmentViewConverter;
 import com.sequenceiq.environment.network.dao.domain.BaseNetwork;
 import com.sequenceiq.environment.network.dao.domain.GcpNetwork;
@@ -95,7 +94,7 @@ public class GcpEnvironmentNetworkConverter extends EnvironmentBaseNetworkConver
                                 subnet.isIgwAvailable(),
                                 subnet.isIgwAvailable() ? PUBLIC : PRIVATE,
                                 subnet.isPublicSubnet()
-                                        ? DeploymentRestriction.ENDPOINT_ACCESS_GATEWAYS
+                                        ? getDeploymentRestrictionWhenPublicSubnet(createdCloudNetwork)
                                         : getDeploymentRestrictionForPrivateSubnet(subnet.getType()))
                         )
                 )

--- a/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/MockEnvironmentNetworkConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/MockEnvironmentNetworkConverter.java
@@ -13,7 +13,6 @@ import com.sequenceiq.cloudbreak.cloud.model.Subnet;
 import com.sequenceiq.cloudbreak.cloud.model.network.CreatedCloudNetwork;
 import com.sequenceiq.cloudbreak.cloud.model.network.CreatedSubnet;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
-import com.sequenceiq.common.api.type.DeploymentRestriction;
 import com.sequenceiq.environment.environment.domain.EnvironmentViewConverter;
 import com.sequenceiq.environment.network.dao.domain.BaseNetwork;
 import com.sequenceiq.environment.network.dao.domain.MockNetwork;
@@ -64,7 +63,7 @@ public class MockEnvironmentNetworkConverter extends EnvironmentBaseNetworkConve
                                 subnet.isIgwAvailable(),
                                 subnet.getType(),
                                 subnet.isPublicSubnet()
-                                        ? DeploymentRestriction.ENDPOINT_ACCESS_GATEWAYS
+                                        ? getDeploymentRestrictionWhenPublicSubnet(createdCloudNetwork)
                                         : getDeploymentRestrictionForPrivateSubnet(subnet.getType()))
                         )
                 )

--- a/environment/src/test/java/com/sequenceiq/environment/network/v1/converter/AzureEnvironmentNetworkConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/network/v1/converter/AzureEnvironmentNetworkConverterTest.java
@@ -197,7 +197,7 @@ class AzureEnvironmentNetworkConverterTest {
         assertEquals(RESOURCE_GROUP_NAME, actual.getResourceGroupName());
         assertTrue(SUBNET_IDS.containsAll(actual.getSubnetMetas().keySet()));
         assertThat(actual.getSubnetMetas().get(SUBNET_1).getDeploymentRestrictions())
-                .containsExactlyElementsOf(DeploymentRestriction.ENDPOINT_ACCESS_GATEWAYS);
+                .containsAll(DeploymentRestriction.ALL);
 
         assertEquals(SUBNET_1, actual.getSubnetMetas().get(SUBNET_1).getId());
         assertEquals(SUBNET_1, actual.getSubnetMetas().get(SUBNET_1).getName());
@@ -211,7 +211,7 @@ class AzureEnvironmentNetworkConverterTest {
         assertEquals(SUBNET_CIDR_2, actual.getSubnetMetas().get(SUBNET_2).getCidr());
         assertTrue(actual.getSubnetMetas().get(SUBNET_2).isPrivateSubnet());
         assertThat(actual.getSubnetMetas().get(SUBNET_2).getDeploymentRestrictions())
-                .containsExactlyElementsOf(DeploymentRestriction.ENDPOINT_ACCESS_GATEWAYS);
+                .containsAll(DeploymentRestriction.ALL);
 
         assertEquals(SUBNET_3, actual.getSubnetMetas().get(SUBNET_3).getId());
         assertEquals(SUBNET_3, actual.getSubnetMetas().get(SUBNET_3).getName());
@@ -219,7 +219,7 @@ class AzureEnvironmentNetworkConverterTest {
         assertEquals(SUBNET_CIDR_3, actual.getSubnetMetas().get(SUBNET_3).getCidr());
         assertTrue(actual.getSubnetMetas().get(SUBNET_3).isPrivateSubnet());
         assertThat(actual.getSubnetMetas().get(SUBNET_3).getDeploymentRestrictions())
-                .containsExactlyElementsOf(DeploymentRestriction.ENDPOINT_ACCESS_GATEWAYS);
+                .containsAll(DeploymentRestriction.ALL);
     }
 
     @Test


### PR DESCRIPTION
…DeploymentRestrictions. In case of new network if the customer does not request private network then we do not apply just the LB restriciton but all of them.

See detailed description in the commit message.