### PR TITLE
CB-21952: Added flow initialization event for CCMv1 key remapping to its flow config.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/clusterproxy/reregister/ClusterProxyReRegistrationConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/clusterproxy/reregister/ClusterProxyReRegistrationConfig.java
@@ -81,7 +81,8 @@ public class ClusterProxyReRegistrationConfig
     @Override
     public ClusterProxyReRegistrationEvent[] getInitEvents() {
         return new ClusterProxyReRegistrationEvent[]{
-                CLUSTER_PROXY_RE_REGISTRATION_EVENT
+                CLUSTER_PROXY_RE_REGISTRATION_EVENT,
+                CLUSTER_PROXY_CCMV1_REMAP_EVENT
         };
     }
 


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-21952

Flow creation for this process was failing due to the flow manager not being able to find the flow for the event. This was due to me not setting the init event correctly in the config file for the flow. This is a simple change which fixes this.

As for why I did not see this before, I have been unable to test CCMv1 changes locally for a while now, and decided to leave the verification for mow-dev. This is still something I am okay with as long as we move forward quickly and do not block anything.