### PR TITLE
CB-21576 SSL setup for flexible server based on the provided parameters

### DIFF
--- a/cloud-azure/src/main/resources/templates/arm-flexible-dbstack.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-flexible-dbstack.ftl
@@ -138,6 +138,20 @@
         "availabilityZone": "[parameters('availabilityZone')]"
       }
     },
+    <#if !useSslEnforcement>
+    {
+      "type": "Microsoft.DBforPostgreSQL/flexibleServers/configurations",
+      "apiVersion": "2022-12-01",
+      "name": "[concat(parameters('dbServerName'), '/require_secure_transport')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', parameters('dbServerName'))]"
+      ],
+      "properties": {
+        "value": "off",
+        "source": "user-override"
+      }
+    },
+    </#if>
     {
       "name": "[concat(parameters('dbServerName'), '/publicaccess')]",
       "type": "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules",


### PR DESCRIPTION
In case if WIRE_ENCRYPTION entitlement is disabled we will turn off ssl for flexible server

See detailed description in the commit message.