### PR TITLE
CB-22098 Hotfix - Load balancer public IP should not be delete in downscale operation

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/loadbalancer/AzureLoadBalancer.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/loadbalancer/AzureLoadBalancer.java
@@ -10,7 +10,7 @@ import com.sequenceiq.common.api.type.LoadBalancerSku;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 
 public class AzureLoadBalancer {
-    private static final String LOAD_BALANCER_NAME_PREFIX = "LoadBalancer";
+    public static final String LOAD_BALANCER_NAME_PREFIX = "LoadBalancer";
 
     private final List<AzureLoadBalancingRule> rules;
 

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTerminationHelperServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTerminationHelperServiceTest.java
@@ -1,9 +1,11 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -15,6 +17,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -22,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.cloud.azure.connector.resource.AzureComputeResourceService;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.transform.CloudResourceHelper;
@@ -146,6 +150,24 @@ class AzureTerminationHelperServiceTest {
         InOrder inOrder = inOrder(azureUtils);
         inOrder.verify(azureUtils).deleteLoadBalancers(any(), any(), any());
         inOrder.verify(azureUtils).deletePublicIps(any(), any(), any());
+    }
+
+    @Test
+    void testWhenDownscaleThenLoadBalancerPublicIpShouldBePreserved() {
+        List<CloudInstance> vms = mock(List.class);
+        List<CloudResource> allResources = mock(List.class);
+        List<CloudResource> resourcesToRemove = List.of(
+                createCloudResource(ResourceType.AZURE_INSTANCE, INSTANCE_NAME),
+                createCloudResource(ResourceType.AZURE_PUBLIC_IP, "LoadBalancerdh-name0OUTBOUND-publicIp"),
+                createCloudResource(ResourceType.AZURE_LOAD_BALANCER, "LoadBalancerdh-name0OUTBOUND"));
+
+        underTest.downscale(ac, cloudStack, vms, allResources, resourcesToRemove);
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        InOrder inOrder = inOrder(azureUtils);
+        inOrder.verify(azureUtils, never()).deleteLoadBalancers(any(), any(), any());
+        inOrder.verify(azureUtils).deletePublicIps(any(), any(), captor.capture());
+        assertTrue(captor.getValue().isEmpty());
     }
 
     private List<CloudResource> setupCloudResources() {


### PR DESCRIPTION
Bug: When an error occurs in the upscale operation, it downscales back. When it tries to delete the public IP associated with the load balancer, as it is in use, the operation fails.

Test:
Created light duty datalake, then create a data engineering HA data hub.
Throw an exception before the save resources in the upscale operation.
The public IP of the LB is skipped.