### PR TITLE
CB-22114 Create an 'os' option for FreeIPA creation

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -139,6 +139,7 @@ public class EnvironmentModelDescription {
     public static final String FREEIPA_IMAGE = "Image parameters for FreeIpa instance creation.";
     public static final String FREEIPA_IMAGE_CATALOG = "Image catalog for FreeIpa instance creation.";
     public static final String FREEIPA_IMAGE_ID = "Image ID for FreeIpa instance creation.";
+    public static final String FREEIPA_IMAGE_OS_TYPE = "OS type to be chosen from the image catalog";
 
     public static final String PROXYCONFIG_NAME = "Name of the proxyconfig of the environment.";
     public static final String PROXYCONFIG_RESPONSE = "ProxyConfig attached to the environment.";

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/FreeIpaImageRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/FreeIpaImageRequest.java
@@ -24,11 +24,16 @@ public class FreeIpaImageRequest implements Serializable {
     @Size(max = 255)
     private String id;
 
+    @ApiModelProperty(EnvironmentModelDescription.FREEIPA_IMAGE_OS_TYPE)
+    @Size(max = 255)
+    private String os;
+
     @Override
     public String toString() {
         return "FreeIpaImageRequest{" +
-                "catalog=" + catalog +
-                ", id=" + id +
+                "catalog='" + catalog + '\'' +
+                ", id='" + id + '\'' +
+                ", os='" + os + '\'' +
                 '}';
     }
 
@@ -46,5 +51,13 @@ public class FreeIpaImageRequest implements Serializable {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getOs() {
+        return os;
+    }
+
+    public void setOs(String os) {
+        this.os = os;
     }
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/FreeIpaImageResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/FreeIpaImageResponse.java
@@ -14,6 +14,9 @@ public class FreeIpaImageResponse implements Serializable {
     @ApiModelProperty(EnvironmentModelDescription.FREEIPA_IMAGE_ID)
     private String id;
 
+    @ApiModelProperty(EnvironmentModelDescription.FREEIPA_IMAGE_OS_TYPE)
+    private String os;
+
     public String getCatalog() {
         return catalog;
     }
@@ -30,11 +33,20 @@ public class FreeIpaImageResponse implements Serializable {
         this.id = id;
     }
 
+    public String getOs() {
+        return os;
+    }
+
+    public void setOs(String os) {
+        this.os = os;
+    }
+
     @Override
     public String toString() {
         return "FreeIpaImageResponse{" +
                 "catalog='" + catalog + '\'' +
                 ", id='" + id + '\'' +
+                ", os='" + os + '\'' +
                 '}';
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/domain/Environment.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/domain/Environment.java
@@ -85,6 +85,8 @@ public class Environment implements AuthResource, AccountAwareResource {
 
     private String freeIpaImageId;
 
+    private String freeIpaImageOs;
+
     @Column(nullable = false)
     private boolean freeIpaEnableMultiAz;
 
@@ -417,6 +419,14 @@ public class Environment implements AuthResource, AccountAwareResource {
 
     public void setFreeIpaImageId(String freeIpaImageId) {
         this.freeIpaImageId = freeIpaImageId;
+    }
+
+    public String getFreeIpaImageOs() {
+        return freeIpaImageOs;
+    }
+
+    public void setFreeIpaImageOs(String freeIpaImageOs) {
+        this.freeIpaImageOs = freeIpaImageOs;
     }
 
     public EnvironmentAuthentication getAuthentication() {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/domain/EnvironmentView.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/domain/EnvironmentView.java
@@ -131,6 +131,8 @@ public class EnvironmentView extends CompactView implements AuthResource {
 
     private String freeIpaImageId;
 
+    private String freeIpaImageOs;
+
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "environment_freeiparecipes", joinColumns = @JoinColumn(name = "environment_id", referencedColumnName = "id"))
     @Column(name = "recipe")
@@ -489,6 +491,14 @@ public class EnvironmentView extends CompactView implements AuthResource {
 
     public void setFreeIpaImageId(String freeIpaImageId) {
         this.freeIpaImageId = freeIpaImageId;
+    }
+
+    public String getFreeIpaImageOs() {
+        return freeIpaImageOs;
+    }
+
+    public void setFreeIpaImageOs(String freeIpaImageOs) {
+        this.freeIpaImageOs = freeIpaImageOs;
     }
 
     public boolean isFreeIpaEnableMultiAz() {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDto.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDto.java
@@ -8,9 +8,10 @@ import com.sequenceiq.cloudbreak.structuredevent.event.cdp.environment.Environme
 import com.sequenceiq.cloudbreak.structuredevent.event.cdp.environment.credential.CredentialDetails;
 import com.sequenceiq.cloudbreak.structuredevent.event.cdp.environment.proxy.ProxyDetails;
 import com.sequenceiq.environment.credential.domain.Credential;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto.Builder;
 import com.sequenceiq.environment.proxy.domain.ProxyConfig;
 
-@JsonDeserialize(builder = EnvironmentDto.Builder.class)
+@JsonDeserialize(builder = Builder.class)
 public class EnvironmentDto extends EnvironmentDtoBase implements EnvironmentDetails {
 
     private Credential credential;

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDtoConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDtoConverter.java
@@ -27,6 +27,7 @@ import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.environment.domain.EnvironmentTags;
 import com.sequenceiq.environment.environment.domain.EnvironmentView;
 import com.sequenceiq.environment.environment.domain.Region;
+import com.sequenceiq.environment.environment.dto.FreeIpaCreationDto.Builder;
 import com.sequenceiq.environment.environment.dto.credential.CredentialDetailsConverter;
 import com.sequenceiq.environment.environment.service.freeipa.FreeIpaInstanceCountByGroupProvider;
 import com.sequenceiq.environment.environment.service.recipe.EnvironmentRecipeService;
@@ -208,6 +209,7 @@ public class EnvironmentDtoConverter {
         environment.setFreeIpaEnableMultiAz(creationDto.getFreeIpaCreation().isEnableMultiAz());
         environment.setDeletionType(NONE);
         environment.setFreeIpaImageId(creationDto.getFreeIpaCreation().getImageId());
+        environment.setFreeIpaImageOs(creationDto.getFreeIpaCreation().getImageOs());
         environment.setAdminGroupName(creationDto.getAdminGroupName());
         environment.setCreated(System.currentTimeMillis());
         environment.setTags(getTags(creationDto));
@@ -301,7 +303,8 @@ public class EnvironmentDtoConverter {
         Set<String> recipesForEnvironment = environmentRecipeService.getRecipes(environment.getId());
         FreeIpaCreationDto freeIpaCreationDto = getFreeIpaCreationDto(environment.isCreateFreeIpa(), environment.getFreeIpaInstanceCountByGroup(),
                 environment.getFreeIpaInstanceType(), environment.getFreeIpaImageCatalog(), environment.getFreeIpaImageId(),
-                environment.isFreeIpaEnableMultiAz(), recipesForEnvironment);
+                environment.getFreeIpaImageOs(), environment.isFreeIpaEnableMultiAz());
+        freeIpaCreationDto.setRecipes(recipesForEnvironment);
         freeIpaCreationDto.setAws(getFreeIpaAwsParameters(environment.getCloudPlatform(), environment.getParameters()));
         return freeIpaCreationDto;
     }
@@ -309,7 +312,8 @@ public class EnvironmentDtoConverter {
     private FreeIpaCreationDto environmentViewToFreeIpaCreationDto(EnvironmentView environment) {
         FreeIpaCreationDto freeIpaCreationDto = getFreeIpaCreationDto(environment.isCreateFreeIpa(), environment.getFreeIpaInstanceCountByGroup(),
                 environment.getFreeIpaInstanceType(), environment.getFreeIpaImageCatalog(), environment.getFreeIpaImageId(),
-                environment.isFreeIpaEnableMultiAz(), environment.getFreeipaRecipes());
+                environment.getFreeIpaImageOs(), environment.isFreeIpaEnableMultiAz());
+        freeIpaCreationDto.setRecipes(environment.getFreeipaRecipes());
         freeIpaCreationDto.setAws(getFreeIpaAwsParameters(environment.getCloudPlatform(), environment.getParameters()));
         return freeIpaCreationDto;
     }
@@ -329,15 +333,15 @@ public class EnvironmentDtoConverter {
     }
 
     private FreeIpaCreationDto getFreeIpaCreationDto(boolean createFreeIpa, Integer freeIpaInstanceCountByGroup, String freeIpaInstanceType,
-            String freeIpaImageCatalog, String freeIpaImageId, boolean freeIpaEnableMultiAz, Set<String> freeipaRecipes) {
+            String freeIpaImageCatalog, String freeIpaImageId, String freeIpaImageOs, boolean freeIpaEnableMultiAz) {
         Integer ipaInstanceCountByGroup = Optional.ofNullable(freeIpaInstanceCountByGroup).orElse(ipaInstanceCountByGroupProvider.getDefaultInstanceCount());
-        FreeIpaCreationDto.Builder builder = FreeIpaCreationDto.builder(ipaInstanceCountByGroup)
+        Builder builder = FreeIpaCreationDto.builder(ipaInstanceCountByGroup)
                 .withCreate(createFreeIpa);
         builder.withInstanceType(freeIpaInstanceType);
         builder.withImageCatalog(freeIpaImageCatalog);
         builder.withImageId(freeIpaImageId);
+        builder.withImageOs(freeIpaImageOs);
         builder.withEnableMultiAz(freeIpaEnableMultiAz);
-        builder.withRecipes(freeipaRecipes);
         return builder.build();
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationHandler.java
@@ -427,11 +427,19 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
         if (environment.getFreeIpaCreation() != null) {
             String imageCatalog = environment.getFreeIpaCreation().getImageCatalog();
             String imageId = environment.getFreeIpaCreation().getImageId();
+            String imageOs = environment.getFreeIpaCreation().getImageOs();
             if (!Strings.isNullOrEmpty(imageId)) {
                 LOGGER.info("FreeIPA creation with a pre-defined image catalog and image id: '{}', '{}'", imageCatalog, imageId);
                 ImageSettingsRequest imageSettings = new ImageSettingsRequest();
                 imageSettings.setCatalog(imageCatalog);
                 imageSettings.setId(imageId);
+                imageSettings.setOs(imageOs);
+                createFreeIpaRequest.setImage(imageSettings);
+            } else if (!Strings.isNullOrEmpty(imageOs)) {
+                LOGGER.info("FreeIPA creation with a pre-defined image catalog and OS type: '{}', '{}'", imageCatalog, imageOs);
+                ImageSettingsRequest imageSettings = new ImageSettingsRequest();
+                imageSettings.setCatalog(imageCatalog);
+                imageSettings.setOs(imageOs);
                 createFreeIpaRequest.setImage(imageSettings);
             } else {
                 LOGGER.info("FreeIPA creation without pre-defined image settings. FreeIpa serivce is going to handle default settings.");

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/FreeIpaConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/FreeIpaConverter.java
@@ -20,6 +20,7 @@ import com.sequenceiq.environment.api.v1.environment.model.response.FreeIpaRespo
 import com.sequenceiq.environment.environment.dto.FreeIpaCreationAwsParametersDto;
 import com.sequenceiq.environment.environment.dto.FreeIpaCreationAwsSpotParametersDto;
 import com.sequenceiq.environment.environment.dto.FreeIpaCreationDto;
+import com.sequenceiq.environment.environment.dto.FreeIpaCreationDto.Builder;
 import com.sequenceiq.environment.environment.service.freeipa.FreeIpaInstanceCountByGroupProvider;
 
 @Component
@@ -40,7 +41,7 @@ public class FreeIpaConverter {
             Optional.ofNullable(freeIpaCreation.getAws())
                     .map(this::convertAws)
                     .ifPresent(response::setAws);
-            response.setImage(convertImage(freeIpaCreation.getImageCatalog(), freeIpaCreation.getImageId()));
+            response.setImage(convertImage(freeIpaCreation.getImageCatalog(), freeIpaCreation.getImageId(), freeIpaCreation.getImageOs()));
             response.setEnableMultiAz(freeIpaCreation.isEnableMultiAz());
             return response;
         }
@@ -59,18 +60,19 @@ public class FreeIpaConverter {
         return result;
     }
 
-    private FreeIpaImageResponse convertImage(String catalog, String id) {
+    private FreeIpaImageResponse convertImage(String catalog, String id, String os) {
         FreeIpaImageResponse result = null;
-        if (!Strings.isNullOrEmpty(catalog) && !Strings.isNullOrEmpty(id)) {
+        if ((!Strings.isNullOrEmpty(catalog) && !Strings.isNullOrEmpty(id)) || !Strings.isNullOrEmpty(os)) {
             result = new FreeIpaImageResponse();
             result.setCatalog(catalog);
             result.setId(id);
+            result.setOs(os);
         }
         return result;
     }
 
     public FreeIpaCreationDto convert(AttachedFreeIpaRequest request, String accountId, String cloudPlatform) {
-        FreeIpaCreationDto.Builder builder = FreeIpaCreationDto.builder(ipaInstanceCountByGroupProvider.getInstanceCount(request));
+        Builder builder = FreeIpaCreationDto.builder(ipaInstanceCountByGroupProvider.getInstanceCount(request));
         if (request != null) {
             builder.withCreate(request.getCreate());
             builder.withEnableMultiAz(request.isEnableMultiAz());
@@ -96,6 +98,7 @@ public class FreeIpaConverter {
             if (image != null) {
                 builder.withImageCatalog(image.getCatalog());
                 builder.withImageId(image.getId());
+                builder.withImageOs(image.getOs());
             }
             Set<String> recipes = request.getRecipes();
             if (recipes != null) {

--- a/environment/src/main/resources/schema/app/20230612074641_CB-22114_Create_new_image_os_field.sql
+++ b/environment/src/main/resources/schema/app/20230612074641_CB-22114_Create_new_image_os_field.sql
@@ -1,0 +1,10 @@
+-- // CB-12577 Table to store account level setting to image terms auto acceptance
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE environment ADD COLUMN IF NOT EXISTS freeipaimageos varchar(255);
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE environment DROP COLUMN IF EXISTS freeipaimageos;

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/environment/dto/FreeIpaCreationDto.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/environment/dto/FreeIpaCreationDto.java
@@ -22,6 +22,8 @@ public class FreeIpaCreationDto {
 
     private String imageId;
 
+    private String imageOs;
+
     private String instanceType;
 
     private FreeIpaCreationDto(Builder builder) {
@@ -31,6 +33,7 @@ public class FreeIpaCreationDto {
         imageCatalog = builder.imageCatalog;
         enableMultiAz = builder.enableMultiAz;
         imageId = builder.imageId;
+        imageOs = builder.imageOs;
         instanceType = builder.instanceType;
         recipes = builder.recipes;
     }
@@ -75,6 +78,14 @@ public class FreeIpaCreationDto {
         this.imageId = imageId;
     }
 
+    public String getImageOs() {
+        return imageOs;
+    }
+
+    public void setImageOs(String imageOs) {
+        this.imageOs = imageOs;
+    }
+
     public boolean isEnableMultiAz() {
         return enableMultiAz;
     }
@@ -109,6 +120,7 @@ public class FreeIpaCreationDto {
                 ", enableMultiAz=" + enableMultiAz +
                 ", imageCatalog='" + imageCatalog + '\'' +
                 ", imageId='" + imageId + '\'' +
+                ", imageOs='" + imageOs + '\'' +
                 ", instanceType='" + instanceType + '\'' +
                 '}';
     }
@@ -129,6 +141,8 @@ public class FreeIpaCreationDto {
         private String imageCatalog;
 
         private String imageId;
+
+        private String imageOs;
 
         private boolean enableMultiAz;
 
@@ -165,6 +179,11 @@ public class FreeIpaCreationDto {
 
         public Builder withImageId(String imageId) {
             this.imageId = imageId;
+            return this;
+        }
+
+        public Builder withImageOs(String imageOs) {
+            this.imageOs = imageOs;
             return this;
         }
 


### PR DESCRIPTION
This PR exposes an already existing backend feature to select
an image based on the [O]perating [S]ystem. As part of the
environment request now you'll be able to do this
```
    "image": {
      "os": "redhat8"
    },
```
to select the latest RedHat8 based FreeIPA image. Later this
functionality can be exposed to the UI. You can achieve the
same thing by specifying the image by direct ID like
```
    "image": {
      "catalog": "https://cloudbreak-imagecatalog.s3.amazonaws.com/v3-test-freeipa-image-catalog.json",
      "id": "ef46a6e8-1cc3-40f4-a33f-606b42ad3772",
    },
```
but it simplifies the testing by not caring about the image
id just the OS type.