### PR TITLE
CB-22030 raising UpgradeCcmFlowIntegrationTest test in freeipa timeout beforce the flow finishes

### DIFF
--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmFlowIntegrationTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmFlowIntegrationTest.java
@@ -299,7 +299,7 @@ class UpgradeCcmFlowIntegrationTest {
                 Thread.sleep(100);
             } catch (InterruptedException e) {
             }
-        } while (flowRegister.get(flowIdentifier.getPollableId()) != null && i < 10);
+        } while (flowRegister.get(flowIdentifier.getPollableId()) != null && i < 30);
     }
 
     @Profile("integration-test")


### PR DESCRIPTION


See detailed description in the commit message.