### PR TITLE
CB-21854: Set m5.4xlarge for the Spark3 AWS master host

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering-spark3.json
@@ -24,7 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "m5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.11/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.11/aws/dataengineering-spark3.json
@@ -24,7 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "m5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.12/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.12/aws/dataengineering-spark3.json
@@ -24,7 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "m5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/aws/dataengineering-spark3.json
@@ -24,7 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "m5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/aws/dataengineering-spark3.json
@@ -24,7 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "m5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/aws/dataengineering-spark3.json
@@ -24,7 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "m5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/aws_gov/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/aws_gov/dataengineering-spark3.json
@@ -27,7 +27,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "m5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/aws/dataengineering-spark3.json
@@ -24,7 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "m5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/aws_gov/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/aws_gov/dataengineering-spark3.json
@@ -27,7 +27,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "m5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.18/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.18/aws/dataengineering-spark3.json
@@ -24,7 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "m5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.18/aws_gov/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.18/aws_gov/dataengineering-spark3.json
@@ -27,7 +27,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "m5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering-spark3.json
@@ -24,7 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "m5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering-spark3.json
@@ -24,7 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "m5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",


### PR DESCRIPTION
This configuration has been already set for Spark2 in 2021 which should fix the HMS OOM memory issues in case of non HA AWS environments