### PR TITLE
CB-21406 Extend Distrox Creation call on API with the azure database type field

### DIFF
--- a/cloud-azure/src/main/resources/templates/arm-flexible-dbstack.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-flexible-dbstack.ftl
@@ -143,7 +143,7 @@
       "type": "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules",
       "apiVersion": "2022-12-01",
       "dependsOn": [
-        "[concat('Microsoft.DBforPostgreSQL/flexibleServers/',parameters('dbServerName'))]"
+        "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', parameters('dbServerName'))]"
       ],
       "properties": {
         "startIpAddress": "0.0.0.0",

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/database/DatabaseAzureRequest.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/database/DatabaseAzureRequest.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
+import com.sequenceiq.common.model.AzureDatabaseType;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DatabaseAzureRequest implements Serializable {
+    @ApiModelProperty(ModelDescriptions.Database.AZURE_DATABASE_TYPE)
+    private AzureDatabaseType azureDatabaseType;
+
+    public AzureDatabaseType getAzureDatabaseType() {
+        return azureDatabaseType == null ? AzureDatabaseType.SINGLE_SERVER : azureDatabaseType;
+    }
+
+    public void setAzureDatabaseType(AzureDatabaseType azureDatabaseType) {
+        this.azureDatabaseType = azureDatabaseType;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/database/DatabaseRequest.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/database/DatabaseRequest.java
@@ -3,12 +3,23 @@ package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.DatabaseBase;
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DatabaseRequest extends DatabaseBase {
+    @ApiModelProperty(ModelDescriptions.Database.AZURE_DATABASE_REQUEST)
+    private DatabaseAzureRequest databaseAzureRequest;
 
+    public DatabaseAzureRequest getDatabaseAzureRequest() {
+        return databaseAzureRequest;
+    }
+
+    public void setDatabaseAzureRequest(DatabaseAzureRequest databaseAzureRequest) {
+        this.databaseAzureRequest = databaseAzureRequest;
+    }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -482,6 +482,8 @@ public class ModelDescriptions {
         public static final String DATABASE_REQUEST_CLUSTER_NAME = "requested cluster name";
         public static final String DATABASE_CONNECTION_TEST_RESULT = "result of RDS connection test";
         public static final String DATABASE_REQUEST = "unsaved RDS config to be tested by connectivity";
+        public static final String AZURE_DATABASE_REQUEST = "Azure Database request.";
+        public static final String AZURE_DATABASE_TYPE = "The type of the azure database: single server / flexible server";
     }
 
     public static class DatabaseServerModelDescription {

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/database/DistroXDatabaseAzureRequest.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/database/DistroXDatabaseAzureRequest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions.Database;
+import com.sequenceiq.common.model.AzureDatabaseType;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -13,15 +14,15 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_NULL)
-public class DistroXDatabaseRequest extends DistroXDatabaseBase implements Serializable {
-    @ApiModelProperty(Database.AZURE_DATABASE_REQUEST)
-    private DistroXDatabaseAzureRequest databaseAzureRequest;
+public class DistroXDatabaseAzureRequest implements Serializable {
+    @ApiModelProperty(Database.AZURE_DATABASE_TYPE)
+    private AzureDatabaseType azureDatabaseType;
 
-    public DistroXDatabaseAzureRequest getDatabaseAzureRequest() {
-        return databaseAzureRequest;
+    public AzureDatabaseType getAzureDatabaseType() {
+        return azureDatabaseType == null ? AzureDatabaseType.SINGLE_SERVER : azureDatabaseType;
     }
 
-    public void setDatabaseAzureRequest(DistroXDatabaseAzureRequest databaseAzureRequest) {
-        this.databaseAzureRequest = databaseAzureRequest;
+    public void setAzureDatabaseType(AzureDatabaseType azureDatabaseType) {
+        this.azureDatabaseType = azureDatabaseType;
     }
 }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Database.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Database.java
@@ -1,0 +1,78 @@
+package com.sequenceiq.cloudbreak.domain.stack;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.json.JsonToString;
+import com.sequenceiq.cloudbreak.domain.ProvisionEntity;
+import com.sequenceiq.cloudbreak.domain.converter.DatabaseAvailabilityTypeConverter;
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+
+@Entity
+@EntityType(entityClass = Database.class)
+@Table(name = "database")
+public class Database implements ProvisionEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "database_generator")
+    @SequenceGenerator(name = "database_generator", sequenceName = "database_id_seq", allocationSize = 1)
+    private Long id;
+
+    @Convert(converter = DatabaseAvailabilityTypeConverter.class)
+    private DatabaseAvailabilityType externalDatabaseAvailabilityType;
+
+    private String externalDatabaseEngineVersion;
+
+    @Convert(converter = JsonToString.class)
+    @Column(columnDefinition = "TEXT")
+    private Json attributes;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public DatabaseAvailabilityType getExternalDatabaseAvailabilityType() {
+        return externalDatabaseAvailabilityType;
+    }
+
+    public void setExternalDatabaseAvailabilityType(DatabaseAvailabilityType externalDatabaseAvailabilityType) {
+        this.externalDatabaseAvailabilityType = externalDatabaseAvailabilityType;
+    }
+
+    public String getExternalDatabaseEngineVersion() {
+        return externalDatabaseEngineVersion;
+    }
+
+    public void setExternalDatabaseEngineVersion(String externalDatabaseEngineVersion) {
+        this.externalDatabaseEngineVersion = externalDatabaseEngineVersion;
+    }
+
+    public Json getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Json attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String toString() {
+        return "Database{" +
+                "id=" + id +
+                ", externalDatabaseAvailabilityType=" + externalDatabaseAvailabilityType +
+                ", externalDatabaseEngineVersion='" + externalDatabaseEngineVersion + '\'' +
+                ", attributes=" + attributes +
+                '}';
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
@@ -86,6 +86,7 @@ import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroup;
 import com.sequenceiq.cloudbreak.domain.view.ClusterComponentView;
 import com.sequenceiq.cloudbreak.dto.InstanceGroupDto;
 import com.sequenceiq.cloudbreak.dto.StackDtoDelegate;
+import com.sequenceiq.cloudbreak.util.DatabaseParameterFallbackUtil;
 import com.sequenceiq.cloudbreak.view.GatewayView;
 import com.sequenceiq.cloudbreak.view.InstanceGroupView;
 import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
@@ -250,6 +251,10 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource, Orchestra
      * the original name.
      */
     private String originalName;
+
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "database_id")
+    private Database database;
 
     public String getResourceCrn() {
         return resourceCrn;
@@ -983,7 +988,7 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource, Orchestra
     }
 
     public DatabaseAvailabilityType getExternalDatabaseCreationType() {
-        return externalDatabaseCreationType;
+        return DatabaseParameterFallbackUtil.getExternalDatabaseCreationType(database, externalDatabaseCreationType);
     }
 
     public void setExternalDatabaseCreationType(DatabaseAvailabilityType externalDatabaseCreationType) {
@@ -1025,7 +1030,7 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource, Orchestra
     }
 
     public String getExternalDatabaseEngineVersion() {
-        return externalDatabaseEngineVersion;
+        return DatabaseParameterFallbackUtil.getExternalDatabaseEngineVersion(database, externalDatabaseEngineVersion);
     }
 
     @Override
@@ -1082,6 +1087,14 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource, Orchestra
         return new ArrayList<>(instanceGroups);
     }
 
+    public Database getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(Database database) {
+        this.database = database;
+    }
+
     @Override
     public String toString() {
         return "Stack{" +
@@ -1131,6 +1144,7 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource, Orchestra
                 ", externalDatabaseEngineVersion=" + externalDatabaseEngineVersion +
                 ", originalName=" + originalName +
                 ", javaVersion=" + javaVersion +
+                ", database=" + database +
                 '}';
     }
 

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/util/DatabaseParameterFallbackUtil.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/util/DatabaseParameterFallbackUtil.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.cloudbreak.util;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.domain.stack.Database;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+
+// TODO It's only needed for handling backward compatibility, can be removed in CB-22002
+public class DatabaseParameterFallbackUtil {
+    private DatabaseParameterFallbackUtil() {
+    }
+
+    public static Database setupDatabaseInitParams(Stack stack, DatabaseAvailabilityType externalDatabaseCreationType, String externalDatabaseEngineVersion) {
+        return setupDatabaseInitParams(stack, externalDatabaseCreationType, externalDatabaseEngineVersion, null);
+    }
+
+    public static Database setupDatabaseInitParams(Stack stack, DatabaseAvailabilityType databaseAvailabilityType, String dbEngineVersion,
+            Json attributes) {
+        Database database = new Database();
+        database.setExternalDatabaseAvailabilityType(databaseAvailabilityType);
+        database.setExternalDatabaseEngineVersion(dbEngineVersion);
+        database.setAttributes(attributes);
+        // TODO only for backward compatibility, can be removed in CB-22002
+        stack.setExternalDatabaseCreationType(databaseAvailabilityType);
+        stack.setExternalDatabaseEngineVersion(dbEngineVersion);
+        return database;
+    }
+
+    public static String getExternalDatabaseEngineVersion(Database database, String fallbackExternalDatabaseEngineVersion) {
+        return database != null ? database.getExternalDatabaseEngineVersion() : fallbackExternalDatabaseEngineVersion;
+    }
+
+    public static DatabaseAvailabilityType getExternalDatabaseCreationType(Database database, DatabaseAvailabilityType fallbackExternalDatabaseCreationType) {
+        return database != null ? database.getExternalDatabaseAvailabilityType() : fallbackExternalDatabaseCreationType;
+    }
+}

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/util/DatabaseParameterFallbackUtilTest.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/util/DatabaseParameterFallbackUtilTest.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.cloudbreak.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
+import com.sequenceiq.cloudbreak.domain.stack.Database;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+
+public class DatabaseParameterFallbackUtilTest {
+
+    @Test
+    public void testSetupDatabaseInitParams() {
+        Stack stack = new Stack();
+        Database database = DatabaseParameterFallbackUtil.setupDatabaseInitParams(stack, DatabaseAvailabilityType.HA, "1.0");
+        assertEquals(DatabaseAvailabilityType.HA, database.getExternalDatabaseAvailabilityType());
+        assertEquals("1.0", database.getExternalDatabaseEngineVersion());
+        assertEquals(DatabaseAvailabilityType.HA, stack.getExternalDatabaseCreationType());
+        assertEquals("1.0", stack.getExternalDatabaseEngineVersion());
+    }
+
+    @Test
+    public void testGetDatabaseEngineVersion() {
+        Database database = new Database();
+        database.setExternalDatabaseEngineVersion("2.0");
+        String fallbackDatabaseEngineVersion = "fallback2.0";
+        assertEquals("2.0", DatabaseParameterFallbackUtil.getExternalDatabaseEngineVersion(database, fallbackDatabaseEngineVersion));
+        assertEquals(fallbackDatabaseEngineVersion, DatabaseParameterFallbackUtil.getExternalDatabaseEngineVersion(null, fallbackDatabaseEngineVersion));
+    }
+
+    @Test
+    public void testGetDatabaseAvailabilityType() {
+        Database sdxDatabase = new Database();
+        sdxDatabase.setExternalDatabaseAvailabilityType(DatabaseAvailabilityType.NONE);
+        DatabaseAvailabilityType fallbackDatabaseAvailabilityType = DatabaseAvailabilityType.HA;
+        assertEquals(DatabaseAvailabilityType.NONE,
+                DatabaseParameterFallbackUtil.getExternalDatabaseCreationType(sdxDatabase, fallbackDatabaseAvailabilityType));
+        assertEquals(DatabaseAvailabilityType.HA,
+                DatabaseParameterFallbackUtil.getExternalDatabaseCreationType(null, fallbackDatabaseAvailabilityType));
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/DatabaseRequestToDatabaseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/DatabaseRequestToDatabaseConverter.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.cloudbreak.converter.v4.stacks;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAzureRequest;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseRequest;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.auth.altus.model.Entitlement;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.domain.stack.Database;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.util.DatabaseParameterFallbackUtil;
+import com.sequenceiq.common.model.AzureDatabaseType;
+
+@Component
+public class DatabaseRequestToDatabaseConverter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseRequestToDatabaseConverter.class);
+
+    @Inject
+    private EntitlementService entitlementService;
+
+    public Database convert(Stack stack, CloudPlatform cloudPlatform, DatabaseRequest source) {
+        Database database = new Database();
+        if (source != null) {
+            database = DatabaseParameterFallbackUtil.setupDatabaseInitParams(
+                    stack, source.getAvailabilityType(), source.getDatabaseEngineVersion(), configureAzureDatabaseIfNeeded(cloudPlatform, source).orElse(null));
+        }
+        return database;
+    }
+
+    private Optional<Json> configureAzureDatabaseIfNeeded(CloudPlatform cloudPlatform, DatabaseRequest databaseRequest) {
+        if (cloudPlatform == CloudPlatform.AZURE) {
+            AzureDatabaseType azureDatabaseType = Optional.ofNullable(databaseRequest)
+                    .map(DatabaseRequest::getDatabaseAzureRequest)
+                    .map(DatabaseAzureRequest::getAzureDatabaseType)
+                    .orElse(AzureDatabaseType.SINGLE_SERVER);
+            String accountId = ThreadBasedUserCrnProvider.getAccountId();
+            if (azureDatabaseType == AzureDatabaseType.FLEXIBLE_SERVER) {
+                if (!entitlementService.isAzureDatabaseFlexibleServerEnabled(accountId)) {
+                    LOGGER.info("Azure Flexible Database Server creation is not entitled for {} account.", accountId);
+                    throw new BadRequestException("You are not entitled to use Flexible Database Server on Azure for your cluster." +
+                            " Please contact Cloudera to enable " + Entitlement.CDP_AZURE_DATABASE_FLEXIBLE_SERVER + " for your account");
+                }
+            }
+            Map<String, Object> params = new HashMap<>();
+            params.put(AzureDatabaseType.AZURE_DATABASE_TYPE_KEY, azureDatabaseType.name());
+            return Optional.of(new Json(params));
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/provision/handler/CreateExternalDatabaseHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/provision/handler/CreateExternalDatabaseHandler.java
@@ -78,7 +78,7 @@ public class CreateExternalDatabaseHandler implements EventHandler<CreateExterna
                 LOGGER.debug("Getting environment CRN for stack {}", stack.getName());
                 DetailedEnvironmentResponse environment = environmentClientService.getByCrn(stack.getEnvironmentCrn());
                 environmentValidator.checkValidEnvironment(stack.getName(), externalDatabase, environment);
-                provisionService.provisionDatabase(stack.getCluster(), externalDatabase, environment);
+                provisionService.provisionDatabase(stack, environment);
                 LOGGER.debug("Updating stack {} status from {} to {}",
                         stack.getName(), stack.getStatus().name(), DetailedStackStatus.PROVISION_REQUESTED.name());
                 stackUpdaterService.updateStatus(stack.getId(), DetailedStackStatus.PROVISION_REQUESTED,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/DatabaseRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/DatabaseRepository.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.repository;
+
+import javax.transaction.Transactional;
+
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.sequenceiq.cloudbreak.domain.stack.Database;
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+
+@Repository
+@Transactional(Transactional.TxType.REQUIRED)
+@EntityType(entityClass = Database.class)
+public interface DatabaseRepository extends CrudRepository<Database, Long> {
+    @Modifying
+    @Query("UPDATE Database d SET d.externalDatabaseEngineVersion = :externalDatabaseEngineVersion WHERE d.id = :id")
+    int updateExternalDatabaseEngineVersion(@Param("id") Long id, @Param("externalDatabaseEngineVersion") String externalDatabaseEngineVersion);
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
@@ -476,7 +476,7 @@ public interface StackRepository extends WorkspaceResourceRepository<Stack, Long
 
     @Modifying
     @Query("UPDATE Stack s SET s.externalDatabaseEngineVersion = :externalDatabaseEngineVersion WHERE s.id = :stackId")
-    void updateExternalDatabaseEngineVersion(@Param("stackId") Long stackId, @Param("externalDatabaseEngineVersion") String externalDatabaseEngineVersion);
+    int updateExternalDatabaseEngineVersion(@Param("stackId") Long stackId, @Param("externalDatabaseEngineVersion") String externalDatabaseEngineVersion);
 
     @Modifying
     @Query("UPDATE Stack s SET s.stackVersion = :stackVersion WHERE s.id = :stackId")
@@ -488,4 +488,6 @@ public interface StackRepository extends WorkspaceResourceRepository<Stack, Long
     @Query("SELECT s.region FROM Stack s WHERE s.id = :stackId")
     Optional<String> findRegionByStackId(@Param("stackId") Long stackId);
 
+    @Query("SELECT s.database.id FROM Stack s WHERE s.id = :stackId")
+    Optional<Long> findDatabaseIdByStackId(@Param("stackId") Long stackId);
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/database/DatabaseService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/database/DatabaseService.java
@@ -12,7 +12,9 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.StackDatabaseServerResponse;
+import com.sequenceiq.cloudbreak.domain.stack.Database;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.repository.DatabaseRepository;
 import com.sequenceiq.distrox.v1.distrox.StackOperations;
 import com.sequenceiq.distrox.v1.distrox.converter.DatabaseServerConverter;
 import com.sequenceiq.flow.api.model.operation.OperationView;
@@ -36,6 +38,9 @@ public class DatabaseService {
 
     @Inject
     private DatabaseServerConverter databaseServerConverter;
+
+    @Inject
+    private DatabaseRepository databaseRepository;
 
     public StackDatabaseServerResponse getDatabaseServer(NameOrCrn nameOrCrn) {
         Stack stack = stackOperations.getStackByNameOrCrn(nameOrCrn);
@@ -62,4 +67,11 @@ public class DatabaseService {
         return result;
     }
 
+    public int updateExternalDatabaseEngineVersion(Long id, String externalDatabaseEngineVersion) {
+        return databaseRepository.updateExternalDatabaseEngineVersion(id, externalDatabaseEngineVersion);
+    }
+
+    public Database save(Database database) {
+        return databaseRepository.save(database);
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/externaldatabase/AzureDatabaseServerParameterDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/externaldatabase/AzureDatabaseServerParameterDecorator.java
@@ -1,10 +1,13 @@
 package com.sequenceiq.cloudbreak.service.externaldatabase;
 
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.service.externaldatabase.model.DatabaseServerParameter;
+import com.sequenceiq.common.model.AzureDatabaseType;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4StackRequest;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.azure.AzureDatabaseServerV4Parameters;
 
@@ -33,14 +36,18 @@ public class AzureDatabaseServerParameterDecorator implements DatabaseServerPara
             parameters.setBackupRetentionDays(retentionPeriodNonHa);
             parameters.setGeoRedundantBackup(geoRedundantBackupNonHa);
         }
-        parameters.setBackupRetentionDays(retentionPeriodHa);
-        parameters.setGeoRedundantBackup(geoRedundantBackupHa);
         parameters.setDbVersion(serverParameter.getEngineVersion());
+        parameters.setAzureDatabaseType(getAzureDatabaseType(serverParameter.getAttributes()));
         request.setAzure(parameters);
     }
 
     @Override
     public CloudPlatform getCloudPlatform() {
         return CloudPlatform.AZURE;
+    }
+
+    private AzureDatabaseType getAzureDatabaseType(Map<String, Object> attributes) {
+        String dbTypeStr = (String) attributes.get(AzureDatabaseType.AZURE_DATABASE_TYPE_KEY);
+        return AzureDatabaseType.safeValueOf(dbTypeStr);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/externaldatabase/model/DatabaseServerParameter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/externaldatabase/model/DatabaseServerParameter.java
@@ -1,14 +1,19 @@
 package com.sequenceiq.cloudbreak.service.externaldatabase.model;
 
+import java.util.Map;
+
 public class DatabaseServerParameter {
 
     private final boolean highlyAvailable;
 
     private final String engineVersion;
 
+    private final Map<String, Object> attributes;
+
     private DatabaseServerParameter(Builder builder) {
         this.highlyAvailable = builder.highlyAvailable;
         this.engineVersion = builder.engineVersion;
+        this.attributes = builder.attributes != null ? builder.attributes : Map.of();
     }
 
     public boolean isHighlyAvailable() {
@@ -17,6 +22,10 @@ public class DatabaseServerParameter {
 
     public String getEngineVersion() {
         return engineVersion;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
     }
 
     public static Builder builder() {
@@ -29,6 +38,8 @@ public class DatabaseServerParameter {
 
         private String engineVersion;
 
+        private Map<String, Object> attributes;
+
         public Builder withHighlyAvailable(boolean highlyAvailable) {
             this.highlyAvailable = highlyAvailable;
             return this;
@@ -36,6 +47,11 @@ public class DatabaseServerParameter {
 
         public Builder withEngineVersion(String engineVersion) {
             this.engineVersion = engineVersion;
+            return this;
+        }
+
+        public Builder withAttributes(Map<String, Object> attributes) {
+            this.attributes = attributes;
             return this;
         }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateService.java
@@ -52,6 +52,7 @@ import com.sequenceiq.cloudbreak.converter.v4.clustertemplate.ClusterTemplateVie
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.Network;
 import com.sequenceiq.cloudbreak.domain.projection.ClusterTemplateStatusView;
+import com.sequenceiq.cloudbreak.domain.stack.Database;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterTemplate;
@@ -62,6 +63,7 @@ import com.sequenceiq.cloudbreak.service.AbstractWorkspaceAwareResourceService;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
+import com.sequenceiq.cloudbreak.service.database.DatabaseService;
 import com.sequenceiq.cloudbreak.service.network.NetworkService;
 import com.sequenceiq.cloudbreak.service.orchestrator.OrchestratorService;
 import com.sequenceiq.cloudbreak.service.runtimes.SupportedRuntimes;
@@ -143,6 +145,9 @@ public class ClusterTemplateService extends AbstractWorkspaceAwareResourceServic
     @Inject
     private InternalClusterTemplateValidator internalClusterTemplateValidator;
 
+    @Inject
+    private DatabaseService databaseService;
+
     @Override
     protected WorkspaceResourceRepository<ClusterTemplate, Long> repository() {
         return clusterTemplateRepository;
@@ -208,6 +213,11 @@ public class ClusterTemplateService extends AbstractWorkspaceAwareResourceServic
             if (cluster != null) {
                 cluster.setWorkspace(stackTemplate.getWorkspace());
                 clusterService.saveWithRef(cluster);
+            }
+
+            Database database = stackTemplate.getDatabase();
+            if (database != null) {
+                databaseService.save(database);
             }
 
             stackTemplate.setResourceCrn(createCRN(ThreadBasedUserCrnProvider.getAccountId()));

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXDatabaseRequestToStackDatabaseRequestConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXDatabaseRequestToStackDatabaseRequestConverter.java
@@ -5,8 +5,10 @@ import static java.lang.String.format;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAzureRequest;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseRequest;
 import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseAvailabilityType;
+import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseAzureRequest;
 import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseRequest;
 
 @Component
@@ -18,6 +20,7 @@ public class DistroXDatabaseRequestToStackDatabaseRequestConverter {
         DatabaseRequest request = new DatabaseRequest();
         request.setAvailabilityType(convertAvailabilityType(source.getAvailabilityType()));
         request.setDatabaseEngineVersion(source.getDatabaseEngineVersion());
+        request.setDatabaseAzureRequest(convertDistroxDatabaseAzureRequest(source.getDatabaseAzureRequest()));
         return request;
     }
 
@@ -27,39 +30,50 @@ public class DistroXDatabaseRequestToStackDatabaseRequestConverter {
             request.setAvailabilityType(convertAvailabilityType(source.getAvailabilityType()));
         }
         request.setDatabaseEngineVersion(source.getDatabaseEngineVersion());
+        request.setDatabaseAzureRequest(convertDatabaseAzureRequest(source.getDatabaseAzureRequest()));
         return request;
     }
 
     private DatabaseAvailabilityType convertAvailabilityType(DistroXDatabaseAvailabilityType availabilityType) {
-        switch (availabilityType) {
-            case NONE:
-                return DatabaseAvailabilityType.NONE;
-            case NON_HA:
-                return DatabaseAvailabilityType.NON_HA;
-            case HA:
-                return DatabaseAvailabilityType.HA;
-            case ON_ROOT_VOLUME:
-                return DatabaseAvailabilityType.ON_ROOT_VOLUME;
-            default:
-                throw new IllegalStateException(format(UNEXPECTED_AVAILABILITY_TYPE_MSG_FORMAT, availabilityType.name()));
-        }
+        return switch (availabilityType) {
+            case NONE -> DatabaseAvailabilityType.NONE;
+            case NON_HA -> DatabaseAvailabilityType.NON_HA;
+            case HA -> DatabaseAvailabilityType.HA;
+            case ON_ROOT_VOLUME -> DatabaseAvailabilityType.ON_ROOT_VOLUME;
+            default -> throw new IllegalStateException(format(UNEXPECTED_AVAILABILITY_TYPE_MSG_FORMAT, availabilityType.name()));
+        };
     }
 
     private DistroXDatabaseAvailabilityType convertAvailabilityType(DatabaseAvailabilityType availabilityType) {
         if (availabilityType == null) {
             throw new IllegalArgumentException(format(UNEXPECTED_AVAILABILITY_TYPE_MSG_FORMAT, "null"));
         }
-        switch (availabilityType) {
-            case NONE:
-                return DistroXDatabaseAvailabilityType.NONE;
-            case NON_HA:
-                return DistroXDatabaseAvailabilityType.NON_HA;
-            case HA:
-                return DistroXDatabaseAvailabilityType.HA;
-            case ON_ROOT_VOLUME:
-                return DistroXDatabaseAvailabilityType.ON_ROOT_VOLUME;
-            default:
-                throw new IllegalStateException(format(UNEXPECTED_AVAILABILITY_TYPE_MSG_FORMAT, availabilityType.name()));
+        return switch (availabilityType) {
+            case NONE -> DistroXDatabaseAvailabilityType.NONE;
+            case NON_HA -> DistroXDatabaseAvailabilityType.NON_HA;
+            case HA -> DistroXDatabaseAvailabilityType.HA;
+            case ON_ROOT_VOLUME -> DistroXDatabaseAvailabilityType.ON_ROOT_VOLUME;
+            default -> throw new IllegalStateException(format(UNEXPECTED_AVAILABILITY_TYPE_MSG_FORMAT, availabilityType.name()));
+        };
+    }
+
+    private DatabaseAzureRequest convertDistroxDatabaseAzureRequest(DistroXDatabaseAzureRequest distroxDatabaseAzureRequest) {
+        if (distroxDatabaseAzureRequest != null) {
+            DatabaseAzureRequest databaseAzureRequest = new DatabaseAzureRequest();
+            databaseAzureRequest.setAzureDatabaseType(distroxDatabaseAzureRequest.getAzureDatabaseType());
+            return databaseAzureRequest;
+        } else {
+            return null;
+        }
+    }
+
+    private DistroXDatabaseAzureRequest convertDatabaseAzureRequest(DatabaseAzureRequest databaseAzureRequest) {
+        if (databaseAzureRequest != null) {
+            DistroXDatabaseAzureRequest distroXDatabaseAzureRequest = new DistroXDatabaseAzureRequest();
+            distroXDatabaseAzureRequest.setAzureDatabaseType(databaseAzureRequest.getAzureDatabaseType());
+            return distroXDatabaseAzureRequest;
+        } else {
+            return null;
         }
     }
 }

--- a/core/src/main/resources/schema/app/20230504140308_CB-21406_Collect_stack_related_db_properties_in_Database_entity.sql
+++ b/core/src/main/resources/schema/app/20230504140308_CB-21406_Collect_stack_related_db_properties_in_Database_entity.sql
@@ -1,0 +1,36 @@
+-- // CB-21406 Collect stack related db properties in Database entity
+-- Migration SQL that makes the change goes here.
+
+CREATE TABLE IF NOT EXISTS database (
+    id bigserial NOT NULL,
+    stack_id bigserial NOT NULL,
+    externaldatabaseavailabilitytype character varying(255),
+    externaldatabaseengineversion character varying(255),
+    attributes text,
+    PRIMARY KEY (id)
+);
+
+ALTER TABLE stack ADD COLUMN IF NOT EXISTS database_id bigint;
+
+ALTER TABLE ONLY stack ADD CONSTRAINT fk_databaseidstack FOREIGN KEY (database_id) REFERENCES database(id);
+
+INSERT INTO database (stack_id, externaldatabaseavailabilitytype, externaldatabaseengineversion)
+   SELECT stack.id, stack.externaldatabasecreationtype, stack.externaldatabaseengineversion FROM stack;
+
+UPDATE stack
+   SET database_id = database.id
+   FROM database
+   WHERE database.stack_id = stack.id;
+
+ALTER TABLE database DROP COLUMN IF EXISTS stack_id;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE ONLY stack DROP CONSTRAINT IF EXISTS fk_databaseidstack;
+
+ALTER TABLE stack DROP COLUMN IF EXISTS database_id;
+
+DROP INDEX IF EXISTS unq_index_database_stack_id;
+
+DROP TABLE IF EXISTS database;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/DatabaseRequestToDatabaseConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/DatabaseRequestToDatabaseConverterTest.java
@@ -1,0 +1,83 @@
+package com.sequenceiq.cloudbreak.converter.v4.stacks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAzureRequest;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseRequest;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.domain.stack.Database;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.common.model.AzureDatabaseType;
+
+@ExtendWith(MockitoExtension.class)
+class DatabaseRequestToDatabaseConverterTest {
+    private static final String ACTOR = "crn:cdp:iam:us-west-1:cloudera:user:__internal__actor__";
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @InjectMocks
+    private DatabaseRequestToDatabaseConverter service;
+
+    @Test
+    void testConvertWithAzureSingleServer() {
+        Stack stack = new Stack();
+        DatabaseRequest databaseRequest = new DatabaseRequest();
+
+        Database database = ThreadBasedUserCrnProvider.doAs(ACTOR, () -> service.convert(stack, CloudPlatform.AZURE, databaseRequest));
+
+        assertEquals(AzureDatabaseType.SINGLE_SERVER.name(), database.getAttributes().getMap().get(AzureDatabaseType.AZURE_DATABASE_TYPE_KEY));
+    }
+
+    @Test
+    void testConvertWithAws() {
+        Stack stack = new Stack();
+        DatabaseRequest databaseRequest = new DatabaseRequest();
+
+        Database database = ThreadBasedUserCrnProvider.doAs(ACTOR, () -> service.convert(stack, CloudPlatform.AWS, databaseRequest));
+
+        assertNull(database.getAttributes());
+    }
+
+    @Test
+    void testConvertWithAzureFlexibleServer() {
+        Stack stack = new Stack();
+        DatabaseRequest databaseRequest = new DatabaseRequest();
+        DatabaseAzureRequest databaseAzureRequest = new DatabaseAzureRequest();
+        databaseAzureRequest.setAzureDatabaseType(AzureDatabaseType.FLEXIBLE_SERVER);
+        databaseRequest.setDatabaseAzureRequest(databaseAzureRequest);
+        when(entitlementService.isAzureDatabaseFlexibleServerEnabled(anyString())).thenReturn(true);
+
+        Database database = ThreadBasedUserCrnProvider.doAs(ACTOR, () -> service.convert(stack, CloudPlatform.AZURE, databaseRequest));
+
+        assertEquals(AzureDatabaseType.FLEXIBLE_SERVER.name(), database.getAttributes().getMap().get(AzureDatabaseType.AZURE_DATABASE_TYPE_KEY));
+    }
+
+    @Test
+    void testConvertWithAzureFlexibleServerWhenNotAllowed() {
+        Stack stack = new Stack();
+        DatabaseRequest databaseRequest = new DatabaseRequest();
+        DatabaseAzureRequest databaseAzureRequest = new DatabaseAzureRequest();
+        databaseAzureRequest.setAzureDatabaseType(AzureDatabaseType.FLEXIBLE_SERVER);
+        databaseRequest.setDatabaseAzureRequest(databaseAzureRequest);
+
+        BadRequestException exception = assertThrows(BadRequestException.class,
+                () -> ThreadBasedUserCrnProvider.doAs(ACTOR, () -> service.convert(stack, CloudPlatform.AZURE, databaseRequest)));
+
+        assertTrue(exception.getMessage().contains("You are not entitled to use Flexible Database Server on Azure for your cluster."));
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
@@ -3,11 +3,13 @@ package com.sequenceiq.cloudbreak.converter.v4.stacks;
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.MOCK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
@@ -53,6 +55,7 @@ import com.sequenceiq.cloudbreak.converter.v4.stacks.instancegroup.InstanceGroup
 import com.sequenceiq.cloudbreak.converter.v4.stacks.network.NetworkV4RequestToNetworkConverter;
 import com.sequenceiq.cloudbreak.domain.SecurityGroup;
 import com.sequenceiq.cloudbreak.domain.StackAuthentication;
+import com.sequenceiq.cloudbreak.domain.stack.Database;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
@@ -174,6 +177,9 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
     @Mock
     private EntitlementService entitlementService;
 
+    @Mock
+    private DatabaseRequestToDatabaseConverter databaseRequestToDatabaseConverter;
+
     @BeforeEach
     void setUp() {
         lenient().when(restRequestThreadLocalService.getCloudbreakUser()).thenReturn(cloudbreakUser);
@@ -192,7 +198,8 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
         lenient().when(costTagging.mergeTags(any(CDPTagMergeRequest.class))).thenReturn(new HashMap<>());
         lenient().when(datalakeService.getDatalakeCrn(any(), any())).thenReturn("crn");
         lenient().when(targetedUpscaleSupportService.isUnboundEliminationSupported(anyString())).thenReturn(Boolean.FALSE);
-
+        lenient().when(databaseRequestToDatabaseConverter.convert(any(Stack.class), any(CloudPlatform.class), isNull()))
+                .thenReturn(new Database());
         // GIVEN
         InstanceGroup instanceGroup = new InstanceGroup();
         SecurityGroup securityGroup = new SecurityGroup();
@@ -233,6 +240,7 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
         verify(gatewaySecurityGroupDecorator, times(1))
                 .extendGatewaySecurityGroupWithDefaultGatewayCidrs(any(Stack.class), any(Tunnel.class));
         assertTrue(stack.getCluster().isAutoTlsEnabled());
+        assertNotNull(stack.getDatabase());
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/provision/handler/CreateExternalDatabaseHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/provision/handler/CreateExternalDatabaseHandlerTest.java
@@ -87,7 +87,7 @@ class CreateExternalDatabaseHandlerTest {
     void acceptCatchErrors(Class<? extends Exception> exceptionClass) {
         doAnswer(a -> {
             throw exceptionClass.getDeclaredConstructor().newInstance();
-        }).when(provisionService).provisionDatabase(any(), any(DatabaseAvailabilityType.class), any());
+        }).when(provisionService).provisionDatabase(any(), any());
         DetailedEnvironmentResponse environment = new DetailedEnvironmentResponse();
         environment.setCloudPlatform("cloudplatform");
         when(environmentClientService.getByCrn(anyString())).thenReturn(environment);
@@ -99,7 +99,7 @@ class CreateExternalDatabaseHandlerTest {
 
         underTest.accept(event);
 
-        verify(provisionService).provisionDatabase(any(), eq(DatabaseAvailabilityType.HA), eq(environment));
+        verify(provisionService).provisionDatabase(any(), eq(environment));
 
         verify(environmentValidator).checkValidEnvironment(eq(STACK_NAME), eq(DatabaseAvailabilityType.HA), eq(environment));
 
@@ -119,10 +119,10 @@ class CreateExternalDatabaseHandlerTest {
         when(environmentClientService.getByCrn(anyString())).thenReturn(environment);
 
         doAnswer(a -> {
-            Cluster cluster = a.getArgument(0);
-            cluster.setDatabaseServerCrn(DATABASE_CRN);
+            Stack stack = a.getArgument(0);
+            stack.getCluster().setDatabaseServerCrn(DATABASE_CRN);
             return null;
-        }).when(provisionService).provisionDatabase(any(), any(), any());
+        }).when(provisionService).provisionDatabase(any(), any());
 
         when(stackService.getById(anyLong())).thenReturn(buildStack(DatabaseAvailabilityType.HA));
         CreateExternalDatabaseRequest request =
@@ -131,7 +131,7 @@ class CreateExternalDatabaseHandlerTest {
 
         underTest.accept(event);
 
-        verify(provisionService).provisionDatabase(any(), eq(DatabaseAvailabilityType.HA), eq(environment));
+        verify(provisionService).provisionDatabase(any(), eq(environment));
 
         verify(environmentValidator).checkValidEnvironment(eq(STACK_NAME), eq(DatabaseAvailabilityType.HA), eq(environment));
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/externaldatabase/AzureDatabaseServerParameterDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/externaldatabase/AzureDatabaseServerParameterDecoratorTest.java
@@ -1,0 +1,78 @@
+package com.sequenceiq.cloudbreak.service.externaldatabase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.service.externaldatabase.model.DatabaseServerParameter;
+import com.sequenceiq.common.model.AzureDatabaseType;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4StackRequest;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.azure.AzureDatabaseServerV4Parameters;
+
+class AzureDatabaseServerParameterDecoratorTest {
+    private final AzureDatabaseServerParameterDecorator underTest = new AzureDatabaseServerParameterDecorator();
+
+    @Test
+    void testSetParametersHa() {
+        ReflectionTestUtils.setField(underTest, "retentionPeriodHa", 2);
+        ReflectionTestUtils.setField(underTest, "geoRedundantBackupHa", Boolean.TRUE);
+        ReflectionTestUtils.setField(underTest, "retentionPeriodNonHa", 1);
+        ReflectionTestUtils.setField(underTest, "geoRedundantBackupNonHa", Boolean.FALSE);
+        DatabaseServerV4StackRequest databaseServerV4StackRequest = new DatabaseServerV4StackRequest();
+        DatabaseServerParameter databaseServerParameter = DatabaseServerParameter.builder()
+                .withHighlyAvailable(true)
+                .withEngineVersion("11")
+                .withAttributes(Map.of(AzureDatabaseType.AZURE_DATABASE_TYPE_KEY, AzureDatabaseType.SINGLE_SERVER.name()))
+                .build();
+        underTest.setParameters(databaseServerV4StackRequest, databaseServerParameter);
+        AzureDatabaseServerV4Parameters azureDatabaseServerV4Parameters = databaseServerV4StackRequest.getAzure();
+        assertEquals(2, azureDatabaseServerV4Parameters.getBackupRetentionDays());
+        assertTrue(azureDatabaseServerV4Parameters.getGeoRedundantBackup());
+        assertEquals("11", azureDatabaseServerV4Parameters.getDbVersion());
+        assertEquals(AzureDatabaseType.SINGLE_SERVER, azureDatabaseServerV4Parameters.getAzureDatabaseType());
+    }
+
+    @Test
+    void testSetParametersNonHa() {
+        ReflectionTestUtils.setField(underTest, "retentionPeriodHa", 2);
+        ReflectionTestUtils.setField(underTest, "geoRedundantBackupHa", Boolean.TRUE);
+        ReflectionTestUtils.setField(underTest, "retentionPeriodNonHa", 1);
+        ReflectionTestUtils.setField(underTest, "geoRedundantBackupNonHa", Boolean.FALSE);
+        DatabaseServerV4StackRequest databaseServerV4StackRequest = new DatabaseServerV4StackRequest();
+        DatabaseServerParameter databaseServerParameter = DatabaseServerParameter.builder()
+                .withHighlyAvailable(false)
+                .withEngineVersion("11")
+                .withAttributes(Map.of(AzureDatabaseType.AZURE_DATABASE_TYPE_KEY, AzureDatabaseType.FLEXIBLE_SERVER.name()))
+                .build();
+        underTest.setParameters(databaseServerV4StackRequest, databaseServerParameter);
+        AzureDatabaseServerV4Parameters azureDatabaseServerV4Parameters = databaseServerV4StackRequest.getAzure();
+        assertEquals(1, azureDatabaseServerV4Parameters.getBackupRetentionDays());
+        assertFalse(azureDatabaseServerV4Parameters.getGeoRedundantBackup());
+        assertEquals("11", azureDatabaseServerV4Parameters.getDbVersion());
+        assertEquals(AzureDatabaseType.FLEXIBLE_SERVER, azureDatabaseServerV4Parameters.getAzureDatabaseType());
+    }
+
+    @Test
+    void testSetParametersNonHaNoAttributes() {
+        ReflectionTestUtils.setField(underTest, "retentionPeriodHa", 2);
+        ReflectionTestUtils.setField(underTest, "geoRedundantBackupHa", Boolean.TRUE);
+        ReflectionTestUtils.setField(underTest, "retentionPeriodNonHa", 1);
+        ReflectionTestUtils.setField(underTest, "geoRedundantBackupNonHa", Boolean.FALSE);
+        DatabaseServerV4StackRequest databaseServerV4StackRequest = new DatabaseServerV4StackRequest();
+        DatabaseServerParameter databaseServerParameter = DatabaseServerParameter.builder()
+                .withHighlyAvailable(false)
+                .withEngineVersion("11")
+                .build();
+        underTest.setParameters(databaseServerV4StackRequest, databaseServerParameter);
+        AzureDatabaseServerV4Parameters azureDatabaseServerV4Parameters = databaseServerV4StackRequest.getAzure();
+        assertEquals(1, azureDatabaseServerV4Parameters.getBackupRetentionDays());
+        assertFalse(azureDatabaseServerV4Parameters.getGeoRedundantBackup());
+        assertEquals("11", azureDatabaseServerV4Parameters.getDbVersion());
+        assertEquals(AzureDatabaseType.SINGLE_SERVER, azureDatabaseServerV4Parameters.getAzureDatabaseType());
+    }
+}

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXDatabaseRequestToStackDatabaseRequestConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXDatabaseRequestToStackDatabaseRequestConverterTest.java
@@ -2,12 +2,16 @@ package com.sequenceiq.distrox.v1.distrox.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAzureRequest;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseRequest;
+import com.sequenceiq.common.model.AzureDatabaseType;
 import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseAvailabilityType;
+import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseAzureRequest;
 import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseRequest;
 
 class DistroXDatabaseRequestToStackDatabaseRequestConverterTest {
@@ -34,17 +38,65 @@ class DistroXDatabaseRequestToStackDatabaseRequestConverterTest {
         assertThat(result.getAvailabilityType().name()).isEqualTo(daType.name());
     }
 
+    @Test
     void convertDatabaseEngineVersion() {
         DatabaseRequest source = new DatabaseRequest();
+        source.setAvailabilityType(DatabaseAvailabilityType.NONE);
         source.setDatabaseEngineVersion(DB_VERSION);
         DistroXDatabaseRequest result = underTest.convert(source);
         assertThat(result.getDatabaseEngineVersion()).isEqualTo(DB_VERSION);
     }
 
+    @Test
     void convertDistroXDatabaseEngineVersion() {
         DistroXDatabaseRequest source = new DistroXDatabaseRequest();
+        source.setAvailabilityType(DistroXDatabaseAvailabilityType.NONE);
         source.setDatabaseEngineVersion(DB_VERSION);
         DatabaseRequest result = underTest.convert(source);
         assertThat(result.getDatabaseEngineVersion()).isEqualTo(DB_VERSION);
+    }
+
+    @Test
+    void convertDistroXAzure() {
+        DistroXDatabaseRequest source = new DistroXDatabaseRequest();
+        source.setAvailabilityType(DistroXDatabaseAvailabilityType.NONE);
+        source.setDatabaseEngineVersion(DB_VERSION);
+        source.setDatabaseAzureRequest(new DistroXDatabaseAzureRequest());
+        DatabaseRequest result = underTest.convert(source);
+        assertThat(result.getDatabaseAzureRequest().getAzureDatabaseType()).isEqualTo(AzureDatabaseType.SINGLE_SERVER);
+    }
+
+    @Test
+    void convertDistroXAzureFlexible() {
+        DistroXDatabaseRequest source = new DistroXDatabaseRequest();
+        source.setAvailabilityType(DistroXDatabaseAvailabilityType.NONE);
+        source.setDatabaseEngineVersion(DB_VERSION);
+        DistroXDatabaseAzureRequest distroXDatabaseAzureRequest = new DistroXDatabaseAzureRequest();
+        distroXDatabaseAzureRequest.setAzureDatabaseType(AzureDatabaseType.FLEXIBLE_SERVER);
+        source.setDatabaseAzureRequest(distroXDatabaseAzureRequest);
+        DatabaseRequest result = underTest.convert(source);
+        assertThat(result.getDatabaseAzureRequest().getAzureDatabaseType()).isEqualTo(AzureDatabaseType.FLEXIBLE_SERVER);
+    }
+
+    @Test
+    void convertDatabaseAzure() {
+        DatabaseRequest source = new DatabaseRequest();
+        source.setAvailabilityType(DatabaseAvailabilityType.NONE);
+        source.setDatabaseEngineVersion(DB_VERSION);
+        source.setDatabaseAzureRequest(new DatabaseAzureRequest());
+        DistroXDatabaseRequest result = underTest.convert(source);
+        assertThat(result.getDatabaseAzureRequest().getAzureDatabaseType()).isEqualTo(AzureDatabaseType.SINGLE_SERVER);
+    }
+
+    @Test
+    void convertDatabaseAzureFlexible() {
+        DatabaseRequest source = new DatabaseRequest();
+        source.setAvailabilityType(DatabaseAvailabilityType.NONE);
+        source.setDatabaseEngineVersion(DB_VERSION);
+        DatabaseAzureRequest databaseAzureRequest = new DatabaseAzureRequest();
+        databaseAzureRequest.setAzureDatabaseType(AzureDatabaseType.FLEXIBLE_SERVER);
+        source.setDatabaseAzureRequest(databaseAzureRequest);
+        DistroXDatabaseRequest result = underTest.convert(source);
+        assertThat(result.getDatabaseAzureRequest().getAzureDatabaseType()).isEqualTo(AzureDatabaseType.FLEXIBLE_SERVER);
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxClusterRepository.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxClusterRepository.java
@@ -138,6 +138,6 @@ public interface SdxClusterRepository extends AccountAwareResourceRepository<Sdx
     @Query("SELECT sdxc.resourceCrn FROM SdxCluster sdxc WHERE sdxc.id = :id")
     Optional<String> findCrnById(@Param("id") Long id);
 
-    @Query(value = "SELECT sdxc.sdxDatabase.id FROM SdxCluster sdxc WHERE sdxc.crn = :crn")
+    @Query("SELECT sdxc.sdxDatabase.id FROM SdxCluster sdxc WHERE sdxc.crn = :crn")
     Optional<Long> findDatabaseIdByCrn(@Param("crn") String crn);
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxExternalDatabaseConfigurer.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxExternalDatabaseConfigurer.java
@@ -60,7 +60,7 @@ public class SdxExternalDatabaseConfigurer {
         String dbEngineVersion =
                 databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeAndOsIfMissing(sdxCluster.getRuntime(), os, requestedDbEngineVersion);
         SdxDatabase sdxDatabase = DatabaseParameterFallbackUtil.setupDatabaseInitParams(sdxCluster, databaseAvailabilityType, dbEngineVersion);
-        configureAzureDatabase(cloudPlatform, databaseRequest, sdxDatabase);
+        configureAzureDatabase(cloudPlatform, internalDatabaseRequest, databaseRequest, sdxDatabase);
         LOGGER.debug("Set database availability type to {}, and engine version to {}", sdxCluster.getDatabaseAvailabilityType(),
                 sdxCluster.getDatabaseEngineVersion());
         validate(cloudPlatform, sdxCluster);
@@ -97,14 +97,11 @@ public class SdxExternalDatabaseConfigurer {
     }
 
     private SdxDatabaseAvailabilityType convertAvailabilityType(DatabaseAvailabilityType dbAvailabilityType) {
-        switch (dbAvailabilityType) {
-        case HA:
-            return SdxDatabaseAvailabilityType.HA;
-        case NON_HA:
-            return SdxDatabaseAvailabilityType.NON_HA;
-        default:
-            return SdxDatabaseAvailabilityType.NONE;
-        }
+        return switch (dbAvailabilityType) {
+            case HA -> SdxDatabaseAvailabilityType.HA;
+            case NON_HA -> SdxDatabaseAvailabilityType.NON_HA;
+            default -> SdxDatabaseAvailabilityType.NONE;
+        };
     }
 
     private boolean isCMExternalDbSupported(CloudPlatform cloudPlatform, SdxCluster sdxCluster) {
@@ -136,9 +133,10 @@ public class SdxExternalDatabaseConfigurer {
         }
     }
 
-    private void configureAzureDatabase(CloudPlatform cloudPlatform, SdxDatabaseRequest databaseRequest, SdxDatabase sdxDatabase) {
+    private void configureAzureDatabase(CloudPlatform cloudPlatform, DatabaseRequest internalDatabaseRequest, SdxDatabaseRequest databaseRequest,
+            SdxDatabase sdxDatabase) {
         if (CloudPlatform.AZURE == cloudPlatform) {
-            azureDatabaseAttributesService.configureAzureDatabase(databaseRequest, sdxDatabase);
+            azureDatabaseAttributesService.configureAzureDatabase(internalDatabaseRequest, databaseRequest, sdxDatabase);
         }
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/database/AzureDatabaseAttributesService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/database/AzureDatabaseAttributesService.java
@@ -11,6 +11,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAzureRequest;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseRequest;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.altus.model.Entitlement;
@@ -40,11 +42,14 @@ public class AzureDatabaseAttributesService {
         return azureDatabaseType;
     }
 
-    public void configureAzureDatabase(SdxDatabaseRequest databaseRequest, SdxDatabase sdxDatabase) {
+    public void configureAzureDatabase(DatabaseRequest internalDatabaseRequest, SdxDatabaseRequest databaseRequest, SdxDatabase sdxDatabase) {
         AzureDatabaseType azureDatabaseType = Optional.ofNullable(databaseRequest)
                 .map(SdxDatabaseRequest::getSdxDatabaseAzureRequest)
                 .map(SdxDatabaseAzureRequest::getAzureDatabaseType)
-                .orElse(AzureDatabaseType.SINGLE_SERVER);
+                .orElse(Optional.ofNullable(internalDatabaseRequest)
+                        .map(DatabaseRequest::getDatabaseAzureRequest)
+                        .map(DatabaseAzureRequest::getAzureDatabaseType)
+                        .orElse(AzureDatabaseType.SINGLE_SERVER));
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         if (azureDatabaseType == AzureDatabaseType.FLEXIBLE_SERVER && !entitlementService.isAzureDatabaseFlexibleServerEnabled(accountId)) {
             LOGGER.info("Azure Flexible Database Server creation is not entitled for {} account.", accountId);


### PR DESCRIPTION
CB-21406 Extend Distrox Creation call on API with the azure database type field

API related changes:
* Extend DistroXDatabaseRequest with DistroXDatabaseAzureRequest
* DistroXDatabaseAzureRequest contains the AzureDatabaseType: SINGLE_SERVER / FLEXIBLE_SERVER
* if the DistroXDatabaseAzureRequest is missing, the default value is SINGLE_SERVER

Refactor Stack entity object:
* Collect database properties in Database entity object
* Add Database to Stack

For backward compatibilty the old database properties cannot be removed in one step from Stack, there is a followup jira for this: CB-22002
