### PR TITLE
CDPSDX-4064 Change getCreated to getId when getting lastFlowChain

### DIFF
--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowChainLogService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowChainLogService.java
@@ -55,7 +55,8 @@ public class FlowChainLogService {
     public List<FlowChainLog> getRelatedFlowChainLogs(List<FlowChainLog> sourceFlowChains) {
         Optional<FlowChainLog> flowChainWithParent = sourceFlowChains.stream()
                 .filter(flowChainLog -> StringUtils.isNotBlank(flowChainLog.getParentFlowChainId())).findFirst();
-        FlowChainLog lastFlowChain = sourceFlowChains.stream().max(Comparator.comparing(FlowChainLog::getCreated)).get();
+        FlowChainLog lastFlowChain = sourceFlowChains.stream().max(Comparator.comparing(FlowChainLog::getCreated)
+                .thenComparing(FlowChainLog::getId)).get();
         FlowChainLog inputFlowChain = flowChainWithParent.orElse(lastFlowChain);
         return collectRelatedFlowChains(inputFlowChain);
     }
@@ -116,7 +117,7 @@ public class FlowChainLogService {
                     .sorted(comparing(FlowChainLog::getCreated).reversed())
                     .findFirst()
                     .get();
-            LOGGER.debug("Checking if chain with id {} has any event in it's queue", latestFlowChain.getFlowChainId());
+            LOGGER.debug("Checking if chain with id {} has any event in its queue", latestFlowChain.getFlowChainId());
             LOGGER.debug("Chain string in db: {}", latestFlowChain.getChainJackson());
             Queue<Selectable> chain = latestFlowChain.getChainAsQueue();
             return !chain.isEmpty();


### PR DESCRIPTION
**JIRA:** [ENGESC-20632](https://jira.cloudera.com/browse/ENGESC-20632) & [CDPSDX-4064](https://jira.cloudera.com/browse/CDPSDX-4064) **(we need it to be a hotfix to 2.72 since many customers are experiencing this issue)** This PR had already been approved in there https://github.com/hortonworks/cloudbreak/pull/15029, creating this new one to merge it into CB2.72.
**CONTEXT:** We recently introduced code in BackupDatalakeDatabaseFlowEventChainFactory that would skip salt_update if salt_update_event has been run, that would left the flowchain only have database_backup_event, which would let the flowchainlog be saved into the database in a very short time (detail is under the code in removeLastTriggerEvent), causing the column created to have the same value in some rare cases.
**ISSUE:** The program is using `FlowChainLog lastFlowChain = sourceFlowChains.stream().max(Comparator.comparing(FlowChainLog::getId)).get() `to get the last FlowChainLog in a list, but when created are the same in some rows, the order may get wrong and when the program tries to get the latest flowchainlog, it is not getting the latest. This creates issues for database backup when in some rare cases created are the same and the program is not getting the latest flowchainlog, resulting database backup is thought as never finished, resulting in backup timeout error.
**SOLUTION:** Discussed this with the CB team there https://cloudera.slack.com/archives/CF66M7WP6/p1685716566710529 (there has been some changes about the strategy after the discussion) and update how the program gets the last/latest flowchainlog for database backup - change from get max created to get max created but if created are the same, use get id.
Below is a screenshot of a client that have the same created and then have a DB backup error which comes from this escalation [ENGESC-20632](https://jira.cloudera.com/browse/ENGESC-20632)
![image](https://github.com/hortonworks/cloudbreak/assets/39275944/f1ce9cd3-d26d-4274-adc6-93b1b37f5867)

**TEST:**
I hardcoded created to be the same:
Before - DB backup fails (sometimes, only when the order is incorrect):
![image](https://github.com/hortonworks/cloudbreak/assets/39275944/85a97087-a202-4743-8286-236f32fdc920)

After - even if the order from` List<FlowChainLog> flowChains = flowChainLogService.findByFlowChainIdOrderByCreatedDesc(chainId);` is not correct (logging out the element from the list one by one and we can see the first is not the latest, 632 etc is the id number and then it is the chainJackson value):

```
!flowchainlog:632;[{"@type":"com.sequenceiq.cloudbreak.reactor.api.event.StackEvent","selector":"SALT_UPDATE_TRIGGER_EVENT","resourceId":25},{"@type":"com.sequenceiq.cloudbreak.core.flow2.event.DatabaseBackupTriggerEvent","selector":"DATABASE_BACKUP_EVENT","resourceId":25,"backupLocation":"s3a://eng-sdx-daily-v2-datalake/gracezhu-aws-env/logs","backupId":"2bb576cd-5dda-49db-9011-e8cac435cf1d","closeConnections":true,"skipDatabaseNames":[],"databaseMaxDurationInMin":0}]
!flowchainlog:633;[{"@type":"com.sequenceiq.cloudbreak.core.flow2.event.DatabaseBackupTriggerEvent","selector":"DATABASE_BACKUP_EVENT","resourceId":25,"backupLocation":"s3a://eng-sdx-daily-v2-datalake/gracezhu-aws-env/logs","backupId":"2bb576cd-5dda-49db-9011-e8cac435cf1d","closeConnections":true,"skipDatabaseNames":[],"databaseMaxDurationInMin":0}]
!flowchainlog:634;[]
```
the result we get from`  List<FlowChainLog> relatedChains = flowChainLogService.getRelatedFlowChainLogs(flowChains); `is giving us the latest/last flowchainlog and DB backup succeeds:
`!relatedChains:634;[]`