### PR TITLE
CB-21906: Fixed failing E2E tests for EDL creation.

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/HostGroupType.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/HostGroupType.java
@@ -18,12 +18,12 @@ public enum HostGroupType {
     ZOOKEEPER("ZooKeeper", InstanceGroupType.CORE, InstanceCountParameter.ZOOKEEPER_INSTANCE_COUNT.getName()),
     AUXILIARY("auxiliary", InstanceGroupType.CORE, InstanceCountParameter.AUXILIARY_INSTANCE_COUNT.getName(), 1),
     CORE("core", InstanceGroupType.CORE, InstanceCountParameter.CORE_INSTANCE_COUNT.getName(), 3),
-    SOLRHG("solrhg", InstanceGroupType.CORE, InstanceCountParameter.SOLRHG_INSTANCE_COUNT.getName()),
-    STORAGEHG("storagehg", InstanceGroupType.CORE, InstanceCountParameter.STORAGEHG_INSTANCE_COUNT.getName()),
-    KAFKAHG("kafkahg", InstanceGroupType.CORE, InstanceCountParameter.KAFKAHG_INSTANCE_COUNT.getName()),
+    SOLRHG("solrhg", InstanceGroupType.CORE, InstanceCountParameter.SOLRHG_INSTANCE_COUNT.getName(), 0),
+    STORAGEHG("storagehg", InstanceGroupType.CORE, InstanceCountParameter.STORAGEHG_INSTANCE_COUNT.getName(), 0),
+    KAFKAHG("kafkahg", InstanceGroupType.CORE, InstanceCountParameter.KAFKAHG_INSTANCE_COUNT.getName(), 0),
     RAZHG("razhg", InstanceGroupType.CORE, InstanceCountParameter.RAZHG_INSTANCE_COUNT.getName(), 0),
-    ATLASHG("atlashg", InstanceGroupType.CORE, InstanceCountParameter.ATLASHG_INSTANCE_COUNT.getName()),
-    HMSHG("hmshg", InstanceGroupType.CORE, InstanceCountParameter.HMSHG_INSTANCE_COUNT.getName());
+    ATLASHG("atlashg", InstanceGroupType.CORE, InstanceCountParameter.ATLASHG_INSTANCE_COUNT.getName(), 0),
+    HMSHG("hmshg", InstanceGroupType.CORE, InstanceCountParameter.HMSHG_INSTANCE_COUNT.getName(), 0);
 
     private final String name;
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRepairTests.java
@@ -217,8 +217,7 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
                 .validate();
     }
 
-    // CB-21906 Disabled due to blueprint error ("Enable TLS/SSL for Kafka Broker does not have same value for the 4 Kafka Brokers")
-//    @Test(dataProvider = TEST_CONTEXT)
+    @Test(dataProvider = TEST_CONTEXT)
     @Description(
             given = "there is a Scalable SDX cluster in available state",
             when = "IDBroker and Gateway instances are going to be deleted on the provider side",


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-21906

A recent change to the EDL logic exposed an issue in the way the cluster is set up in the E2E environment. This change fixes that issue by ensuring the host groups have the correct amount of instances associated with them.

I have verified this locally by recreating the original issue with the E2E, and then ensuring the test passes after making the change.