### PR TITLE
CB-21993 ProjectId is not returned from GCP credentials

### DIFF
--- a/cloud-gcp/src/main/resources/definitions/gcp-credential.json
+++ b/cloud-gcp/src/main/resources/definitions/gcp-credential.json
@@ -1,6 +1,12 @@
 {
   "values": [
     {
+      "name": "projectId",
+      "type": "String",
+      "sensitive": false,
+      "optional": true
+    },
+    {
       "name": "gcp.json.credentialJson",
       "type": "String",
       "sensitive": true,

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/CredentialToCredentialV1ResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/CredentialToCredentialV1ResponseConverter.java
@@ -94,7 +94,7 @@ public class CredentialToCredentialV1ResponseConverter {
             CredentialAttributes credentialAttributes = json.get(CredentialAttributes.class);
             doIfNotNull(credentialAttributes.getAws(), param -> response.setAws(awsConverter.convert(param)));
             doIfNotNull(credentialAttributes.getAzure(), param -> response.setAzure(azureConverter.convert(param)));
-            doIfNotNull(credentialAttributes.getGcp(), param -> response.setGcp(gcpConverter.convert(param)));
+            doIfNotNull(credentialAttributes.getGcp(), param -> response.setGcp(gcpConverter.convert(param, json)));
             doIfNotNull(credentialAttributes.getMock(), param -> response.setMock(mockConverter.convert(param)));
             doIfNotNull(credentialAttributes.getYarn(), param -> response.setYarn(yarnConverter.convert(param)));
         } catch (IOException e) {

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/gcp/GcpCredentialV1ParametersToGcpCredentialAttributesConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/gcp/GcpCredentialV1ParametersToGcpCredentialAttributesConverter.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.environment.credential.v1.converter.gcp;
 
+import static com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil.PROJECT_ID;
 import static com.sequenceiq.cloudbreak.util.NullUtil.doIfNotNull;
 
 import org.apache.commons.codec.binary.Base64;
@@ -8,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.environment.api.v1.credential.model.parameters.gcp.GcpCredentialParameters;
 import com.sequenceiq.environment.api.v1.credential.model.parameters.gcp.JsonParameters;
@@ -28,10 +30,18 @@ public class GcpCredentialV1ParametersToGcpCredentialAttributesConverter {
         return response;
     }
 
-    public GcpCredentialParameters convert(GcpCredentialAttributes source) {
+    public GcpCredentialParameters convert(GcpCredentialAttributes source, Json rawJson) {
         GcpCredentialParameters response = new GcpCredentialParameters();
-        doIfNotNull(source.getJson(), param -> response.setJson(getJson(param)));
-        doIfNotNull(source.getP12(), param -> response.setP12(getP12(param)));
+        doIfNotNull(source.getJson(), param -> {
+            JsonParameters jsonParameters = getJson(param);
+            jsonParameters.setProjectId(rawJson.getValue(PROJECT_ID));
+            response.setJson(jsonParameters);
+        });
+        doIfNotNull(source.getP12(), param -> {
+            P12Parameters p12Parameters = getP12(param);
+            p12Parameters.setProjectId(rawJson.getValue(PROJECT_ID));
+            response.setP12(p12Parameters);
+        });
         return response;
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/credential/v1/converter/gcp/GcpCredentialV1ParametersToGcpCredentialAttributesConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/credential/v1/converter/gcp/GcpCredentialV1ParametersToGcpCredentialAttributesConverterTest.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.environment.credential.v1.converter.gcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.environment.api.v1.credential.model.parameters.gcp.GcpCredentialParameters;
+import com.sequenceiq.environment.credential.attributes.gcp.GcpCredentialAttributes;
+import com.sequenceiq.environment.credential.attributes.gcp.JsonAttributes;
+import com.sequenceiq.environment.credential.attributes.gcp.P12Attributes;
+
+class GcpCredentialV1ParametersToGcpCredentialAttributesConverterTest {
+
+    private static final String MY_PROJECT_ID = "myProjectId";
+
+    private static final Json RAW_JSON = new Json("""
+            {
+                "projectId": "%s"
+            }""".formatted(MY_PROJECT_ID));
+
+    private final GcpCredentialV1ParametersToGcpCredentialAttributesConverter underTest = new GcpCredentialV1ParametersToGcpCredentialAttributesConverter();
+
+    @Test
+    void testConvertProjectIdJson() {
+        GcpCredentialAttributes source = new GcpCredentialAttributes();
+        source.setJson(new JsonAttributes());
+        GcpCredentialParameters result = underTest.convert(source, RAW_JSON);
+        assertThat(result.getJson().getProjectId()).isEqualTo(MY_PROJECT_ID);
+    }
+
+    @Test
+    void testConvertProjectIdP12() {
+        GcpCredentialAttributes source = new GcpCredentialAttributes();
+        source.setP12(new P12Attributes());
+        GcpCredentialParameters result = underTest.convert(source, RAW_JSON);
+        assertThat(result.getP12().getProjectId()).isEqualTo(MY_PROJECT_ID);
+    }
+
+}


### PR DESCRIPTION
GCP secret structure was not reflected in the resource definitions as the `projectId` is a top level attribute. The converter had to be altered accordingly, to fill up this field with the raw value from the credential JSON. Previously the `projectId` was embedded under the `gcp` attribute.