### PR TITLE
CB-21796 saveHostsPillar should use getNotDeletedInstanceMetaData instead of getAllFunctioningNodes

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/StackDto.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/StackDto.java
@@ -16,6 +16,8 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
@@ -42,6 +44,8 @@ import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
 public class StackDto implements OrchestratorAware, StackDtoDelegate, MdcContextInfoProvider, IdAware {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackDto.class);
 
     private StackView stack;
 
@@ -307,14 +311,27 @@ public class StackDto implements OrchestratorAware, StackDtoDelegate, MdcContext
         Set<Node> ret = new HashSet<>();
         getInstanceGroupDtos().forEach(ig -> {
             InstanceGroupView instanceGroup = ig.getInstanceGroup();
-            ig.getNotDeletedAndNotZombieInstanceMetaData().forEach(im -> {
-                if (StringUtils.isNotBlank(im.getDiscoveryFQDN())) {
-                    ret.add(new Node(im.getPrivateIp(), im.getPublicIp(), im.getInstanceId(),
-                            instanceGroup.getTemplate().getInstanceType(), im.getDiscoveryFQDN(), instanceGroup.getGroupName()));
-                }
-            });
+            List<InstanceMetadataView> notDeletedInstanceMetaData = ig.getNotDeletedInstanceMetaData();
+            filterDuplicatedPrivateIPs(notDeletedInstanceMetaData).values().forEach(im -> {
+                        if (StringUtils.isNotBlank(im.getDiscoveryFQDN())) {
+                            ret.add(new Node(im.getPrivateIp(), im.getPublicIp(), im.getInstanceId(),
+                                    instanceGroup.getTemplate().getInstanceType(), im.getDiscoveryFQDN(), instanceGroup.getGroupName()));
+                        }
+                    });
         });
         return ret;
+    }
+
+    private Map<String, InstanceMetadataView> filterDuplicatedPrivateIPs(List<InstanceMetadataView> notDeletedInstanceMetaData) {
+        return notDeletedInstanceMetaData.stream()
+                .collect(Collectors.toMap(InstanceMetadataView::getPrivateIp, instanceMetadataView -> instanceMetadataView, (i1, i2) -> {
+                    LOGGER.warn("We have the same ip address for two nodes, we will return with the newer node! Affected nodes: {}, {}", i1, i2);
+                    if (i1.getStartDate().compareTo(i2.getStartDate()) < 0) {
+                        return i2;
+                    } else {
+                        return i1;
+                    }
+                }));
     }
 
     public Optional<InstanceGroupView> getGatewayGroup() {

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/dto/StackDtoTest.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/dto/StackDtoTest.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.cloudbreak.dto;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
+import com.sequenceiq.cloudbreak.domain.Template;
+import com.sequenceiq.cloudbreak.view.InstanceGroupView;
+import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
+
+class StackDtoTest {
+
+    @Test
+    void getAllFunctioningNodesAndReturnWithNewerInstancesIfWeHaveTwoInstancesWithTheSamePrivateIp() {
+        Map<String, InstanceGroupDto> instanceGroups = new HashMap<>();
+        ArrayList<InstanceMetadataView> workerInstanceMetadataViews = new ArrayList<>();
+        InstanceMetadataView instanceMetadataView1 = mock(InstanceMetadataView.class);
+        when(instanceMetadataView1.getInstanceStatus()).thenReturn(InstanceStatus.ZOMBIE);
+        when(instanceMetadataView1.getPrivateIp()).thenReturn("192.168.1.1");
+        when(instanceMetadataView1.getStartDate()).thenReturn(1L);
+        when(instanceMetadataView1.getDiscoveryFQDN()).thenReturn("fqdn1");
+        workerInstanceMetadataViews.add(instanceMetadataView1);
+        InstanceMetadataView instanceMetadataView2 = mock(InstanceMetadataView.class);
+        when(instanceMetadataView2.getInstanceStatus()).thenReturn(InstanceStatus.SERVICES_HEALTHY);
+        when(instanceMetadataView2.getPrivateIp()).thenReturn("192.168.1.1");
+        when(instanceMetadataView2.getStartDate()).thenReturn(2L);
+        when(instanceMetadataView2.getDiscoveryFQDN()).thenReturn("fqdn2");
+        workerInstanceMetadataViews.add(instanceMetadataView2);
+        InstanceMetadataView instanceMetadataView3 = mock(InstanceMetadataView.class);
+        when(instanceMetadataView3.getInstanceStatus()).thenReturn(InstanceStatus.SERVICES_HEALTHY);
+        when(instanceMetadataView3.getPrivateIp()).thenReturn("192.168.1.3");
+        when(instanceMetadataView3.getDiscoveryFQDN()).thenReturn("fqdn3");
+        workerInstanceMetadataViews.add(instanceMetadataView3);
+        InstanceGroupView instanceGroupView = mock(InstanceGroupView.class);
+        when(instanceGroupView.getTemplate()).thenReturn(mock(Template.class));
+        instanceGroups.put("worker", new InstanceGroupDto(instanceGroupView, workerInstanceMetadataViews));
+        StackDto stackDto = new StackDto(null, null, null, null, null, instanceGroups, null, null, null, null, null, null, null, null, null, null);
+        Set<Node> allFunctioningNodes = stackDto.getAllFunctioningNodes();
+        assertThat(allFunctioningNodes, hasItem(hasProperty("hostname", equalTo("fqdn2"))));
+        assertThat(allFunctioningNodes, hasItem(hasProperty("hostname", equalTo("fqdn3"))));
+    }
+}


### PR DESCRIPTION
I extended the getAllFunctioningNodes with a function which will only return one node for one ip address, even if we have multiple nodes with the same ip address in the database. With this implementation I would like to avoid the situation where a ZOMBIE node is deleted on provider, but a new upscaled node has the same IP address. Without this implementation the getAllFunctioningNodes would return both nodes, which can cause issues at hosts pillar save, because the key is the private IP address and there would be duplicated key.

**IT IS A CHERRY-PICK FROM MASTER**