### PR TITLE
CDPSDX-4157 Fixed "remote_admin is undefined" error on database backup

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
@@ -2,7 +2,7 @@
 {% set object_storage_url = salt['pillar.get']('disaster_recovery:object_storage_url') %}
 {% set remote_db_url = salt['pillar.get']('postgres:clouderamanager:remote_db_url') %}
 {% set remote_db_port = salt['pillar.get']('postgres:clouderamanager:remote_db_port') %}
-{% set pg_username = salt['pillar.get']('postgres:clouderamanager:remote_admin') %}
+{% set remote_admin = salt['pillar.get']('postgres:clouderamanager:remote_admin') %}
 {% set ranger_admin_group = salt['pillar.get']('disaster_recovery:ranger_admin_group') %}
 {% set close_connections = salt['pillar.get']('disaster_recovery:close_connections') %}
 {% set compression_level = salt['pillar.get']('disaster_recovery:compression_level', '0') %}


### PR DESCRIPTION
**JIRA:** [CDPSDX-4157](https://jira.cloudera.com/browse/CDPSDX-4157) - the root cause of this jira is the database backup failed (but it showed successful). This PR will fix the issue that cause the database backup fail.
**ISSUE:** Get this error when running DB backup: [{"outputter":"highstate","data":{"dl-9go86ufc7i-master0.sdx-quas.xcu2-8y8x.dev.cldr.work":["Rendering SLS 'base:postgresql.disaster_recovery.backup' failed: Jinja variable 'remote_admin' is undefined"]}}]}
**FIX:** Renamed pg_username (which is never used) to remote_admin