### PR TITLE
CB-21834 Azure datalake upgrade E2E test fails on master with bad request from Azure related to image creation

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureImageFormatValidator.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureImageFormatValidator.java
@@ -155,7 +155,10 @@ public class AzureImageFormatValidator implements Validator {
     }
 
     public boolean isMarketplaceImageFormat(Image image) {
-        String imageUri = image.getImageName();
+        return isMarketplaceImageFormat(image.getImageName());
+    }
+
+    public boolean isMarketplaceImageFormat(String imageUri) {
         Matcher matcher = MARKETPLACE_PATTERN.matcher(imageUri);
         if (matcher.matches()) {
             LOGGER.debug("Image with name {} is a valid marketplace image", imageUri);
@@ -167,7 +170,10 @@ public class AzureImageFormatValidator implements Validator {
     }
 
     public boolean isVhdImageFormat(Image image) {
-        String imageUri = image.getImageName();
+        return isVhdImageFormat(image.getImageName());
+    }
+
+    private boolean isVhdImageFormat(String imageUri) {
         Matcher matcher = VHD_PATTERN.matcher(imageUri);
         if (matcher.matches()) {
             LOGGER.debug("Image with name {} is a valid VHD based image", imageUri);

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnectorTest.java
@@ -164,7 +164,7 @@ public class AzureResourceConnectorTest {
     public void testWhenTemplateDeploymentDoesNotExistThenComputeResourceServiceBuildsTheResources() {
         when(client.templateDeploymentExists(RESOURCE_GROUP_NAME, STACK_NAME)).thenReturn(false);
         when(client.createTemplateDeployment(any(), any(), any(), any())).thenReturn(deployment);
-        when(azureImageFormatValidator.isMarketplaceImageFormat(any())).thenReturn(false);
+        when(azureImageFormatValidator.isMarketplaceImageFormat(any(Image.class))).thenReturn(false);
 
         AdjustmentTypeWithThreshold adjustmentTypeWithThreshold = new AdjustmentTypeWithThreshold(ADJUSTMENT_TYPE, THRESHOLD);
         underTest.launch(ac, stack, notifier, adjustmentTypeWithThreshold);
@@ -219,7 +219,7 @@ public class AzureResourceConnectorTest {
     public void testWhenMarketplaceImageThenTemplateBuilderUsesMarketplaceImage() {
         when(client.templateDeploymentExists(RESOURCE_GROUP_NAME, STACK_NAME)).thenReturn(false);
         when(client.createTemplateDeployment(any(), any(), any(), any())).thenReturn(deployment);
-        when(azureImageFormatValidator.isMarketplaceImageFormat(any())).thenReturn(true);
+        when(azureImageFormatValidator.isMarketplaceImageFormat(any(Image.class))).thenReturn(true);
         when(stack.getParameters()).thenReturn(Map.of(ACCEPTANCE_POLICY_PARAMETER, Boolean.TRUE.toString()));
         ReflectionTestUtils.setField(underTest, "enableAzureImageTermsAutomaticSigner", true);
 
@@ -234,7 +234,7 @@ public class AzureResourceConnectorTest {
     public void testWhenMarketplaceImageThenTemplateBuilderUsesMarketplaceImageGlobalSettingOff() {
         when(client.templateDeploymentExists(RESOURCE_GROUP_NAME, STACK_NAME)).thenReturn(false);
         when(client.createTemplateDeployment(any(), any(), any(), any())).thenReturn(deployment);
-        when(azureImageFormatValidator.isMarketplaceImageFormat(any())).thenReturn(true);
+        when(azureImageFormatValidator.isMarketplaceImageFormat(any(Image.class))).thenReturn(true);
         when(stack.getParameters()).thenReturn(Map.of(ACCEPTANCE_POLICY_PARAMETER, Boolean.FALSE.toString()));
         ReflectionTestUtils.setField(underTest, "enableAzureImageTermsAutomaticSigner", true);
 

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStackViewProviderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStackViewProviderTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -106,15 +107,19 @@ public class AzureStackViewProviderTest {
         when(cloudStack.getGroups()).thenReturn(groups);
         when(cloudStack.getParameters()).thenReturn(Collections.emptyMap());
         when(cloudStack.getNetwork()).thenReturn(network);
-        when(cloudStack.getImage()).thenReturn(imageModel);
         when(network.getStringParameter("resourceGroupName")).thenReturn(RESOURCE_GROUP);
         when(network.getStringParameter("networkId")).thenReturn(NETWORK_ID);
         when(azureUtils.getCustomSubnetIds(network)).thenReturn(Collections.emptyList());
-        when(azureImageFormatValidator.isMarketplaceImageFormat(imageModel)).thenReturn(marketplaceImage);
+        when(azureImageFormatValidator.isMarketplaceImageFormat(IMAGE_ID)).thenReturn(marketplaceImage);
 
         AzureStackView actual = underTest.getAzureStack(azureCredentialView, cloudStack, client, ac);
 
         assertEquals("i1-c4ca4238", actual.getInstancesByGroupType().get(InstanceGroupType.CORE.name()).get(0).getInstanceId());
+        if (marketplaceImage) {
+            assertNull(actual.getInstancesByGroupType().get(InstanceGroupType.CORE.name()).get(0).getCustomImageId());
+        } else {
+            assertEquals("id", actual.getInstancesByGroupType().get(InstanceGroupType.CORE.name()).get(0).getCustomImageId());
+        }
         assertEquals(GROUP_NAME, actual.getInstanceGroups().get(0).getName());
         assertEquals(imageId, actual.getInstancesByGroupType().get(InstanceGroupType.CORE.name()).get(0).getCustomImageId());
 

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTemplateDeploymentServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTemplateDeploymentServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -35,6 +36,7 @@ import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.service.Retry;
 import com.sequenceiq.cloudbreak.service.RetryService;
 
@@ -72,7 +74,7 @@ class AzureTemplateDeploymentServiceTest {
         AuthenticatedContext ac = new AuthenticatedContext(cloudContext, new CloudCredential());
         AzureStackView stackView = mock(AzureStackView.class);
         when(azureResourceGroupMetadataProvider.getResourceGroupName(any(CloudContext.class), any(CloudStack.class))).thenReturn("rg1");
-        when(azureImageFormatValidator.isMarketplaceImageFormat(any())).thenReturn(false);
+        when(azureImageFormatValidator.isMarketplaceImageFormat(isNull(Image.class))).thenReturn(false);
         when(azureStorage.getCustomImage(any(), any(), any())).thenReturn(new AzureImage("1", "image1", true));
         when(azureTemplateBuilder.build(eq("stack1"), eq("1"), any(), any(), any(), any(), any(), any())).thenReturn("template");
         when(retry.testWith1SecDelayMax5Times(any(Supplier.class))).thenAnswer(invocation -> invocation.getArgument(0, Supplier.class).get());

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureImageFormatValidatorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureImageFormatValidatorTest.java
@@ -5,6 +5,8 @@ import static com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureImage
 import static com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureImageTermStatus.NON_READABLE;
 import static com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureImageTermStatus.NOT_ACCEPTED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -248,6 +250,50 @@ public class AzureImageFormatValidatorTest {
         String expected = "Your image name cldrwestus2.blob.core.windows.net/images/cb-cdh-726-210326090153.vhd\" is invalid. " +
                 "Please check the desired format in the documentation!";
         assertEquals(expected, exception.getMessage());
+    }
+
+    @Test
+    void testMarketplaceImageUri() {
+        boolean actualResult = underTest.isMarketplaceImageFormat(MARKETPLACE_IMAGE_NAME);
+        assertTrue(actualResult);
+    }
+
+    @Test
+    void testWrongMarketplaceImageUri() {
+        boolean actualResult = underTest.isMarketplaceImageFormat(INVALID_IMAGE_NAME);
+        assertFalse(actualResult);
+    }
+
+    @Test
+    void testMarketplaceImage() {
+        Image image = new Image(MARKETPLACE_IMAGE_NAME, new HashMap<>(), "centos7", "redhat7", "", "default",
+                "default-id", new HashMap<>());
+        boolean actualResult = underTest.isMarketplaceImageFormat(image);
+        assertTrue(actualResult);
+    }
+
+    @Test
+    void testWrongMarketplaceImage() {
+        Image image = new Image(INVALID_IMAGE_NAME, new HashMap<>(), "centos7", "redhat7", "", "default",
+                "default-id", new HashMap<>());
+        boolean actualResult = underTest.isMarketplaceImageFormat(image);
+        assertFalse(actualResult);
+    }
+
+    @Test
+    void testVhdImage() {
+        Image image = new Image(VALID_IMAGE_NAME, new HashMap<>(), "centos7", "redhat7", "", "default",
+                "default-id", new HashMap<>());
+        boolean actualResult = underTest.isVhdImageFormat(image);
+        assertTrue(actualResult);
+    }
+
+    @Test
+    void testWrongVhdImage() {
+        Image image = new Image(INVALID_IMAGE_NAME, new HashMap<>(), "centos7", "redhat7", "", "default",
+                "default-id", new HashMap<>());
+        boolean actualResult = underTest.isVhdImageFormat(image);
+        assertFalse(actualResult);
     }
 
     private void setupAuthenticatedContext() {


### PR DESCRIPTION
CB-21834 Azure datalake upgrade E2E test fails on master with bad request from Azure related to image creation

In case of marketplace -> vhd upgrade without vm replacement, the original marketplace image is stored in instance metadata, but the image in stack will be replaced with the new vhd one.
The fix: In AzureStackViewProvider.getCustomImageNamePerInstance() we will check if the image is marketplace on instance level when we collect instance image names not boased on image name stored in stack.

The fix was tested with marketplace -> vhd upgrade without vm replacement, after it vertical scale, repair, os upgrade is worked, na azure exception has thrown.
