### PR TITLE
CDPSDX-4157 Fixed "remote_admin is undefined" error on database backup

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
@@ -2,7 +2,7 @@
 {% set object_storage_url = salt['pillar.get']('disaster_recovery:object_storage_url') %}
 {% set remote_db_url = salt['pillar.get']('postgres:clouderamanager:remote_db_url') %}
 {% set remote_db_port = salt['pillar.get']('postgres:clouderamanager:remote_db_port') %}
-{% set pg_username = salt['pillar.get']('postgres:clouderamanager:remote_admin') %}
+{% set remote_admin = salt['pillar.get']('postgres:clouderamanager:remote_admin') %}
 {% set ranger_admin_group = salt['pillar.get']('disaster_recovery:ranger_admin_group') %}
 {% set close_connections = salt['pillar.get']('disaster_recovery:close_connections') %}
 {% set compression_level = salt['pillar.get']('disaster_recovery:compression_level', '0') %}


### PR DESCRIPTION
**JIRA:** [CDPSDX-4157](https://jira.cloudera.com/browse/CDPSDX-4157) The root cause of the restore fails is the database backup failed but it shows successful. This PR is aimed to fix the issue of the database backup failure because it is urgent. We need to have another PR to fix the issue on why it shows successful rather than failed (jira created and assigned to myself to fix that: [CDPSDX-4160](https://jira.cloudera.com/browse/CDPSDX-4160))
**ISSUE:** Get this error when running DB backup (this error is in the Kibana log): [{"outputter":"highstate","data":{"dl-9go86ufc7i-master0.sdx-quas.xcu2-8y8x.dev.cldr.work":["Rendering SLS 'base:postgresql.disaster_recovery.backup' failed: Jinja variable 'remote_admin' is undefined"]}}]}
**FIX:** Renamed pg_username (which is never used in backup.sls) to remote_admin

Before: DB backup doesn't exist:
![Screen Shot 2023-06-05 at 10 18 21 AM](https://github.com/hortonworks/cloudbreak/assets/39275944/2db90964-5366-4368-9c38-959054bece0e)

After: DB backup exists:
![Screen Shot 2023-06-05 at 10 21 07 AM](https://github.com/hortonworks/cloudbreak/assets/39275944/613a5bd6-6652-4fb2-b70e-e84335835c2e)
