### PR TITLE
CB-22019 - Update Ranger sticky session and LB configs

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -286,11 +286,11 @@
              {% if 'RANGER' in exposed and 'RANGER_ADMIN' in salt['pillar.get']('gateway:location') -%}
              <param>
                  <name>RANGER</name>
-                 <value>enableStickySession=false;noFallback=false;enableLoadBalancing=true</value>
+                 <value>enableStickySession=true;noFallback=false;enableLoadBalancing=true</value>
              </param>
              <param>
                  <name>RANGERUI</name>
-                 <value>enableStickySession=true;noFallback=true;enableLoadBalancing=true</value>
+                 <value>enableStickySession=true;noFallback=false;enableLoadBalancing=true</value>
              </param>
              {%- endif %}
              {% if 'YARNUIV2' in exposed and 'RESOURCEMANAGER' in salt['pillar.get']('gateway:location') -%}


### PR DESCRIPTION
**Proposed changes:**
Change Ranger UI and API configs, specifically update stickysession and nofallback properties to prevent case where Ranger UI becomes unresponsive in case of HA failover. This is because Ranger UI calls Ranger API which does not fallback when there is an error.

**Testing**
Testing for these configs was done on a QE cluster.