### PR TITLE
CB-21868 Add FreeIPA Subject Alt Name On RHEL 8

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
@@ -53,6 +53,7 @@ net.ipv6.conf.lo.disable_ipv6:
     - group: root
     - mode: 700
     - source: salt://freeipa/scripts/update_cnames.sh
+    - template: jinja
 
 /opt/salt/scripts/repair.sh:
   file.managed:

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/update_cnames.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/update_cnames.sh
@@ -137,10 +137,12 @@ addHost "kerberos.$DOMAIN"
 addService "HTTP/kerberos.$DOMAIN"
 addHostToService "HTTP/kerberos.$DOMAIN" "$FQDN"
 
-# httpd Server-Cert (re)submit is needed when the legacy cert db does exist
-if [ -f "/etc/httpd/alias/cert8.db" ]; then
-  HTTP_CERT_REQUEST_ID=$(getCertRequestIdFromDir /etc/httpd/alias Server-Cert)
-  setDomainsForCert "$HTTP_CERT_REQUEST_ID" "freeipa.$DOMAIN kdc.$DOMAIN kerberos.$DOMAIN"
-fi
+
+{%- if grains['os_family'] == 'RedHat' and grains['osmajorrelease'] | int == 8 %}
+HTTP_CERT_REQUEST_ID=$(getCertRequestIdFromFile /var/lib/ipa/certs/httpd.crt)
+{%- else %}
+HTTP_CERT_REQUEST_ID=$(getCertRequestIdFromDir /etc/httpd/alias Server-Cert)
+{%- endif %}
+setDomainsForCert "$HTTP_CERT_REQUEST_ID" "freeipa.$DOMAIN kdc.$DOMAIN kerberos.$DOMAIN"
 
 set +e


### PR DESCRIPTION
Cert are located at a different place on RHEL8 in a file instead of a cert db fot HTTPD. The script has been modified to depend on this file when fetching the cert requiest id on RHEL8.

See detailed description in the commit message.