### PR TITLE
CB-20488: Roll forward should detect and not fail on newer parcel version

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmProductChooserService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmProductChooserService.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak.service.upgrade.sync.component;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -12,6 +11,7 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cluster.model.ParcelInfo;
+import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 
 @Service
 public class CmProductChooserService {
@@ -23,11 +23,11 @@ public class CmProductChooserService {
      * A product is matching if the name and version both match.
      * @param activeParcels parcels installed on the CM server
      * @param candidateProducts A list of ClouderaManagerProducts extracted from image catalog
-     * @return List of ClouderaManagerProducts installed on the DL / DH
+     * @return Set of ClouderaManagerProducts installed on the DL / DH
      */
     Set<ClouderaManagerProduct> chooseParcelProduct(Set<ParcelInfo> activeParcels, Set<ClouderaManagerProduct> candidateProducts) {
         Set<ClouderaManagerProduct> foundProducts = activeParcels.stream()
-                .map(ip -> findMatchingClouderaManagerProduct(candidateProducts, ip))
+                .map(activeParcel -> findMatchingClouderaManagerProduct(candidateProducts, activeParcel))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.toSet());
@@ -55,12 +55,11 @@ public class CmProductChooserService {
         }
     }
 
-    private Optional<ClouderaManagerProduct> findMatchingClouderaManagerProduct(Set<ClouderaManagerProduct> candidateProducts, ParcelInfo ip) {
-        List<ClouderaManagerProduct> matchingProducts = candidateProducts.stream()
-                .filter(cp -> ip.getName().equals(cp.getName()))
-                .filter(cp -> ip.getVersion().equals(cp.getVersion()))
-                .collect(Collectors.toList());
-        return matchingProducts.stream().findFirst();
+    private Optional<ClouderaManagerProduct> findMatchingClouderaManagerProduct(Set<ClouderaManagerProduct> candidateProducts, ParcelInfo activeParcel) {
+        return candidateProducts.stream()
+                .filter(cp -> activeParcel.getName().equals(cp.getName()) &&
+                        CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited(cp.getVersion(), activeParcel::getVersion))
+                .findFirst();
     }
 
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmProductChooserServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmProductChooserServiceTest.java
@@ -22,9 +22,11 @@ import com.sequenceiq.cloudbreak.cluster.model.ParcelStatus;
 
 @ExtendWith(MockitoExtension.class)
 public class CmProductChooserServiceTest {
-    private static final String PARCEL_VERSION_1 = "Version1";
+    private static final String PARCEL_VERSION_1 = "7.2.12";
 
-    private static final String PARCEL_VERSION_2 = "Version2";
+    private static final String PARCEL_VERSION_2 = "7.2.15";
+
+    private static final String PARCEL_VERSION_3 = "7.2.7";
 
     private static final String PARCEL_NAME_1 = "ParcelName1";
 
@@ -85,12 +87,34 @@ public class CmProductChooserServiceTest {
 
     @Test
     void testChooseParcelProductWhenMatchingNameButDifferentVersionThenEmptyResult() {
-        Set<ParcelInfo> activeParcels = Set.of(new ParcelInfo(PARCEL_NAME_1, PARCEL_VERSION_2, ParcelStatus.ACTIVATED));
-        Set<ClouderaManagerProduct> candidateProducts = Set.of(new ClouderaManagerProduct().withName(PARCEL_NAME_1).withVersion(PARCEL_VERSION_1));
+        Set<ParcelInfo> activeParcels = Set.of(new ParcelInfo(PARCEL_NAME_1, PARCEL_VERSION_1, ParcelStatus.ACTIVATED));
+        Set<ClouderaManagerProduct> candidateProducts = Set.of(new ClouderaManagerProduct().withName(PARCEL_NAME_1).withVersion(PARCEL_VERSION_3));
 
         Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(activeParcels, candidateProducts);
 
         assertThat(foundProducts, hasSize(0));
+    }
+
+    @Test
+    void testChooseParcelProductWhenMatchingNameButNewerActiveVersionThenReturnsOne() {
+        Set<ParcelInfo> activeParcels = Set.of(new ParcelInfo(PARCEL_NAME_1, PARCEL_VERSION_1, ParcelStatus.ACTIVATED));
+        Set<ClouderaManagerProduct> candidateProducts = Set.of(new ClouderaManagerProduct().withName(PARCEL_NAME_1).withVersion(PARCEL_VERSION_2));
+
+        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(activeParcels, candidateProducts);
+
+        assertThat(foundProducts, hasSize(1));
+        assertEquals(PARCEL_VERSION_2, foundProducts.iterator().next().getVersion());
+    }
+
+    @Test
+    void testChooseParcelProductWhenMatchingNameButEqualActiveVersionThenReturnsOne() {
+        Set<ParcelInfo> activeParcels = Set.of(new ParcelInfo(PARCEL_NAME_1, PARCEL_VERSION_1, ParcelStatus.ACTIVATED));
+        Set<ClouderaManagerProduct> candidateProducts = Set.of(new ClouderaManagerProduct().withName(PARCEL_NAME_1).withVersion(PARCEL_VERSION_1));
+
+        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(activeParcels, candidateProducts);
+
+        assertThat(foundProducts, hasSize(1));
+        assertEquals(PARCEL_VERSION_1, foundProducts.iterator().next().getVersion());
     }
 
     @Test


### PR DESCRIPTION
In this commit I've fixed the handling of the case gracefully when one parcel present in CB metadata is missing from CM (e.g. customer deleted it) but there is a newer version of that parcel already installed and activated.