### PR TITLE
CB-22154 change the name of the extra host group in case of EDL.

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/type/InstanceGroupName.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/InstanceGroupName.java
@@ -7,12 +7,12 @@ public enum InstanceGroupName {
     GATEWAY("gateway"),
     AUXILIARY("auxiliary"),
     CORE("core"),
-    SOLRHG("solrhg"),
-    STORAGEHG("storagehg"),
-    KAFKAHG("kafkahg"),
-    RAZHG("razhg"),
-    ATLASHG("atlashg"),
-    HMSHG("hmshg");
+    SOLR_SCALE_OUT("solrscaleout"),
+    STORAGE_SCALE_OUT("storagescaleout"),
+    KAFKA_SCALE_OUT("kafkascaleout"),
+    RAZSCALEOUT("razscaleout"),
+    ATLAS_SCALE_OUT("atlasscaleout"),
+    HMS_SCALE_OUT("hmsscaleout");
 
     private final String name;
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/template/TemplateValidatorAndUpdater.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/template/TemplateValidatorAndUpdater.java
@@ -47,6 +47,7 @@ import com.sequenceiq.cloudbreak.template.model.ServiceComponent;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 import com.sequenceiq.cloudbreak.workspace.model.User;
 import com.sequenceiq.common.api.type.CdpResourceType;
+import com.sequenceiq.common.api.type.InstanceGroupName;
 import com.sequenceiq.common.model.AwsDiskType;
 
 @Component
@@ -60,7 +61,8 @@ public class TemplateValidatorAndUpdater {
 
     public static final String ROLE_IMPALAD = "IMPALAD";
 
-    private static final Set<String> SDX_COMPUTE_INSTANCES = Set.of("hmshg", "razhg", "atlashg");
+    private static final Set<String> SDX_COMPUTE_INSTANCES = Set.of(InstanceGroupName.HMS_SCALE_OUT.name().toLowerCase(Locale.ROOT),
+            InstanceGroupName.RAZSCALEOUT.name().toLowerCase(Locale.ROOT), InstanceGroupName.ATLAS_SCALE_OUT.name().toLowerCase(Locale.ROOT));
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TemplateValidatorAndUpdater.class);
 

--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-enterprise.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-enterprise.bp
@@ -72,7 +72,7 @@
       },
       {
         "cardinality":0,
-        "refName":"solrHG",
+        "refName":"solrScaleOut",
         "roleConfigGroupsRefNames":[
           "solr-SOLR_SERVER-EXTERNAL",
           "solr-GATEWAY-BASE"
@@ -80,7 +80,7 @@
       },
       {
         "cardinality":0,
-        "refName":"storageHG",
+        "refName":"storageScaleOut",
         "roleConfigGroupsRefNames":[
           "hbase-REGIONSERVER-EXTERNAL",
           "hdfs-DATANODE-EXTERNAL",
@@ -90,7 +90,7 @@
       },
       {
         "cardinality":0,
-        "refName":"kafkaHG",
+        "refName":"kafkaScaleOut",
         "roleConfigGroupsRefNames":[
           "kafka-KAFKA_BROKER-EXTERNAL",
           "kafka-GATEWAY-BASE"
@@ -98,13 +98,13 @@
       },
       {
         "cardinality":0,
-        "refName":"razHG",
+        "refName":"razScaleOut",
         "roleConfigGroupsRefNames":[
         ]
       },
       {
         "cardinality":0,
-        "refName":"atlasHG",
+        "refName":"atlasScaleOut",
         "roleConfigGroupsRefNames":[
           "atlas-ATLAS_SERVER-EXTERNAL",
           "hdfs-GATEWAY-BASE",
@@ -113,7 +113,7 @@
       },
       {
         "cardinality":0,
-        "refName":"hmsHG",
+        "refName":"hmsScaleOut",
         "roleConfigGroupsRefNames":[
           "hive-HIVEMETASTORE-EXTERNAL",
           "hive-GATEWAY-BASE"

--- a/core/src/main/resources/defaults/blueprints/7.2.18/cdp-sdx-enterprise.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.18/cdp-sdx-enterprise.bp
@@ -72,7 +72,7 @@
       },
       {
         "cardinality":0,
-        "refName":"solrHG",
+        "refName":"solrScaleOut",
         "roleConfigGroupsRefNames":[
           "solr-SOLR_SERVER-EXTERNAL",
           "solr-GATEWAY-BASE"
@@ -80,7 +80,7 @@
       },
       {
         "cardinality":0,
-        "refName":"storageHG",
+        "refName":"storageScaleOut",
         "roleConfigGroupsRefNames":[
           "hbase-REGIONSERVER-EXTERNAL",
           "hdfs-DATANODE-EXTERNAL",
@@ -90,7 +90,7 @@
       },
       {
         "cardinality":0,
-        "refName":"kafkaHG",
+        "refName":"kafkaScaleOut",
         "roleConfigGroupsRefNames":[
           "kafka-KAFKA_BROKER-EXTERNAL",
           "kafka-GATEWAY-BASE"
@@ -98,13 +98,13 @@
       },
       {
         "cardinality":0,
-        "refName":"razHG",
+        "refName":"razScaleOut",
         "roleConfigGroupsRefNames":[
         ]
       },
       {
         "cardinality":0,
-        "refName":"atlasHG",
+        "refName":"atlasScaleOut",
         "roleConfigGroupsRefNames":[
           "atlas-ATLAS_SERVER-EXTERNAL",
           "hdfs-GATEWAY-BASE",
@@ -113,7 +113,7 @@
       },
       {
         "cardinality":0,
-        "refName":"hmsHG",
+        "refName":"hmsScaleOut",
         "roleConfigGroupsRefNames":[
           "hive-HIVEMETASTORE-EXTERNAL",
           "hive-GATEWAY-BASE"

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/template/TemplateValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/template/TemplateValidatorTest.java
@@ -332,19 +332,19 @@ public class TemplateValidatorTest {
         services.add(service);
         when(cmTemplateProcessor.getAllComponents()).thenReturn(services);
 
-        instanceGroup = createSDXInstanceGroupWithoutAttachedVolumes("c5.xlarge", "hmsHG");
+        instanceGroup = createSDXInstanceGroupWithoutAttachedVolumes("c5.xlarge", "hms_scale_out");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, never()).error(anyString());
 
-        instanceGroup = createSDXInstanceGroupWithoutAttachedVolumes("c5.xlarge", "atlasHG");
+        instanceGroup = createSDXInstanceGroupWithoutAttachedVolumes("c5.xlarge", "atlas_scale_out");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, never()).error(anyString());
 
-        instanceGroup = createSDXInstanceGroupWithoutAttachedVolumes("m5.xlarge", "razHG");
+        instanceGroup = createSDXInstanceGroupWithoutAttachedVolumes("m5.xlarge", "razscaleout");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, never()).error(anyString());
 
-        instanceGroup = createSDXInstanceGroupWithoutAttachedVolumes("m5.xlarge", "storageHG");
+        instanceGroup = createSDXInstanceGroupWithoutAttachedVolumes("m5.xlarge", "storage_scale_out");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, times(2)).error(anyString());
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/OrderedOSUpgradeRequestProvider.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/OrderedOSUpgradeRequestProvider.java
@@ -1,16 +1,16 @@
 package com.sequenceiq.datalake.service.upgrade;
 
-import static com.sequenceiq.common.api.type.InstanceGroupName.ATLASHG;
+import static com.sequenceiq.common.api.type.InstanceGroupName.ATLAS_SCALE_OUT;
 import static com.sequenceiq.common.api.type.InstanceGroupName.AUXILIARY;
 import static com.sequenceiq.common.api.type.InstanceGroupName.CORE;
 import static com.sequenceiq.common.api.type.InstanceGroupName.GATEWAY;
-import static com.sequenceiq.common.api.type.InstanceGroupName.HMSHG;
+import static com.sequenceiq.common.api.type.InstanceGroupName.HMS_SCALE_OUT;
 import static com.sequenceiq.common.api.type.InstanceGroupName.IDBROKER;
-import static com.sequenceiq.common.api.type.InstanceGroupName.KAFKAHG;
+import static com.sequenceiq.common.api.type.InstanceGroupName.KAFKA_SCALE_OUT;
 import static com.sequenceiq.common.api.type.InstanceGroupName.MASTER;
-import static com.sequenceiq.common.api.type.InstanceGroupName.RAZHG;
-import static com.sequenceiq.common.api.type.InstanceGroupName.SOLRHG;
-import static com.sequenceiq.common.api.type.InstanceGroupName.STORAGEHG;
+import static com.sequenceiq.common.api.type.InstanceGroupName.RAZSCALEOUT;
+import static com.sequenceiq.common.api.type.InstanceGroupName.SOLR_SCALE_OUT;
+import static com.sequenceiq.common.api.type.InstanceGroupName.STORAGE_SCALE_OUT;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -119,12 +119,12 @@ public class OrderedOSUpgradeRequestProvider {
 
     private Set<String> collectInstanceIdsFromInstanceGroups(Map<String, List<String>> instanceIdsByInstanceGroup) {
         Set<String> instanceIds = new HashSet<>();
-        pollInstanceIdFromServiceHostGroup(instanceIdsByInstanceGroup, SOLRHG, instanceIds);
-        pollInstanceIdFromServiceHostGroup(instanceIdsByInstanceGroup, STORAGEHG, instanceIds);
-        pollInstanceIdFromServiceHostGroup(instanceIdsByInstanceGroup, KAFKAHG, instanceIds);
-        pollInstanceIdFromServiceHostGroup(instanceIdsByInstanceGroup, RAZHG, instanceIds);
-        pollInstanceIdFromServiceHostGroup(instanceIdsByInstanceGroup, ATLASHG, instanceIds);
-        pollInstanceIdFromServiceHostGroup(instanceIdsByInstanceGroup, HMSHG, instanceIds);
+        pollInstanceIdFromServiceHostGroup(instanceIdsByInstanceGroup, SOLR_SCALE_OUT, instanceIds);
+        pollInstanceIdFromServiceHostGroup(instanceIdsByInstanceGroup, STORAGE_SCALE_OUT, instanceIds);
+        pollInstanceIdFromServiceHostGroup(instanceIdsByInstanceGroup, KAFKA_SCALE_OUT, instanceIds);
+        pollInstanceIdFromServiceHostGroup(instanceIdsByInstanceGroup, RAZSCALEOUT, instanceIds);
+        pollInstanceIdFromServiceHostGroup(instanceIdsByInstanceGroup, ATLAS_SCALE_OUT, instanceIds);
+        pollInstanceIdFromServiceHostGroup(instanceIdsByInstanceGroup, HMS_SCALE_OUT, instanceIds);
         return instanceIds;
     }
 

--- a/datalake/src/main/resources/duties/7.2.1/gcp/enterprise.json
+++ b/datalake/src/main/resources/duties/7.2.1/gcp/enterprise.json
@@ -77,7 +77,7 @@
       "recipeNames": []
     },
     {
-      "name": "solrHG",
+      "name": "solrScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [
@@ -94,7 +94,7 @@
       "recipeNames": []
     },
     {
-      "name": "storageHG",
+      "name": "storageScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [
@@ -111,7 +111,7 @@
       "recipeNames": []
     },
     {
-      "name": "kafkaHG",
+      "name": "kafkaScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [
@@ -128,7 +128,7 @@
       "recipeNames": []
     },
     {
-      "name": "razHG",
+      "name": "razScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [
@@ -145,7 +145,7 @@
       "recipeNames": []
     },
     {
-      "name": "atlasHG",
+      "name": "atlasScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [
@@ -162,7 +162,7 @@
       "recipeNames": []
     },
     {
-      "name": "hmsHG",
+      "name": "hmsScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [

--- a/datalake/src/main/resources/duties/7.2.17/aws/enterprise.json
+++ b/datalake/src/main/resources/duties/7.2.17/aws/enterprise.json
@@ -77,7 +77,7 @@
       "recipeNames": []
     },
     {
-      "name": "solrHG",
+      "name": "solrScaleOut",
       "template": {
         "instanceType": "m5.xlarge",
         "attachedVolumes": [
@@ -94,7 +94,7 @@
       "recipeNames": []
     },
     {
-      "name":"storageHG",
+      "name":"storageScaleOut",
       "template": {
         "instanceType": "m5.xlarge",
         "attachedVolumes": [
@@ -111,7 +111,7 @@
       "recipeNames": []
     },
     {
-      "name": "kafkaHG",
+      "name": "kafkaScaleOut",
       "template": {
         "instanceType": "c5.large",
         "attachedVolumes": [
@@ -128,7 +128,7 @@
       "recipeNames": []
     },
     {
-      "name": "razHG",
+      "name": "razScaleOut",
       "template": {
         "instanceType": "c5.xlarge",
         "attachedVolumes": [
@@ -145,7 +145,7 @@
       "recipeNames": []
     },
     {
-      "name": "atlasHG",
+      "name": "atlasScaleOut",
       "template": {
         "instanceType": "m5.xlarge",
         "attachedVolumes": [
@@ -162,7 +162,7 @@
       "recipeNames": []
     },
     {
-      "name": "hmsHG",
+      "name": "hmsScaleOut",
       "template": {
         "instanceType": "m5.xlarge",
         "attachedVolumes": [

--- a/datalake/src/main/resources/duties/7.2.17/azure/enterprise.json
+++ b/datalake/src/main/resources/duties/7.2.17/azure/enterprise.json
@@ -77,7 +77,7 @@
       "recipeNames": []
     },
     {
-      "name": "solrHG",
+      "name": "solrScaleOut",
       "template": {
         "instanceType": "Standard_D4s_v3",
         "attachedVolumes": [
@@ -94,7 +94,7 @@
       "recipeNames": []
     },
     {
-      "name": "storageHG",
+      "name": "storageScaleOut",
       "template": {
         "instanceType": "Standard_D4s_v3",
         "attachedVolumes": [
@@ -111,7 +111,7 @@
       "recipeNames": []
     },
     {
-      "name": "kafkaHG",
+      "name": "kafkaScaleOut",
       "template": {
         "instanceType": "Standard_F2s_v2",
         "attachedVolumes": [
@@ -128,7 +128,7 @@
       "recipeNames": []
     },
     {
-      "name": "razHG",
+      "name": "razScaleOut",
       "template": {
         "instanceType": "Standard_F4s_v2",
         "attachedVolumes": [
@@ -145,7 +145,7 @@
       "recipeNames": []
     },
     {
-      "name": "atlasHG",
+      "name": "atlasScaleOut",
       "template": {
         "instanceType": "Standard_D4s_v3",
         "attachedVolumes": [
@@ -162,7 +162,7 @@
       "recipeNames": []
     },
     {
-      "name": "hmsHG",
+      "name": "hmsScaleOut",
       "template": {
         "instanceType": "Standard_D4s_v3",
         "attachedVolumes": [

--- a/datalake/src/main/resources/duties/7.2.17/gcp/enterprise.json
+++ b/datalake/src/main/resources/duties/7.2.17/gcp/enterprise.json
@@ -77,7 +77,7 @@
       "recipeNames": []
     },
     {
-      "name": "solrHG",
+      "name": "solrScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [
@@ -94,7 +94,7 @@
       "recipeNames": []
     },
     {
-      "name": "storageHG",
+      "name": "storageScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [
@@ -111,7 +111,7 @@
       "recipeNames": []
     },
     {
-      "name": "kafkaHG",
+      "name": "kafkaScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [
@@ -128,7 +128,7 @@
       "recipeNames": []
     },
     {
-      "name": "razHG",
+      "name": "razScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [
@@ -145,7 +145,7 @@
       "recipeNames": []
     },
     {
-      "name": "atlasHG",
+      "name": "atlasScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [
@@ -162,7 +162,7 @@
       "recipeNames": []
     },
     {
-      "name": "hmsHG",
+      "name": "hmsScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [

--- a/datalake/src/main/resources/duties/7.2.18/aws/enterprise.json
+++ b/datalake/src/main/resources/duties/7.2.18/aws/enterprise.json
@@ -77,7 +77,7 @@
       "recipeNames": []
     },
     {
-      "name": "solrHG",
+      "name": "solrScaleOut",
       "template": {
         "instanceType": "m5.xlarge",
         "attachedVolumes": [
@@ -94,7 +94,7 @@
       "recipeNames": []
     },
     {
-      "name":"storageHG",
+      "name":"storageScaleOut",
       "template": {
         "instanceType": "m5.xlarge",
         "attachedVolumes": [
@@ -111,7 +111,7 @@
       "recipeNames": []
     },
     {
-      "name": "kafkaHG",
+      "name": "kafkaScaleOut",
       "template": {
         "instanceType": "c5.large",
         "attachedVolumes": [
@@ -128,7 +128,7 @@
       "recipeNames": []
     },
     {
-      "name": "razHG",
+      "name": "razScaleOut",
       "template": {
         "instanceType": "c5.xlarge",
         "attachedVolumes": [
@@ -145,7 +145,7 @@
       "recipeNames": []
     },
     {
-      "name": "atlasHG",
+      "name": "atlasScaleOut",
       "template": {
         "instanceType": "m5.xlarge",
         "attachedVolumes": [
@@ -162,7 +162,7 @@
       "recipeNames": []
     },
     {
-      "name": "hmsHG",
+      "name": "hmsScaleOut",
       "template": {
         "instanceType": "m5.xlarge",
         "attachedVolumes": [

--- a/datalake/src/main/resources/duties/7.2.18/azure/enterprise.json
+++ b/datalake/src/main/resources/duties/7.2.18/azure/enterprise.json
@@ -77,7 +77,7 @@
       "recipeNames": []
     },
     {
-      "name": "solrHG",
+      "name": "solrScaleOut",
       "template": {
         "instanceType": "Standard_D4s_v3",
         "attachedVolumes": [
@@ -94,7 +94,7 @@
       "recipeNames": []
     },
     {
-      "name": "storageHG",
+      "name": "storageScaleOut",
       "template": {
         "instanceType": "Standard_D4s_v3",
         "attachedVolumes": [
@@ -111,7 +111,7 @@
       "recipeNames": []
     },
     {
-      "name": "kafkaHG",
+      "name": "kafkaScaleOut",
       "template": {
         "instanceType": "Standard_F2s_v2",
         "attachedVolumes": [
@@ -128,7 +128,7 @@
       "recipeNames": []
     },
     {
-      "name": "razHG",
+      "name": "razScaleOut",
       "template": {
         "instanceType": "Standard_F4s_v2",
         "attachedVolumes": [
@@ -145,7 +145,7 @@
       "recipeNames": []
     },
     {
-      "name": "atlasHG",
+      "name": "atlasScaleOut",
       "template": {
         "instanceType": "Standard_D4s_v3",
         "attachedVolumes": [
@@ -162,7 +162,7 @@
       "recipeNames": []
     },
     {
-      "name": "hmsHG",
+      "name": "hmsScaleOut",
       "template": {
         "instanceType": "Standard_D4s_v3",
         "attachedVolumes": [

--- a/datalake/src/main/resources/duties/7.2.18/gcp/enterprise.json
+++ b/datalake/src/main/resources/duties/7.2.18/gcp/enterprise.json
@@ -77,7 +77,7 @@
       "recipeNames": []
     },
     {
-      "name": "solrHG",
+      "name": "solrScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [
@@ -94,7 +94,7 @@
       "recipeNames": []
     },
     {
-      "name": "storageHG",
+      "name": "storageScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [
@@ -111,7 +111,7 @@
       "recipeNames": []
     },
     {
-      "name": "kafkaHG",
+      "name": "kafkaScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [
@@ -128,7 +128,7 @@
       "recipeNames": []
     },
     {
-      "name": "razHG",
+      "name": "razScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [
@@ -145,7 +145,7 @@
       "recipeNames": []
     },
     {
-      "name": "atlasHG",
+      "name": "atlasScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [
@@ -162,7 +162,7 @@
       "recipeNames": []
     },
     {
-      "name": "hmsHG",
+      "name": "hmsScaleOut",
       "template": {
         "instanceType": "e2-standard-4",
         "attachedVolumes": [

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/OrderedOSUpgradeRequestProviderTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/OrderedOSUpgradeRequestProviderTest.java
@@ -1,16 +1,16 @@
 package com.sequenceiq.datalake.service.upgrade;
 
-import static com.sequenceiq.common.api.type.InstanceGroupName.ATLASHG;
+import static com.sequenceiq.common.api.type.InstanceGroupName.ATLAS_SCALE_OUT;
 import static com.sequenceiq.common.api.type.InstanceGroupName.AUXILIARY;
 import static com.sequenceiq.common.api.type.InstanceGroupName.CORE;
 import static com.sequenceiq.common.api.type.InstanceGroupName.GATEWAY;
-import static com.sequenceiq.common.api.type.InstanceGroupName.HMSHG;
+import static com.sequenceiq.common.api.type.InstanceGroupName.HMS_SCALE_OUT;
 import static com.sequenceiq.common.api.type.InstanceGroupName.IDBROKER;
-import static com.sequenceiq.common.api.type.InstanceGroupName.KAFKAHG;
+import static com.sequenceiq.common.api.type.InstanceGroupName.KAFKA_SCALE_OUT;
 import static com.sequenceiq.common.api.type.InstanceGroupName.MASTER;
-import static com.sequenceiq.common.api.type.InstanceGroupName.RAZHG;
-import static com.sequenceiq.common.api.type.InstanceGroupName.SOLRHG;
-import static com.sequenceiq.common.api.type.InstanceGroupName.STORAGEHG;
+import static com.sequenceiq.common.api.type.InstanceGroupName.RAZSCALEOUT;
+import static com.sequenceiq.common.api.type.InstanceGroupName.SOLR_SCALE_OUT;
+import static com.sequenceiq.common.api.type.InstanceGroupName.STORAGE_SCALE_OUT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -97,26 +97,26 @@ class OrderedOSUpgradeRequestProviderTest {
                 createInstanceMetadata(GATEWAY, 1)
         )));
         instanceGroups.add(createInstanceGroup(Set.of(createInstanceMetadata(AUXILIARY, 0))));
-        instanceGroups.add(createInstanceGroup(Set.of(createInstanceMetadata(SOLRHG, 3))));
-        instanceGroups.add(createInstanceGroup(Set.of(createInstanceMetadata(STORAGEHG, 3))));
+        instanceGroups.add(createInstanceGroup(Set.of(createInstanceMetadata(SOLR_SCALE_OUT, 3))));
+        instanceGroups.add(createInstanceGroup(Set.of(createInstanceMetadata(STORAGE_SCALE_OUT, 3))));
         instanceGroups.add(createInstanceGroup(Set.of(
-                createInstanceMetadata(KAFKAHG, 3),
-                createInstanceMetadata(KAFKAHG, 4)
+                createInstanceMetadata(KAFKA_SCALE_OUT, 3),
+                createInstanceMetadata(KAFKA_SCALE_OUT, 4)
         )));
         instanceGroups.add(createInstanceGroup(Set.of(
-                createInstanceMetadata(RAZHG, 3),
-                createInstanceMetadata(RAZHG, 4),
-                createInstanceMetadata(RAZHG, 5)
+                createInstanceMetadata(RAZSCALEOUT, 3),
+                createInstanceMetadata(RAZSCALEOUT, 4),
+                createInstanceMetadata(RAZSCALEOUT, 5)
         )));
         instanceGroups.add(createInstanceGroup(Set.of(
-                createInstanceMetadata(ATLASHG, 3),
-                createInstanceMetadata(ATLASHG, 4),
-                createInstanceMetadata(ATLASHG, 5),
-                createInstanceMetadata(ATLASHG, 6)
+                createInstanceMetadata(ATLAS_SCALE_OUT, 3),
+                createInstanceMetadata(ATLAS_SCALE_OUT, 4),
+                createInstanceMetadata(ATLAS_SCALE_OUT, 5),
+                createInstanceMetadata(ATLAS_SCALE_OUT, 6)
         )));
         instanceGroups.add(createInstanceGroup(Set.of(
-                createInstanceMetadata(HMSHG, 3),
-                createInstanceMetadata(HMSHG, 4)
+                createInstanceMetadata(HMS_SCALE_OUT, 3),
+                createInstanceMetadata(HMS_SCALE_OUT, 4)
         )));
 
         OrderedOSUpgradeSetRequest actual = underTest.createDatalakeOrderedOSUpgradeSetRequest(createStackV4Response(instanceGroups), TARGET_IMAGE_ID);
@@ -137,13 +137,14 @@ class OrderedOSUpgradeRequestProviderTest {
         assertThat(actual.getOrderedOsUpgradeSets().get(2).getInstanceIds(),
                 containsInAnyOrder(Set.of("i-core2", "i-gateway1").toArray()));
         assertThat(actual.getOrderedOsUpgradeSets().get(3).getInstanceIds(),
-                containsInAnyOrder(Set.of("i-solrhg3", "i-storagehg3", "i-kafkahg3", "i-razhg3", "i-atlashg3", "i-hmshg3").toArray()));
+                containsInAnyOrder(Set.of("i-solrscaleout3", "i-storagescaleout3", "i-kafkascaleout3", "i-razscaleout3", "i-atlasscaleout3", "i-hmsscaleout3")
+                        .toArray()));
         assertThat(actual.getOrderedOsUpgradeSets().get(4).getInstanceIds(),
-                containsInAnyOrder(Set.of("i-kafkahg4", "i-razhg4", "i-atlashg4", "i-hmshg4").toArray()));
+                containsInAnyOrder(Set.of("i-kafkascaleout4", "i-razscaleout4", "i-atlasscaleout4", "i-hmsscaleout4").toArray()));
         assertThat(actual.getOrderedOsUpgradeSets().get(5).getInstanceIds(),
-                containsInAnyOrder(Set.of("i-razhg5", "i-atlashg5").toArray()));
+                containsInAnyOrder(Set.of("i-razscaleout5", "i-atlasscaleout5").toArray()));
         assertThat(actual.getOrderedOsUpgradeSets().get(6).getInstanceIds(),
-                containsInAnyOrder(Set.of("i-atlashg6").toArray()));
+                containsInAnyOrder(Set.of("i-atlasscaleout6").toArray()));
     }
 
     @Test

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/HostGroupType.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/HostGroupType.java
@@ -18,12 +18,12 @@ public enum HostGroupType {
     ZOOKEEPER("ZooKeeper", InstanceGroupType.CORE, InstanceCountParameter.ZOOKEEPER_INSTANCE_COUNT.getName()),
     AUXILIARY("auxiliary", InstanceGroupType.CORE, InstanceCountParameter.AUXILIARY_INSTANCE_COUNT.getName(), 1),
     CORE("core", InstanceGroupType.CORE, InstanceCountParameter.CORE_INSTANCE_COUNT.getName(), 3),
-    SOLRHG("solrhg", InstanceGroupType.CORE, InstanceCountParameter.SOLRHG_INSTANCE_COUNT.getName(), 0),
-    STORAGEHG("storagehg", InstanceGroupType.CORE, InstanceCountParameter.STORAGEHG_INSTANCE_COUNT.getName(), 0),
-    KAFKAHG("kafkahg", InstanceGroupType.CORE, InstanceCountParameter.KAFKAHG_INSTANCE_COUNT.getName(), 0),
-    RAZHG("razhg", InstanceGroupType.CORE, InstanceCountParameter.RAZHG_INSTANCE_COUNT.getName(), 0),
-    ATLASHG("atlashg", InstanceGroupType.CORE, InstanceCountParameter.ATLASHG_INSTANCE_COUNT.getName(), 0),
-    HMSHG("hmshg", InstanceGroupType.CORE, InstanceCountParameter.HMSHG_INSTANCE_COUNT.getName(), 0);
+    SOLR_SCALE_OUT("solrscaleout", InstanceGroupType.CORE, InstanceCountParameter.SOLR_SCALE_OUT_INSTANCE_COUNT.getName(), 0),
+    STORAGE_SCALE_OUT("storagescaleout", InstanceGroupType.CORE, InstanceCountParameter.STORAGE_SCALE_OUT_INSTANCE_COUNT.getName(), 0),
+    KAFKA_SCALE_OUT("kafkascaleout", InstanceGroupType.CORE, InstanceCountParameter.KAFKA_SCALE_OUT_INSTANCE_COUNT.getName(), 0),
+    RAZ_SCALE_OUT("razscaleout", InstanceGroupType.CORE, InstanceCountParameter.RAZ_SCALE_OUT_INSTANCE_COUNT.getName(), 0),
+    ATLAS_SCALE_OUT("atlasscalout", InstanceGroupType.CORE, InstanceCountParameter.ATLAS_SCALE_OUT_INSTANCE_COUNT.getName(), 0),
+    HMS_SCALE_OUT("hmsscaleout", InstanceGroupType.CORE, InstanceCountParameter.HMS_SCALE_OUT_INSTANCE_COUNT.getName(), 0);
 
     private final String name;
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/InstanceCountParameter.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/InstanceCountParameter.java
@@ -11,12 +11,12 @@ public enum InstanceCountParameter {
     ZOOKEEPER_INSTANCE_COUNT("zookeeperInstanceCount"),
     AUXILIARY_INSTANCE_COUNT("auxiliaryInstanceCount"),
     CORE_INSTANCE_COUNT("coreInstanceCount"),
-    SOLRHG_INSTANCE_COUNT("solrhgInstanceCount"),
-    STORAGEHG_INSTANCE_COUNT("storagehgInstanceCount"),
-    KAFKAHG_INSTANCE_COUNT("kafkahgInstanceCount"),
-    RAZHG_INSTANCE_COUNT("razhgInstanceCount"),
-    ATLASHG_INSTANCE_COUNT("atlashgInstanceCount"),
-    HMSHG_INSTANCE_COUNT("hmshgInstanceCount");
+    SOLR_SCALE_OUT_INSTANCE_COUNT("solrscaleoutInstanceCount"),
+    STORAGE_SCALE_OUT_INSTANCE_COUNT("storagescaleoutInstanceCount"),
+    KAFKA_SCALE_OUT_INSTANCE_COUNT("kafkascaleoutInstanceCount"),
+    RAZ_SCALE_OUT_INSTANCE_COUNT("razscaleoutInstanceCount"),
+    ATLAS_SCALE_OUT_INSTANCE_COUNT("atlasscaleoutInstanceCount"),
+    HMS_SCALE_OUT_INSTANCE_COUNT("hmsscaleoutInstanceCount");
 
     private final String name;
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/InstanceGroupTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/InstanceGroupTestDto.java
@@ -1,21 +1,21 @@
 package com.sequenceiq.it.cloudbreak.dto;
 
 import static com.sequenceiq.cloudbreak.doc.ModelDescriptions.HostGroupModelDescription.RECOVERY_MODE;
-import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.ATLASHG;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.ATLAS_SCALE_OUT;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.AUXILIARY;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.COMPUTE;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.CORE;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.GATEWAY;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.GATEWAY_ENT;
-import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.HMSHG;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.HMS_SCALE_OUT;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.IDBROKER;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.IDBROKER_ENT;
-import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.KAFKAHG;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.KAFKA_SCALE_OUT;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.MASTER;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.MASTER_ENT;
-import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.RAZHG;
-import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.SOLRHG;
-import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.STORAGEHG;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.RAZ_SCALE_OUT;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.SOLR_SCALE_OUT;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.STORAGE_SCALE_OUT;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.WORKER;
 
 import java.util.List;
@@ -89,7 +89,8 @@ public class InstanceGroupTestDto extends AbstractCloudbreakTestDto<InstanceGrou
     }
 
     public static List<InstanceGroupTestDto> sdxEnterpriseHostGroup(TestContext testContext) {
-        return withHostGroup(testContext, MASTER_ENT, IDBROKER_ENT, GATEWAY_ENT, CORE, AUXILIARY, SOLRHG, STORAGEHG, KAFKAHG, RAZHG, ATLASHG, HMSHG);
+        return withHostGroup(testContext, MASTER_ENT, IDBROKER_ENT, GATEWAY_ENT, CORE, AUXILIARY, SOLR_SCALE_OUT, STORAGE_SCALE_OUT, KAFKA_SCALE_OUT,
+                RAZ_SCALE_OUT, ATLAS_SCALE_OUT, HMS_SCALE_OUT);
     }
 
     public static List<InstanceGroupTestDto> withHostGroup(TestContext testContext, HostGroupType... groupTypes) {

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatalakeConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatalakeConfigProvider.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.raz;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -12,13 +13,15 @@ import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+import com.sequenceiq.common.api.type.InstanceGroupName;
 
 /**
  * Enables the Ranger Raz service.
  */
 @Component
 public class RangerRazDatalakeConfigProvider extends RangerRazBaseConfigProvider {
-    private static final Set<String> ADDITIONAL_SERVICE_HOSTGROUPS = Set.of("master", "razhg");
+    private static final Set<String> ADDITIONAL_SERVICE_HOSTGROUPS = Set.of(InstanceGroupName.MASTER.name().toLowerCase(Locale.ROOT),
+            InstanceGroupName.RAZSCALEOUT.name().toLowerCase(Locale.ROOT));
 
     @Override
     public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatalakeConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatalakeConfigProviderTest.java
@@ -172,34 +172,34 @@ public class RangerRazDatalakeConfigProviderTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("razCloudPlatformAndCmVersionDataProvider")
     @DisplayName("DL is used with the right CM and Raz is requested and Raz hostgroup is present, Raz service needs to be added to the template")
-    void getAdditionalServicesWhenRazIsEnabledAndRAZHGPresentWithRightCm(String testCaseName, CloudPlatform cloudPlatform, String cmVersion) {
+    void getAdditionalServicesWhenRazIsEnabledAndRAZScaleOutPresentWithRightCm(String testCaseName, CloudPlatform cloudPlatform, String cmVersion) {
         ClouderaManagerRepo cmRepo = new ClouderaManagerRepo();
         cmRepo.setVersion(cmVersion);
         GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
         generalClusterConfigs.setEnableRangerRaz(true);
         HostgroupView master = new HostgroupView("master", 0, InstanceGroupType.GATEWAY, List.of());
         HostgroupView idbroker = new HostgroupView("idbroker", 0, InstanceGroupType.CORE, List.of());
-        HostgroupView razHG = new HostgroupView("razhg", 0, InstanceGroupType.CORE, List.of());
+        HostgroupView razScaleOut = new HostgroupView("razscaleout", 0, InstanceGroupType.CORE, List.of());
         TemplatePreparationObject preparationObject = Builder.builder()
                 .withStackType(StackType.DATALAKE)
                 .withCloudPlatform(cloudPlatform)
                 .withProductDetails(cmRepo, List.of())
                 .withGeneralClusterConfigs(generalClusterConfigs)
-                .withHostgroupViews(Set.of(master, idbroker, razHG))
+                .withHostgroupViews(Set.of(master, idbroker, razScaleOut))
                 .build();
         Map<String, ApiClusterTemplateService> additionalServices = configProvider.getAdditionalServices(cmTemplateProcessor, preparationObject);
 
-        ApiClusterTemplateService razHGService = additionalServices.get("razhg");
-        List<ApiClusterTemplateRoleConfigGroup> razHGRoleConfigGroups = razHGService.getRoleConfigGroups();
+        ApiClusterTemplateService razScaleOutService = additionalServices.get("razscaleout");
+        List<ApiClusterTemplateRoleConfigGroup> razScaleOutRoleConfigGroups = razScaleOutService.getRoleConfigGroups();
         ApiClusterTemplateService masterService = additionalServices.get("master");
         List<ApiClusterTemplateRoleConfigGroup> masterRoleConfigGroups = masterService.getRoleConfigGroups();
         Assertions.assertAll(
                 () -> assertEquals(2, additionalServices.size()),
 
-                () -> assertEquals("RANGER_RAZ", razHGService.getServiceType()),
-                () -> assertEquals("ranger-RANGER_RAZ", razHGService.getRefName()),
-                () -> assertEquals("RANGER_RAZ_SERVER", razHGRoleConfigGroups.get(0).getRoleType()),
-                () -> assertEquals("ranger-RANGER_RAZ_SERVER", razHGRoleConfigGroups.get(0).getRefName()),
+                () -> assertEquals("RANGER_RAZ", razScaleOutService.getServiceType()),
+                () -> assertEquals("ranger-RANGER_RAZ", razScaleOutService.getRefName()),
+                () -> assertEquals("RANGER_RAZ_SERVER", razScaleOutRoleConfigGroups.get(0).getRoleType()),
+                () -> assertEquals("ranger-RANGER_RAZ_SERVER", razScaleOutRoleConfigGroups.get(0).getRefName()),
 
                 () -> assertEquals("RANGER_RAZ", masterService.getServiceType()),
                 () -> assertEquals("ranger-RANGER_RAZ", masterService.getRefName()),


### PR DESCRIPTION
[CB-22154](https://jira.cloudera.com/browse/CB-22154) change the name of the extra host group in case of `EDL`. The original name contains the `HG` as a prefix and it can confuse the customer based on that we have `SolrHG` and the newly created environment show the `SolrHG` as empty. The customer can ask why the datalake does not contains the `Solr` insetance(s). The new name give more details when these host group will alive. The new name is scaleout, which refers to that these host groups are part of the datalake scaling. Tested locally: the enw host group names are changed to name+scaleout. E.q.: `Solrscaleout`
UI:
![image](https://github.com/hortonworks/cloudbreak/assets/17518249/0952dba4-076b-43d3-84ae-b72e8657251c)
