### PR TITLE
CB-22018. Increase LDAP search limits

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/initial-ldap-conf.ldif
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/initial-ldap-conf.ldif
@@ -13,7 +13,7 @@ nsslapd-db-deadlock-policy: 6
 dn: cn=config
 changetype: modify
 replace: nsslapd-sizelimit
-nsslapd-sizelimit: 11000
+nsslapd-sizelimit: 30000
 
 
 dn: cn=config


### PR DESCRIPTION
The LDAP search limits need to be increased to support more users. Increase the limit to 30K to support 25K users + some headroom.
