### PR TITLE
CB-21883 load GCP related keystore from google.jks instead of google.p12 to avoid the usage of PBEWithSHA1AndRC2_40 algorithm

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpHttpClientConfig.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpHttpClientConfig.java
@@ -26,7 +26,7 @@ public class GcpHttpClientConfig {
 
     private KeyStore getCertificateTrustStore() throws IOException, GeneralSecurityException {
         KeyStore certTrustStore = SecurityUtils.getDefaultKeyStore();
-        try (InputStream keyStoreStream = GoogleUtils.class.getResourceAsStream("google.p12")) {
+        try (InputStream keyStoreStream = GoogleUtils.class.getResourceAsStream("google.jks")) {
             SecurityUtils.loadKeyStore(certTrustStore, Objects.requireNonNull(keyStoreStream), "notasecret");
         }
         return certTrustStore;


### PR DESCRIPTION
This fix is intended to solve the manowar-gov-dev deployment issues of CB services.