### PR TITLE
CB-22015 Only specify providerclass and providerarg for keytool on GOV

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/setup-autotls.sh.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/setup-autotls.sh.j2
@@ -41,9 +41,7 @@ rm -f ${CACERTS_DIR}/cacerts.bcfks
 
 keytool -importkeystore \
   -srckeystore ${JAVA_HOME}/jre/lib/security/cacerts \
-  -srcstorepass changeit \
-  -providerclass sun.security.pkcs11.SunPKCS11 \
-  -providerarg ${JAVA_HOME}/jre/lib/security/nss.cfg \
+  -srcstorepass changeit {% if gov_cloud == True %} -providerclass sun.security.pkcs11.SunPKCS11 -providerarg ${JAVA_HOME}/jre/lib/security/nss.cfg {% endif %} \
   -destkeystore ${CACERTS_DIR}/cacerts.p12 \
   -deststorepass changeit \
   -deststoretype PKCS12


### PR DESCRIPTION
On commercial we also have Java 11 which does not have the specified providerclass, and it only has to be specified for GOV as it has different java security providers.

See detailed description in the commit message.