### PR TITLE
CB-16526: Mixed package warings should use UPGRADE_FAILED status when upgrade failed

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CandidateImageAwareMixedPackageVersionService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CandidateImageAwareMixedPackageVersionService.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak.service.upgrade.sync;
 
-import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_IN_PROGRESS;
 import static com.sequenceiq.cloudbreak.cloud.model.catalog.ImagePackageVersion.CM;
 import static com.sequenceiq.cloudbreak.cloud.model.catalog.ImagePackageVersion.CM_BUILD_NUMBER;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.STACK_CM_MIXED_PACKAGE_VERSIONS_FAILED;
@@ -23,15 +22,11 @@ import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cluster.model.ParcelInfo;
 import com.sequenceiq.cloudbreak.event.ResourceEvent;
 import com.sequenceiq.cloudbreak.service.parcel.ClouderaManagerProductTransformer;
-import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
 @Service
 public class CandidateImageAwareMixedPackageVersionService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CandidateImageAwareMixedPackageVersionService.class);
-
-    @Inject
-    private CloudbreakEventService eventService;
 
     @Inject
     private MixedPackageMessageProvider mixedPackageMessageProvider;
@@ -41,6 +36,9 @@ public class CandidateImageAwareMixedPackageVersionService {
 
     @Inject
     private ClouderaManagerProductTransformer clouderaManagerProductTransformer;
+
+    @Inject
+    private MixedPackageNotificationService mixedPackageNotificationService;
 
     public void examinePackageVersionsWithAllCandidateImages(Long stackId, Set<Image> candidateImages, String currentCmVersion, Set<ParcelInfo> activeParcels,
             String imageCatalogUrl) {
@@ -104,6 +102,6 @@ public class CandidateImageAwareMixedPackageVersionService {
     }
 
     private void sendNotification(Long stackId, ResourceEvent resourceEvent, List<String> args) {
-        eventService.fireCloudbreakEvent(stackId, UPDATE_IN_PROGRESS.name(), resourceEvent, args);
+        mixedPackageNotificationService.sendNotification(stackId, resourceEvent, args);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/MixedPackageNotificationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/MixedPackageNotificationService.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.cloudbreak.service.upgrade.sync;
+
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_FAILED;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_IN_PROGRESS;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.cloudbreak.service.stackstatus.StackStatusService;
+import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
+
+@Component
+class MixedPackageNotificationService {
+
+    @Inject
+    private CloudbreakEventService eventService;
+
+    @Inject
+    private StackStatusService stackStatusService;
+
+    void sendNotification(Long stackId, ResourceEvent resourceEvent, List<String> args) {
+        Optional<StackStatus> currentStatus = stackStatusService.findFirstByStackIdOrderByCreatedDesc(stackId);
+        Status status = currentStatus.isPresent() && UPDATE_FAILED.equals(currentStatus.get().getStatus()) ? UPDATE_FAILED : UPDATE_IN_PROGRESS;
+        eventService.fireCloudbreakEvent(stackId, status.name(), resourceEvent, args);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/TargetImageAwareMixedPackageVersionService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/TargetImageAwareMixedPackageVersionService.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak.service.upgrade.sync;
 
-import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_IN_PROGRESS;
 import static com.sequenceiq.cloudbreak.cloud.model.catalog.ImagePackageVersion.CM;
 import static com.sequenceiq.cloudbreak.cloud.model.catalog.ImagePackageVersion.CM_BUILD_NUMBER;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.STACK_CM_MIXED_PACKAGE_VERSIONS_FAILED;
@@ -20,15 +19,11 @@ import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cluster.model.ParcelInfo;
 import com.sequenceiq.cloudbreak.event.ResourceEvent;
 import com.sequenceiq.cloudbreak.service.parcel.ClouderaManagerProductTransformer;
-import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
 @Service
 public class TargetImageAwareMixedPackageVersionService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TargetImageAwareMixedPackageVersionService.class);
-
-    @Inject
-    private CloudbreakEventService eventService;
 
     @Inject
     private MixedPackageMessageProvider mixedPackageMessageProvider;
@@ -38,6 +33,9 @@ public class TargetImageAwareMixedPackageVersionService {
 
     @Inject
     private ClouderaManagerProductTransformer clouderaManagerProductTransformer;
+
+    @Inject
+    private MixedPackageNotificationService mixedPackageNotificationService;
 
     public void examinePackageVersionsWithTargetImage(Long stackId, Image targetImage, String activeCmVersion, Set<ParcelInfo> activeParcels) {
         LOGGER.debug("Comparing active package versions {} and active CM version {} with target image {}", activeParcels, activeCmVersion, targetImage);
@@ -97,6 +95,6 @@ public class TargetImageAwareMixedPackageVersionService {
     }
 
     private void sendNotification(Long stackId, ResourceEvent resourceEvent, List<String> args) {
-        eventService.fireCloudbreakEvent(stackId, UPDATE_IN_PROGRESS.name(), resourceEvent, args);
+        mixedPackageNotificationService.sendNotification(stackId, resourceEvent, args);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/MixedPackageNotificationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/MixedPackageNotificationServiceTest.java
@@ -1,0 +1,74 @@
+package com.sequenceiq.cloudbreak.service.upgrade.sync;
+
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_FAILED;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_IN_PROGRESS;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.cloudbreak.service.stackstatus.StackStatusService;
+import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
+
+@ExtendWith(MockitoExtension.class)
+class MixedPackageNotificationServiceTest {
+
+    private static final long STACK_ID = 1L;
+
+    private static final ResourceEvent RESOURCE_EVENT = ResourceEvent.STACK_CM_MIXED_PACKAGE_VERSIONS_FAILED;
+
+    private static final List<String> ARGS = List.of("args");
+
+    @InjectMocks
+    private MixedPackageNotificationService underTest;
+
+    @Mock
+    private CloudbreakEventService eventService;
+
+    @Mock
+    private StackStatusService stackStatusService;
+
+    @Test
+    void testSendNotificationShouldSendUpdateInProgressEvent() {
+        when(stackStatusService.findFirstByStackIdOrderByCreatedDesc(STACK_ID)).thenReturn(createStackStatus(UPDATE_IN_PROGRESS));
+
+        underTest.sendNotification(STACK_ID, RESOURCE_EVENT, ARGS);
+
+        verify(eventService).fireCloudbreakEvent(STACK_ID, UPDATE_IN_PROGRESS.name(), RESOURCE_EVENT, ARGS);
+    }
+
+    @Test
+    void testSendNotificationShouldSendUpdateInProgressEventWhenTheStackStatusIsNotPresent() {
+        when(stackStatusService.findFirstByStackIdOrderByCreatedDesc(STACK_ID)).thenReturn(Optional.empty());
+
+        underTest.sendNotification(STACK_ID, RESOURCE_EVENT, ARGS);
+
+        verify(eventService).fireCloudbreakEvent(STACK_ID, UPDATE_IN_PROGRESS.name(), RESOURCE_EVENT, ARGS);
+    }
+
+    @Test
+    void testSendNotificationShouldSendUpdateFailedEventWhenTheStackStatusUpdateFailed() {
+        when(stackStatusService.findFirstByStackIdOrderByCreatedDesc(STACK_ID)).thenReturn(createStackStatus(UPDATE_FAILED));
+
+        underTest.sendNotification(STACK_ID, RESOURCE_EVENT, ARGS);
+
+        verify(eventService).fireCloudbreakEvent(STACK_ID, UPDATE_FAILED.name(), RESOURCE_EVENT, ARGS);
+    }
+
+    private Optional<StackStatus> createStackStatus(Status status) {
+        StackStatus stackStatus = new StackStatus();
+        stackStatus.setStatus(status);
+        return Optional.of(stackStatus);
+    }
+
+}


### PR DESCRIPTION
When an upgrade fails, the roll-forward is called automatically to sync versions from CM to CDP DB. It, however, uses the UPDATE_IN_PROGRESS notification type.

This is because the roll-forward can be used:

automatically during upgrade failure - UPGRADE_FAILED voluntarily by the customer - UPDATE_IN_PROGRESS