### PR TITLE
CB-21969 Update EDL HMS configuration.

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-enterprise.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-enterprise.bp
@@ -613,6 +613,10 @@
               {
                 "name":"hive_metastore_java_heapsize",
                 "value":12348030976
+              },
+              {
+                "name": "hive_metastore_server_max_message_size",
+                "value": 1234803097
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.18/cdp-sdx-enterprise.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.18/cdp-sdx-enterprise.bp
@@ -613,6 +613,10 @@
               {
                 "name":"hive_metastore_java_heapsize",
                 "value":12348030976
+              },
+              {
+                "name": "hive_metastore_server_max_message_size",
+                "value": 1234803097
               }
             ]
           }


### PR DESCRIPTION
Change the message size to 10% of the available memory. This modification will remove the warning message on the CM UI. This configuration refers to the max size of a thrift message being sent back to the client. This change is done to address the warning thrown by CM.

See detailed description in the commit message.