### PR TITLE
CB-22020 AutoscaleV4Endpoint's getAllForAutoscale method should be in…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/AutoscaleV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/AutoscaleV4Controller.java
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 
 import com.sequenceiq.authorization.annotation.AccountIdNotNeeded;
-import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceName;
 import com.sequenceiq.authorization.annotation.InternalOnly;
@@ -186,7 +185,8 @@ public class AutoscaleV4Controller implements AutoscaleV4Endpoint {
     }
 
     @Override
-    @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
+    @InternalOnly
+    @AccountIdNotNeeded
     public AutoscaleStackV4Responses getAllForAutoscale() {
         Set<AutoscaleStackV4Response> allForAutoscale = stackCommonService.getAllForAutoscale();
         return new AutoscaleStackV4Responses(new ArrayList<>(allForAutoscale));


### PR DESCRIPTION
…ternal only

- As part of #10476 , `POWERUSER_ONLY` authz was added to `AutoscaleV4Endpoint#getAllForAutoscale`.
- A single API call to this endpoint will provide stack info about multiple tenants, which is a major security concern.
- Changed this to an `@InternalOnly` API to prevent this. Additionally, periscope does not invoke this API.

See detailed description in the commit message.