### PR TITLE
CB-14443: Handle custom parcels during CM parcel sync

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CustomParcelFilterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CustomParcelFilterService.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.cloudbreak.service.upgrade.sync;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cluster.model.ParcelInfo;
+
+@Component
+public class CustomParcelFilterService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CustomParcelFilterService.class);
+
+    public Set<ParcelInfo> filterCustomParcels(Set<ParcelInfo> activeParcels, Set<ClouderaManagerProduct> availableProducts) {
+        Set<ParcelInfo> customParcels = findCustomParcels(activeParcels, availableProducts);
+        if (customParcels.isEmpty()) {
+            return activeParcels;
+        } else {
+            LOGGER.debug("Found custom parcels during CM parcel sync: {}", customParcels);
+            return activeParcels.stream()
+                    .filter(parcelInfo -> !customParcels.contains(parcelInfo))
+                    .collect(Collectors.toSet());
+        }
+    }
+
+    private Set<ParcelInfo> findCustomParcels(Set<ParcelInfo> activeParcels, Set<ClouderaManagerProduct> candidateProducts) {
+        Set<String> allParcelName = candidateProducts.stream().map(ClouderaManagerProduct::getName).collect(Collectors.toSet());
+        return activeParcels.stream()
+                .filter(parcel -> !allParcelName.contains(parcel.getName()))
+                .collect(Collectors.toSet());
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CustomParcelFilterServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CustomParcelFilterServiceTest.java
@@ -1,0 +1,50 @@
+package com.sequenceiq.cloudbreak.service.upgrade.sync;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cluster.model.ParcelInfo;
+import com.sequenceiq.cloudbreak.cluster.model.ParcelStatus;
+
+class CustomParcelFilterServiceTest {
+
+    private final CustomParcelFilterService underTest = new CustomParcelFilterService();
+
+    @Test
+    void testFilterCustomParcelsShouldReturnAllParcelsWhenThereAreNoCustomParcelFound() {
+        Set<ParcelInfo> activeParcels = Set.of(createParcelInfo("CDH"), createParcelInfo("CFM"), createParcelInfo("SPARK"));
+        Set<ClouderaManagerProduct> availableProducts =
+                Set.of(createCmProduct("CFM"), createCmProduct("CDH"), createCmProduct("SPARK"), createCmProduct("NIFI"));
+
+        Set<ParcelInfo> actual = underTest.filterCustomParcels(activeParcels, availableProducts);
+
+        assertEquals(activeParcels, actual);
+    }
+
+    @Test
+    void testFilterCustomParcelsShouldReturnParcelsWhenACustomParcelIsPresent() {
+        ParcelInfo parcel1 = createParcelInfo("CDH");
+        ParcelInfo parcel2 = createParcelInfo("CFM");
+        ParcelInfo parcel3 = createParcelInfo("SPARK");
+        Set<ParcelInfo> activeParcels = Set.of(parcel1, parcel2, parcel3, createParcelInfo("custom_parcel"));
+        Set<ClouderaManagerProduct> availableProducts =
+                Set.of(createCmProduct("CFM"), createCmProduct("CDH"), createCmProduct("SPARK"), createCmProduct("NIFI"));
+
+        Set<ParcelInfo> actual = underTest.filterCustomParcels(activeParcels, availableProducts);
+
+        assertEquals(Set.of(parcel1, parcel2, parcel3), actual);
+    }
+
+    private ParcelInfo createParcelInfo(String parcelName) {
+        return new ParcelInfo(parcelName, "7.2.12", ParcelStatus.ACTIVATED);
+    }
+
+    private ClouderaManagerProduct createCmProduct(String productName) {
+        return new ClouderaManagerProduct().withName(productName);
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmInstalledComponentFinderServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmInstalledComponentFinderServiceTest.java
@@ -23,6 +23,7 @@ import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cluster.model.ParcelInfo;
 import com.sequenceiq.cloudbreak.cluster.model.ParcelStatus;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.upgrade.sync.CustomParcelFilterService;
 import com.sequenceiq.cloudbreak.service.upgrade.sync.operationresult.CmParcelSyncOperationResult;
 import com.sequenceiq.cloudbreak.service.upgrade.sync.operationresult.CmRepoSyncOperationResult;
 
@@ -39,6 +40,9 @@ public class CmInstalledComponentFinderServiceTest {
 
     @Mock
     private ImageReaderService imageReaderService;
+
+    @Mock
+    private CustomParcelFilterService customParcelFilterService;
 
     @InjectMocks
     private CmInstalledComponentFinderService underTest;
@@ -66,13 +70,14 @@ public class CmInstalledComponentFinderServiceTest {
     @Test
     void testFindParcelComponents() {
         Set<Image> candidateImages = Set.of(mock(Image.class));
-        Set<ClouderaManagerProduct> candidateCmProduct = Set.of(new ClouderaManagerProduct());
+        Set<ClouderaManagerProduct> candidateCmProduct = Set.of(new ClouderaManagerProduct().withName("C"));
         Set<ParcelInfo> queriedParcelInfo = Set.of(new ParcelInfo("", "", ParcelStatus.ACTIVATED));
         Set<ClouderaManagerProduct> chosenClouderaManagerProducts = Set.of(new ClouderaManagerProduct());
         when(stack.isDatalake()).thenReturn(true);
         when(imageReaderService.getParcels(candidateImages, true)).thenReturn(candidateCmProduct);
         when(cmInfoRetriever.queryActiveParcels(eq(stack))).thenReturn(queriedParcelInfo);
         when(cmProductChooserService.chooseParcelProduct(queriedParcelInfo, candidateCmProduct)).thenReturn(chosenClouderaManagerProducts);
+        when(customParcelFilterService.filterCustomParcels(queriedParcelInfo, candidateCmProduct)).thenReturn(queriedParcelInfo);
 
         CmParcelSyncOperationResult cmParcelSyncOperationResult = underTest.findParcelComponents(stack, candidateImages);
 
@@ -80,6 +85,7 @@ public class CmInstalledComponentFinderServiceTest {
         verify(imageReaderService).getParcels(candidateImages, true);
         verify(cmInfoRetriever).queryActiveParcels(stack);
         verify(cmProductChooserService).chooseParcelProduct(queriedParcelInfo, candidateCmProduct);
+        verify(customParcelFilterService).filterCustomParcels(queriedParcelInfo, candidateCmProduct);
     }
 
 }


### PR DESCRIPTION
In this commit, I've improved the handling of the custom parcels during CM parcel sync. When we've retrieved the active parcels from the CM we're filtering out those parcels that are not present in our image catalog.