### PR TITLE
CB-21998 DNS registration failures trigger an event

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -286,6 +286,7 @@ public enum ResourceEvent {
     STACK_LB_CREATE_CLOUD_RESOURCE("stack.lb.update.create.cloud.resource"),
     STACK_LB_COLLECT_METADATA("stack.lb.update.collect.metadata"),
     STACK_LB_REGISTER_PUBLIC_DNS("stack.lb.update.register.public.dns"),
+    STACK_LB_REGISTER_PUBLIC_DNS_FAILED("stack.lb.update.register.public.dns.failed"),
     STACK_LB_REGISTER_FREEIPA_DNS("stack.lb.update.register.freeipa.dns"),
     STACK_LB_UPDATE_CM_CONFIG("stack.lb.update.update.cm.config"),
     STACK_LB_RESTART_CM("stack.lb.update.restart.cm"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -670,6 +670,7 @@ stack.lb.update.create.entity=Creating load balancer entities.
 stack.lb.update.create.cloud.resource=Creating load balancer cloud resources.
 stack.lb.update.collect.metadata=Collecting load balancer metadata.
 stack.lb.update.register.public.dns=Registering load balancer public DNS.
+stack.lb.update.register.public.dns.failed=Load balancer public DNS registration failed. It's possible that instances are not reachable, if that is the case, please contact the support, so they can register this DNS entry manually through the PEM service.
 stack.lb.update.register.freeipa.dns=Register load balancer FreeIPA DNS.
 stack.lb.update.update.cm.config=Updating CM frontend URL.
 stack.lb.update.restart.cm=Restarting the CM server.


### PR DESCRIPTION
Tests:
Thrown an exception in DNS Registration.
![DNS Registration Failure](https://github.com/hortonworks/cloudbreak/assets/29693430/b8c6a9ef-6113-4076-af3b-1dcd48de4c72)
