### PR TITLE
CB-21842 Do not fetch network for Redbeams DBStack

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverter.java
@@ -144,7 +144,7 @@ public class AllocateDatabaseServerV4RequestToDBStackConverter {
             asMap.forEach((key, value) -> parameter.put(key, value.toString()));
             dbStack.setParameters(parameter);
         }
-        dbStack.setNetwork(networkBuilderService.buildNetwork(source.getNetwork(), environment, cloudPlatform, dbStack));
+        dbStack.setNetwork(networkBuilderService.buildNetwork(source.getNetwork(), environment, cloudPlatform, dbStack).getId());
 
         Instant now = clock.getCurrentInstant();
         dbStack.setDBStackStatus(new DBStackStatus(dbStack, DetailedDBStackStatus.PROVISION_REQUESTED, now.toEpochMilli()));

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/DBStack.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/DBStack.java
@@ -57,8 +57,8 @@ public class DBStack {
 
     private String availabilityZone;
 
-    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-    private Network network;
+    @Column(nullable = false, name = "network_id")
+    private Long networkId;
 
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     @SecretValue
@@ -148,12 +148,12 @@ public class DBStack {
         this.availabilityZone = availabilityZone;
     }
 
-    public Network getNetwork() {
-        return network;
+    public Long getNetwork() {
+        return networkId;
     }
 
-    public void setNetwork(Network network) {
-        this.network = network;
+    public void setNetwork(Long networkId) {
+        this.networkId = networkId;
     }
 
     public DatabaseServer getDatabaseServer() {
@@ -328,7 +328,7 @@ public class DBStack {
                 + "',displayName='" + displayName
                 + "',region='" + region
                 + "',availabilityZone='" + availabilityZone
-                + ",network=" + (network != null ? network.toString() : "null")
+                + ",networkId=" + networkId
                 + ",databaseServer=" + (databaseServer != null ? databaseServer.toString() : "null")
                 + ",tags=" + (tags != null ? tags.getValue() : "null")
                 + ",parameters=" + parameters

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/repository/NetworkRepository.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/repository/NetworkRepository.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.redbeams.repository;
+
+import javax.transaction.Transactional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sequenceiq.redbeams.domain.stack.Network;
+
+@Transactional(Transactional.TxType.REQUIRED)
+public interface NetworkRepository extends JpaRepository<Network, Long> {
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/NetworkService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/NetworkService.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.redbeams.service.network;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.redbeams.domain.stack.Network;
+import com.sequenceiq.redbeams.repository.NetworkRepository;
+
+@Service
+public class NetworkService {
+
+    @Inject
+    private NetworkRepository repository;
+
+    public Optional<Network> findById(Long id) {
+        return repository.findById(id);
+    }
+
+    public Network getById(Long id) {
+        return repository.findById(id).orElseThrow(() -> new NotFoundException(String.format("Network [%s] not found", id)));
+    }
+
+    public Network save(Network network) {
+        return repository.save(network);
+    }
+
+    public void delete(Long id) {
+        Optional.ofNullable(id).ifPresent(networkId -> repository.deleteById(networkId));
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsUpgradeService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsUpgradeService.java
@@ -136,7 +136,7 @@ public class RedbeamsUpgradeService {
             return handleAlreadyUpgraded(crn, currentVersion);
         }
 
-        dbStack = networkBuilderService.updateNetworkSubnets(dbStack);
+        networkBuilderService.updateNetworkSubnets(dbStack);
         dbStackStatusUpdater.updateStatus(dbStack.getId(), DetailedDBStackStatus.UPGRADE_REQUESTED);
         RedbeamsStartUpgradeRequest redbeamsStartUpgradeRequest = new RedbeamsStartUpgradeRequest(dbStack.getId(),
                 targetVersion);

--- a/redbeams/src/main/resources/schema/app/20230515125404_CB-21842_Remove_'network_id_idx'_as_it_duplicates_pkey_index.sql
+++ b/redbeams/src/main/resources/schema/app/20230515125404_CB-21842_Remove_'network_id_idx'_as_it_duplicates_pkey_index.sql
@@ -1,0 +1,9 @@
+-- // CB-21842 Remove 'network_id_idx' as it duplicates pkey index
+-- Migration SQL that makes the change goes here.
+
+DROP INDEX IF EXISTS network_id_idx;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+CREATE UNIQUE INDEX IF NOT EXISTS network_id_idx ON network(id);

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/spi/DBStackToDatabaseStackConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/spi/DBStackToDatabaseStackConverterTest.java
@@ -7,12 +7,14 @@ import static com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts.RESOURCE_
 import static com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.CREATE_REQUESTED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +44,7 @@ import com.sequenceiq.redbeams.domain.stack.Network;
 import com.sequenceiq.redbeams.domain.stack.SecurityGroup;
 import com.sequenceiq.redbeams.domain.stack.SslConfig;
 import com.sequenceiq.redbeams.service.EnvironmentService;
+import com.sequenceiq.redbeams.service.network.NetworkService;
 
 @ExtendWith(MockitoExtension.class)
 public class DBStackToDatabaseStackConverterTest {
@@ -52,6 +55,8 @@ public class DBStackToDatabaseStackConverterTest {
 
     private static final String STACK_TAGS = "{ \"userDefinedTags\": { \"ukey1\" : \"uvalue1\", \"key1\": \"value1\" }, "
                                             + " \"defaultTags\": { \"dkey1\" : \"dvalue1\", \"key1\": \"shadowed\" } }";
+
+    private static final Long NETWORK_ID = 12L;
 
     private static final String CLOUD_PLATFORM = "AZURE";
 
@@ -67,6 +72,9 @@ public class DBStackToDatabaseStackConverterTest {
     @Mock
     private EnvironmentService environmentService;
 
+    @Mock
+    private NetworkService networkService;
+
     @BeforeEach
     public void setUp() {
         dbStack = new DBStack();
@@ -75,13 +83,14 @@ public class DBStackToDatabaseStackConverterTest {
         dbStack.setDisplayName("My Stack");
         dbStack.setDescription("my stack");
         dbStack.setEnvironmentId("myenv");
+        dbStack.setNetwork(NETWORK_ID);
     }
 
     @Test
     public void testConversionNormal() {
         Network network = new Network();
         network.setAttributes(new Json(NETWORK_ATTRIBUTES));
-        dbStack.setNetwork(network);
+        when(networkService.findById(NETWORK_ID)).thenReturn(Optional.of(network));
 
         DatabaseServer server = new DatabaseServer();
         server.setName("myserver");
@@ -141,13 +150,15 @@ public class DBStackToDatabaseStackConverterTest {
         assertThat(convertedStack.getDatabaseServer()).isNull();
         assertThat(convertedStack.getTemplate()).isNull();
         assertThat(convertedStack.getTags().size()).isEqualTo(0);
+        verifyNoInteractions(networkService);
     }
 
     @Test
     public void testConversionAzureWithMultipleResourceGroups() {
         Network network = new Network();
         network.setAttributes(new Json(NETWORK_ATTRIBUTES));
-        dbStack.setNetwork(network);
+        when(networkService.findById(NETWORK_ID)).thenReturn(Optional.of(network));
+        dbStack.setNetwork(NETWORK_ID);
         dbStack.setCloudPlatform(CLOUD_PLATFORM);
         dbStack.setParameters(new HashMap<>());
         DatabaseServer server = new DatabaseServer();
@@ -177,7 +188,8 @@ public class DBStackToDatabaseStackConverterTest {
     public void testConversionAzureWithSingleResourceGroups() {
         Network network = new Network();
         network.setAttributes(new Json(NETWORK_ATTRIBUTES));
-        dbStack.setNetwork(network);
+        when(networkService.findById(NETWORK_ID)).thenReturn(Optional.of(network));
+        dbStack.setNetwork(NETWORK_ID);
         dbStack.setCloudPlatform(CLOUD_PLATFORM);
         dbStack.setParameters(new HashMap<>());
         DatabaseServer server = new DatabaseServer();
@@ -208,7 +220,8 @@ public class DBStackToDatabaseStackConverterTest {
     public void testConversionAzureWithAzureEncryptionResourcesPresentAndNoEncryptionKeyRG() {
         Network network = new Network();
         network.setAttributes(new Json(NETWORK_ATTRIBUTES));
-        dbStack.setNetwork(network);
+        when(networkService.findById(NETWORK_ID)).thenReturn(Optional.of(network));
+        dbStack.setNetwork(NETWORK_ID);
         dbStack.setCloudPlatform(CLOUD_PLATFORM);
         dbStack.setParameters(new HashMap<>());
         DatabaseServer server = new DatabaseServer();
@@ -242,7 +255,8 @@ public class DBStackToDatabaseStackConverterTest {
     public void testConversionAzureWithAzureEncryptionResourcesPresentAndEncryptionKeyRG() {
         Network network = new Network();
         network.setAttributes(new Json(NETWORK_ATTRIBUTES));
-        dbStack.setNetwork(network);
+        when(networkService.findById(NETWORK_ID)).thenReturn(Optional.of(network));
+        dbStack.setNetwork(NETWORK_ID);
         dbStack.setCloudPlatform(CLOUD_PLATFORM);
         dbStack.setParameters(new HashMap<>());
         DatabaseServer server = new DatabaseServer();
@@ -273,7 +287,8 @@ public class DBStackToDatabaseStackConverterTest {
     public void testConversionGcpWithGcpEncryptionResourcesPresent() {
         Network network = new Network();
         network.setAttributes(new Json(NETWORK_ATTRIBUTES));
-        dbStack.setNetwork(network);
+        when(networkService.findById(NETWORK_ID)).thenReturn(Optional.of(network));
+        dbStack.setNetwork(NETWORK_ID);
         dbStack.setCloudPlatform("GCP");
         dbStack.setParameters(new HashMap<>());
         DatabaseServer server = new DatabaseServer();
@@ -302,7 +317,8 @@ public class DBStackToDatabaseStackConverterTest {
     public void testConversionAzureWithAzureEncryptionResourcesPresentAndSingleResourceGroup() {
         Network network = new Network();
         network.setAttributes(new Json(NETWORK_ATTRIBUTES));
-        dbStack.setNetwork(network);
+        when(networkService.findById(NETWORK_ID)).thenReturn(Optional.of(network));
+        dbStack.setNetwork(NETWORK_ID);
         dbStack.setCloudPlatform(CLOUD_PLATFORM);
         dbStack.setParameters(new HashMap<>());
         DatabaseServer server = new DatabaseServer();
@@ -390,7 +406,8 @@ public class DBStackToDatabaseStackConverterTest {
     public void testConversionAwsWithAwsEncryptionResourcesPresent() {
         Network network = new Network();
         network.setAttributes(new Json(NETWORK_ATTRIBUTES));
-        dbStack.setNetwork(network);
+        when(networkService.findById(NETWORK_ID)).thenReturn(Optional.of(network));
+        dbStack.setNetwork(NETWORK_ID);
         dbStack.setCloudPlatform("AWS");
         dbStack.setParameters(new HashMap<>());
         DatabaseServer server = new DatabaseServer();

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverterTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -150,6 +151,8 @@ class AllocateDatabaseServerV4RequestToDBStackConverterTest {
 
     private static final int THREE_CERTS = 3;
 
+    private static final Long NETWORK_ID = 12L;
+
     @Mock
     private EnvironmentService environmentService;
 
@@ -260,6 +263,7 @@ class AllocateDatabaseServerV4RequestToDBStackConverterTest {
                 .build();
         when(environmentService.getByCrn(ENVIRONMENT_CRN)).thenReturn(environment);
         Network network = new Network();
+        network.setId(NETWORK_ID);
         when(networkBuilderService.buildNetwork(eq(networkRequest), eq(environment), eq(AWS_CLOUD_PLATFORM), any(DBStack.class))).thenReturn(network);
         DBStack dbStack = underTest.convert(allocateRequest, OWNER_CRN);
 
@@ -286,7 +290,7 @@ class AllocateDatabaseServerV4RequestToDBStackConverterTest {
         assertEquals("dbvalue", dbStack.getDatabaseServer().getAttributes().getMap().get("dbkey"));
         assertEquals(REDBEAMS_DB_MAJOR_VERSION, dbStack.getDatabaseServer().getAttributes().getMap().get("engineVersion"));
         assertEquals(securityGroupRequest.getSecurityGroupIds(), dbStack.getDatabaseServer().getSecurityGroup().getSecurityGroupIds());
-        assertEquals(network, dbStack.getNetwork());
+        assertEquals(NETWORK_ID, dbStack.getNetwork());
         assertEquals(dbStack.getTags().get(StackTags.class).getUserDefinedTags().get("DistroXKey1"), "DistroXValue1");
 
         verifySsl(dbStack, Set.of(CERT_PEM_V3), CLOUD_PROVIDER_IDENTIFIER_V3);
@@ -331,6 +335,9 @@ class AllocateDatabaseServerV4RequestToDBStackConverterTest {
         when(environmentService.getByCrn(ENVIRONMENT_CRN)).thenReturn(environment);
         when(userGeneratorService.generateUserName()).thenReturn(USERNAME);
         when(passwordGeneratorService.generatePassword(any())).thenReturn(PASSWORD);
+        Network network = new Network();
+        network.setId(NETWORK_ID);
+        when(networkBuilderService.buildNetwork(isNull(), eq(environment), eq(AWS_CLOUD_PLATFORM), any(DBStack.class))).thenReturn(network);
 
         DBStack dbStack = underTest.convert(allocateRequest, OWNER_CRN);
 
@@ -424,6 +431,9 @@ class AllocateDatabaseServerV4RequestToDBStackConverterTest {
         when(environmentService.getByCrn(ENVIRONMENT_CRN)).thenReturn(environment);
 
         databaseServerRequest.setDatabaseVendor(DATABASE_VENDOR);
+        Network network = new Network();
+        network.setId(NETWORK_ID);
+        when(networkBuilderService.buildNetwork(eq(networkRequest), eq(environment), eq(cloudPlatform), any(DBStack.class))).thenReturn(network);
     }
 
     @Test

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/domain/stack/DBStackTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/domain/stack/DBStackTest.java
@@ -23,8 +23,6 @@ import com.sequenceiq.redbeams.api.model.common.Status;
 
 public class DBStackTest {
 
-    private static final Network NETWORK = new Network();
-
     private static final DatabaseServer SERVER = new DatabaseServer();
 
     private static final Json TAGS = new Json("{}");
@@ -65,9 +63,6 @@ public class DBStackTest {
 
         dbStack.setAvailabilityZone("us-east-1b");
         assertEquals("us-east-1b", dbStack.getAvailabilityZone());
-
-        dbStack.setNetwork(NETWORK);
-        assertEquals(NETWORK, dbStack.getNetwork());
 
         dbStack.setDatabaseServer(SERVER);
         assertEquals(SERVER, dbStack.getDatabaseServer());

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/stack/RedbeamsUpgradeServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/stack/RedbeamsUpgradeServiceTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -48,7 +47,6 @@ import com.sequenceiq.redbeams.converter.spi.DBStackToDatabaseStackConverter;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.domain.stack.DBStackStatus;
 import com.sequenceiq.redbeams.domain.stack.DatabaseServer;
-import com.sequenceiq.redbeams.domain.stack.Network;
 import com.sequenceiq.redbeams.domain.upgrade.UpgradeDatabaseRequest;
 import com.sequenceiq.redbeams.domain.upgrade.UpgradeDatabaseResponse;
 import com.sequenceiq.redbeams.dto.Credential;
@@ -115,7 +113,6 @@ public class RedbeamsUpgradeServiceTest {
         DBStack dbStack = getDbStack(Status.AVAILABLE);
         when(dbStackService.getByCrn(SERVER_CRN_STRING)).thenReturn(dbStack);
         UpgradeDatabaseRequest upgradeDatabaseRequest = getUpgradeDatabaseRequest();
-        when(networkBuilderService.updateNetworkSubnets(dbStack)).thenReturn(dbStack);
 
         RedbeamsStartUpgradeRequest redbeamsStartUpgradeRequest = new RedbeamsStartUpgradeRequest(dbStack.getId(),
                 upgradeDatabaseRequest.getTargetMajorVersion());
@@ -186,7 +183,6 @@ public class RedbeamsUpgradeServiceTest {
         DBStack dbStack = getDbStack(Status.AVAILABLE);
         when(dbStackService.getByCrn(SERVER_CRN_STRING)).thenReturn(dbStack);
         UpgradeDatabaseRequest upgradeDatabaseRequest = getUpgradeDatabaseRequest();
-        when(networkBuilderService.updateNetworkSubnets(dbStack)).thenReturn(dbStack);
 
         underTest.upgradeDatabaseServer(SERVER_CRN_STRING, upgradeDatabaseRequest);
     }
@@ -200,7 +196,6 @@ public class RedbeamsUpgradeServiceTest {
                 thenReturn(getOperationViewWithStatus(OperationProgressStatus.FINISHED));
         RedbeamsStartUpgradeRequest redbeamsStartUpgradeRequest = new RedbeamsStartUpgradeRequest(dbStack.getId(),
                 upgradeDatabaseRequest.getTargetMajorVersion());
-        when(networkBuilderService.updateNetworkSubnets(dbStack)).thenReturn(dbStack);
 
         when(flowManager.notify(RedbeamsUpgradeEvent.REDBEAMS_START_UPGRADE_EVENT.selector(), redbeamsStartUpgradeRequest)).
                 thenReturn(new FlowIdentifier(FlowType.FLOW, "1"));
@@ -292,9 +287,6 @@ public class RedbeamsUpgradeServiceTest {
         DatabaseServer databaseServer = new DatabaseServer();
         databaseServer.setAttributes(new Json(DATABASE_SERVER_ATTRIBUTES));
         dbStack.setDatabaseServer(databaseServer);
-        Network network = new Network();
-        network.setAttributes(new Json(Collections.emptyMap()));
-        dbStack.setNetwork(network);
         return dbStack;
     }
 


### PR DESCRIPTION
Remove entity level connection between `DBStack` and `Network` to avoid join during fetching `DBStack`. This involves:
- using the id from `DBStack` to fetch and delete `Network`
- store the id instead of the entity (this makes the change backward compatible as it is the current state at db level)
- separate saving Network from DBStack
- during termination create a transaction for deleting the 2 together to simulate `orphanRemoval = true`

Also removed unnecessary unique index for primary key.

See detailed description in the commit message.