### PR TITLE
CB-22139 [API E2E] Introduce new Cloudera Manager defaultPassword for FIPS 140-2 compliance

### DIFF
--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -84,7 +84,7 @@ integrationtest:
   internalDistroXBlueprintName: "%s - Data Engineering: Apache Spark, Apache Hive, Apache Oozie"
   clouderamanager:
     defaultUser: admin
-    defaultPassword: Admin123
+    defaultPassword: cb1STPneh2b6KyJn
     defaultPort: 7180
   cloudProvider: MOCK
   runtimeVersion: 7.2.15


### PR DESCRIPTION
7 out of the 13 E2E tests are failing at Fedramp E2E, because of `com.safelogic.cryptocomply.crypto.fips.FipsUnapprovedOperationError: password must be at least 112 bits` at `RangerAuthenticationProvider` as `JDBC Authentication failure`.

The test project's `defaultPassword` for `clouderamanager` at `cloudbreak/integration-test/src/main/resources/application.yml` should be replaced with a FIPS comliant password.