### PR TITLE
CB-22006 Validate CCMv2 Server connectivity

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/CheckResult.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/CheckResult.java
@@ -1,0 +1,5 @@
+package com.sequenceiq.freeipa.flow.stack.upgrade.ccm;
+
+public enum CheckResult {
+    FAILED, SUCCESSFUL
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/ConnectivityCheckResponse.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/ConnectivityCheckResponse.java
@@ -1,0 +1,4 @@
+package com.sequenceiq.freeipa.flow.stack.upgrade.ccm;
+
+public record ConnectivityCheckResponse(CheckResult result, String reason) {
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmCheckPrerequisitesHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmCheckPrerequisitesHandler.java
@@ -43,7 +43,7 @@ public class UpgradeCcmCheckPrerequisitesHandler extends AbstractUpgradeCcmEvent
     protected Selectable doAccept(HandlerEvent<UpgradeCcmEvent> event) {
         UpgradeCcmEvent request = event.getData();
         LOGGER.info("Checking prerequisites for CCM upgrade...");
-        upgradeCcmService.checkPrerequsities(request.getResourceId());
+        upgradeCcmService.checkPrerequsities(request.getResourceId(), request.getOldTunnel());
         return UPGRADE_CCM_CHECK_PREREQUISITES_FINISHED_EVENT.createBasedOn(request);
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/proxy/ModifyProxyConfigOrchestratorService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/proxy/ModifyProxyConfigOrchestratorService.java
@@ -18,7 +18,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.Instanc
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.NodeHealthDetails;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
-import com.sequenceiq.freeipa.service.orchestrator.OrchestratorStateParamsProvider;
+import com.sequenceiq.freeipa.service.orchestrator.OrchestratorParamsProvider;
 import com.sequenceiq.freeipa.service.stack.FreeIpaSafeInstanceHealthDetailsService;
 import com.sequenceiq.freeipa.service.stack.StackService;
 
@@ -33,7 +33,7 @@ public class ModifyProxyConfigOrchestratorService {
     private StackService stackService;
 
     @Inject
-    private OrchestratorStateParamsProvider orchestratorStateParamsProvider;
+    private OrchestratorParamsProvider orchestratorParamsProvider;
 
     @Inject
     private HostOrchestrator hostOrchestrator;
@@ -47,7 +47,7 @@ public class ModifyProxyConfigOrchestratorService {
 
         for (InstanceMetaData instance : sortedInstances) {
             String hostName = instance.getDiscoveryFQDN();
-            OrchestratorStateParams stateParams = orchestratorStateParamsProvider.createStateParamsForSingleTarget(stack, hostName, MODIFY_PROXY_STATE);
+            OrchestratorStateParams stateParams = orchestratorParamsProvider.createStateParamsForSingleTarget(stack, hostName, MODIFY_PROXY_STATE);
             LOGGER.debug("Calling applyModifyProxyState for instance {} with state params '{}'", hostName, stateParams);
             hostOrchestrator.runOrchestratorState(stateParams);
             runHealthCheck(stack, instance);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/upgrade/ccm/UpgradeCcmOrchestratorService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/upgrade/ccm/UpgradeCcmOrchestratorService.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.freeipa.service.upgrade.ccm;
 
+import java.util.Map;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -8,8 +10,9 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorRunParams;
 import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateParams;
-import com.sequenceiq.freeipa.service.orchestrator.OrchestratorStateParamsProvider;
+import com.sequenceiq.freeipa.service.orchestrator.OrchestratorParamsProvider;
 
 @Service
 public class UpgradeCcmOrchestratorService {
@@ -24,33 +27,42 @@ public class UpgradeCcmOrchestratorService {
 
     private static final String FINALIZE = "upgradeccm/finalize";
 
+    private static final String CONNECTIVITY_CHECK_COMMAND = "ccmv2-connectivity-check.sh %s";
+
     @Inject
-    private OrchestratorStateParamsProvider orchestratorStateParamsProvider;
+    private OrchestratorParamsProvider orchestratorParamsProvider;
 
     @Inject
     private HostOrchestrator hostOrchestrator;
 
     public void applyUpgradeState(Long stackId) throws CloudbreakOrchestratorException {
-        OrchestratorStateParams stateParams = orchestratorStateParamsProvider.createStateParams(stackId, UPGRADE_CCM_STATE);
+        OrchestratorStateParams stateParams = orchestratorParamsProvider.createStateParams(stackId, UPGRADE_CCM_STATE);
         LOGGER.debug("Calling applyUpgradeState with state params '{}'", stateParams);
         hostOrchestrator.runOrchestratorState(stateParams);
     }
 
     public void reconfigureNginx(Long stackId) throws CloudbreakOrchestratorException {
-        OrchestratorStateParams stateParams = orchestratorStateParamsProvider.createStateParams(stackId, NGINX_STATE);
+        OrchestratorStateParams stateParams = orchestratorParamsProvider.createStateParams(stackId, NGINX_STATE);
         LOGGER.debug("Calling reconfigureNginx with state params '{}'", stateParams);
         hostOrchestrator.runOrchestratorState(stateParams);
     }
 
     public void finalizeConfiguration(Long stackId) throws CloudbreakOrchestratorException {
-        OrchestratorStateParams stateParams = orchestratorStateParamsProvider.createStateParams(stackId, FINALIZE);
+        OrchestratorStateParams stateParams = orchestratorParamsProvider.createStateParams(stackId, FINALIZE);
         LOGGER.debug("Calling finalize with state params '{}'", stateParams);
         hostOrchestrator.runOrchestratorState(stateParams);
     }
 
     public void disableMina(Long stackId) throws CloudbreakOrchestratorException {
-        OrchestratorStateParams stateParams = orchestratorStateParamsProvider.createStateParams(stackId, DISABLE_MINA_STATE);
+        OrchestratorStateParams stateParams = orchestratorParamsProvider.createStateParams(stackId, DISABLE_MINA_STATE);
         LOGGER.debug("Calling disableMina with state params '{}'", stateParams);
         hostOrchestrator.runOrchestratorState(stateParams);
+    }
+
+    public Map<String, String> checkCcmV2Connectivity(Long stackId, String cidr) {
+        OrchestratorRunParams runParams = orchestratorParamsProvider.createRunParams(stackId,
+                String.format(CONNECTIVITY_CHECK_COMMAND, cidr), "Failed to determine CCMv2 Connectivity.");
+        LOGGER.debug("Calling checkCcmV2Connectivity with run params '{}'", runParams);
+        return hostOrchestrator.runShellCommandOnNodes(runParams);
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/chain/UpgradeCcmFlowChainIntegrationTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/chain/UpgradeCcmFlowChainIntegrationTest.java
@@ -221,7 +221,7 @@ class UpgradeCcmFlowChainIntegrationTest {
         int i = 0;
         InOrder inOrder = Mockito.inOrder(upgradeCcmService, userDataService, resourcesApi);
         inOrder.verify(upgradeCcmService, times(expected[i++])).checkPrerequisitesState(STACK_ID);
-        inOrder.verify(upgradeCcmService, times(expected[i++])).checkPrerequsities(STACK_ID);
+        inOrder.verify(upgradeCcmService, times(expected[i++])).checkPrerequsities(STACK_ID, Tunnel.CCM);
         inOrder.verify(upgradeCcmService, times(expected[i++])).changeTunnelState(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).changeTunnel(STACK_ID, Tunnel.latestUpgradeTarget());
         inOrder.verify(upgradeCcmService, times(expected[i++])).obtainAgentDataState(STACK_ID);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmFlowIntegrationTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmFlowIntegrationTest.java
@@ -130,7 +130,7 @@ class UpgradeCcmFlowIntegrationTest {
 
     @Test
     public void testCcmUpgradeWhenPreparationFails() throws CloudbreakOrchestratorException {
-        doThrow(new BadRequestException()).when(upgradeCcmService).checkPrerequsities(1L);
+        doThrow(new BadRequestException()).when(upgradeCcmService).checkPrerequsities(1L, CCM);
         testFlow(CALLED_ONCE_TILL_PREPARATION, false);
     }
 
@@ -234,7 +234,7 @@ class UpgradeCcmFlowIntegrationTest {
         int i = 0;
         InOrder inOrder = Mockito.inOrder(upgradeCcmService);
         inOrder.verify(upgradeCcmService, times(expected[i++])).checkPrerequisitesState(STACK_ID);
-        inOrder.verify(upgradeCcmService, times(expected[i++])).checkPrerequsities(STACK_ID);
+        inOrder.verify(upgradeCcmService, times(expected[i++])).checkPrerequsities(STACK_ID, CCM);
         inOrder.verify(upgradeCcmService, times(expected[i++])).changeTunnelState(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).changeTunnel(STACK_ID, Tunnel.latestUpgradeTarget());
         inOrder.verify(upgradeCcmService, times(expected[i++])).obtainAgentDataState(STACK_ID);
@@ -280,7 +280,7 @@ class UpgradeCcmFlowIntegrationTest {
     private void flowFinishedSuccessfully() {
         ArgumentCaptor<FlowLog> flowLog = ArgumentCaptor.forClass(FlowLog.class);
         verify(flowLogRepository, times(2)).save(flowLog.capture());
-        assertTrue(flowLog.getAllValues().stream().anyMatch(f -> f.getFinalized()), "flow has not finalized");
+        assertTrue(flowLog.getAllValues().stream().anyMatch(FlowLog::getFinalized), "flow has not finalized");
     }
 
     private FlowIdentifier triggerFlow() {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmServiceTest.java
@@ -2,7 +2,14 @@ package com.sequenceiq.freeipa.flow.stack.upgrade.ccm;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,14 +19,21 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.HealthDetailsFreeIpaResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.upgrade.model.FreeIpaUpgradeOptions;
+import com.sequenceiq.freeipa.entity.ImageEntity;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.image.ImageService;
 import com.sequenceiq.freeipa.service.stack.ClusterProxyService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaStackHealthDetailsService;
 import com.sequenceiq.freeipa.service.stack.StackService;
+import com.sequenceiq.freeipa.service.upgrade.UpgradeService;
+import com.sequenceiq.freeipa.service.upgrade.ccm.UpgradeCcmOrchestratorService;
 
 @ExtendWith(MockitoExtension.class)
 class UpgradeCcmServiceTest {
@@ -30,6 +44,8 @@ class UpgradeCcmServiceTest {
 
     private static final String ENV_CRN = "envCrn";
 
+    private static final String CIDR = "someCidr";
+
     @Mock
     private StackService stackService;
 
@@ -39,6 +55,15 @@ class UpgradeCcmServiceTest {
     @Mock
     private FreeIpaStackHealthDetailsService healthService;
 
+    @Mock
+    private ImageService imageService;
+
+    @Mock
+    private UpgradeCcmOrchestratorService upgradeCcmOrchestratorService;
+
+    @Mock
+    private UpgradeService upgradeService;
+
     @InjectMocks
     private UpgradeCcmService underTest;
 
@@ -47,7 +72,7 @@ class UpgradeCcmServiceTest {
         Stack stack = new Stack();
         stack.setAccountId(ACCOUNT_ID);
         stack.setEnvironmentCrn(ENV_CRN);
-        when(stackService.getStackById(STACK_ID)).thenReturn(stack);
+        lenient().when(stackService.getStackById(STACK_ID)).thenReturn(stack);
     }
 
     @ParameterizedTest
@@ -67,6 +92,73 @@ class UpgradeCcmServiceTest {
         healthDetails.setStatus(Status.AVAILABLE);
         when(healthService.getHealthDetails(ENV_CRN, ACCOUNT_ID)).thenReturn(healthDetails);
         underTest.registerClusterProxyAndCheckHealth(STACK_ID);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Tunnel.class, names = "CCM", mode = EXCLUDE)
+    void ccmV2ConnectivityIsNotCheckedButForCcmV1(Tunnel tunnel) {
+        ReflectionTestUtils.setField(underTest, "ccmV2ServersCidr", CIDR);
+        setupFreeIpaUpgradeCheck();
+        underTest.checkPrerequsities(STACK_ID, tunnel);
+        verify(upgradeCcmOrchestratorService, never()).checkCcmV2Connectivity(any(), any());
+    }
+
+    @Test
+    void ccmV2ConnectivityIsNotCheckedForCcmV1IfNoCidr() {
+        setupFreeIpaUpgradeCheck();
+        underTest.checkPrerequsities(STACK_ID, Tunnel.CCM);
+        verify(upgradeCcmOrchestratorService, never()).checkCcmV2Connectivity(any(), any());
+    }
+
+    @Test
+    void ccmV2ConnectivityIsCheckedForCcmV1NullResult() {
+        ReflectionTestUtils.setField(underTest, "ccmV2ServersCidr", CIDR);
+        setupFreeIpaUpgradeCheck();
+        underTest.checkPrerequsities(STACK_ID, Tunnel.CCM);
+        verify(upgradeCcmOrchestratorService).checkCcmV2Connectivity(STACK_ID, CIDR);
+    }
+
+    @Test
+    void ccmV2ConnectivityIsCheckedForCcmV1NoFailure() {
+        ReflectionTestUtils.setField(underTest, "ccmV2ServersCidr", CIDR);
+        setupFreeIpaUpgradeCheck();
+        Map<String, String> resultMap = Map.of(
+                "server1", """
+                        {"result": "%s", "reason": "all ok"}
+                        """.formatted(CheckResult.SUCCESSFUL),
+                "server2", """
+                        {"result": "%s", "reason": "all ok"}
+                        """.formatted(CheckResult.SUCCESSFUL));
+        when(upgradeCcmOrchestratorService.checkCcmV2Connectivity(STACK_ID, CIDR)).thenReturn(resultMap);
+        underTest.checkPrerequsities(STACK_ID, Tunnel.CCM);
+        verify(upgradeCcmOrchestratorService).checkCcmV2Connectivity(STACK_ID, CIDR);
+    }
+
+    @Test
+    void ccmV2ConnectivityIsCheckedForCcmV1WithFailure() {
+        ReflectionTestUtils.setField(underTest, "ccmV2ServersCidr", CIDR);
+        setupFreeIpaUpgradeCheck();
+        Map<String, String> resultMap = Map.of(
+                "server1", """
+                        {"result": "%s", "reason": "all ok"}
+                        """.formatted(CheckResult.SUCCESSFUL),
+                "server2", """
+                        {"result": "%s", "reason": "cmon..."}
+                        """.formatted(CheckResult.FAILED));
+        when(upgradeCcmOrchestratorService.checkCcmV2Connectivity(STACK_ID, CIDR)).thenReturn(resultMap);
+        assertThatThrownBy(() -> underTest.checkPrerequsities(STACK_ID, Tunnel.CCM))
+                .isInstanceOf(CloudbreakServiceException.class)
+                .hasMessageContaining("cmon");
+        verify(upgradeCcmOrchestratorService).checkCcmV2Connectivity(STACK_ID, CIDR);
+    }
+
+    private void setupFreeIpaUpgradeCheck() {
+        ImageEntity imageEntity = new ImageEntity();
+        imageEntity.setImageCatalogName("catalog");
+        when(imageService.getByStackId(STACK_ID)).thenReturn(imageEntity);
+        FreeIpaUpgradeOptions upgradeOptions = new FreeIpaUpgradeOptions();
+        upgradeOptions.setImages(new ArrayList<>());
+        when(upgradeService.collectUpgradeOptions(ACCOUNT_ID, ENV_CRN, "catalog")).thenReturn(upgradeOptions);
     }
 
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmCheckPrerequisitesHandlerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmCheckPrerequisitesHandlerTest.java
@@ -48,7 +48,7 @@ class UpgradeCcmCheckPrerequisitesHandlerTest {
     @Test
     void checkPrerequisitesInAnyCase() {
         underTest.accept(event);
-        verify(upgradeCcmService).checkPrerequsities(STACK_ID);
+        verify(upgradeCcmService).checkPrerequsities(STACK_ID, Tunnel.CCM);
         verify(eventBus).notify(eq(UPGRADE_CCM_CHECK_PREREQUISITES_FINISHED_EVENT.event()), eventCaptor.capture());
         Event<UpgradeCcmEvent> eventResult = eventCaptor.getValue();
         assertThat(eventResult.getData().getOldTunnel()).isEqualTo(Tunnel.CCM);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/orchestrator/OrchestratorParamsProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/orchestrator/OrchestratorParamsProviderTest.java
@@ -23,14 +23,14 @@ import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaNodeUtilService;
 import com.sequenceiq.freeipa.service.stack.StackService;
 
 @ExtendWith(MockitoExtension.class)
-class OrchestratorStateParamsProviderTest {
+class OrchestratorParamsProviderTest {
 
     private static final long STACK_ID = 123L;
 
     private static final String STATE = "state";
 
     @InjectMocks
-    private OrchestratorStateParamsProvider underTest;
+    private OrchestratorParamsProvider underTest;
 
     @Mock
     private StackService stackService;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/proxy/ModifyProxyConfigOrchestratorServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/proxy/ModifyProxyConfigOrchestratorServiceTest.java
@@ -28,7 +28,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.Instanc
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.NodeHealthDetails;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
-import com.sequenceiq.freeipa.service.orchestrator.OrchestratorStateParamsProvider;
+import com.sequenceiq.freeipa.service.orchestrator.OrchestratorParamsProvider;
 import com.sequenceiq.freeipa.service.stack.FreeIpaSafeInstanceHealthDetailsService;
 import com.sequenceiq.freeipa.service.stack.StackService;
 
@@ -47,7 +47,7 @@ class ModifyProxyConfigOrchestratorServiceTest {
     private StackService stackService;
 
     @Mock
-    private OrchestratorStateParamsProvider orchestratorStateParamsProvider;
+    private OrchestratorParamsProvider orchestratorParamsProvider;
 
     @Mock
     private HostOrchestrator hostOrchestrator;
@@ -74,9 +74,9 @@ class ModifyProxyConfigOrchestratorServiceTest {
     void setUp() throws Exception {
         when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
         lenient().when(stack.getNotDeletedInstanceMetaDataList()).thenReturn(List.of(I_2, I_1, I_3));
-        lenient().when(orchestratorStateParamsProvider.createStateParamsForSingleTarget(eq(stack), eq(I_1.getDiscoveryFQDN()), any())).thenReturn(stateParams1);
-        lenient().when(orchestratorStateParamsProvider.createStateParamsForSingleTarget(eq(stack), eq(I_2.getDiscoveryFQDN()), any())).thenReturn(stateParams2);
-        lenient().when(orchestratorStateParamsProvider.createStateParamsForSingleTarget(eq(stack), eq(I_3.getDiscoveryFQDN()), any())).thenReturn(stateParams3);
+        lenient().when(orchestratorParamsProvider.createStateParamsForSingleTarget(eq(stack), eq(I_1.getDiscoveryFQDN()), any())).thenReturn(stateParams1);
+        lenient().when(orchestratorParamsProvider.createStateParamsForSingleTarget(eq(stack), eq(I_2.getDiscoveryFQDN()), any())).thenReturn(stateParams2);
+        lenient().when(orchestratorParamsProvider.createStateParamsForSingleTarget(eq(stack), eq(I_3.getDiscoveryFQDN()), any())).thenReturn(stateParams3);
         NodeHealthDetails nodeHealthDetails = new NodeHealthDetails();
         nodeHealthDetails.setStatus(InstanceStatus.CREATED);
         lenient().when(healthDetailsService.getInstanceHealthDetails(eq(stack), any())).thenReturn(nodeHealthDetails);
@@ -95,16 +95,16 @@ class ModifyProxyConfigOrchestratorServiceTest {
     void applyModifyProxyState() throws Exception {
         underTest.applyModifyProxyState(STACK_ID);
 
-        InOrder inOrder = inOrder(orchestratorStateParamsProvider, hostOrchestrator, healthDetailsService);
-        inOrder.verify(orchestratorStateParamsProvider)
+        InOrder inOrder = inOrder(orchestratorParamsProvider, hostOrchestrator, healthDetailsService);
+        inOrder.verify(orchestratorParamsProvider)
                 .createStateParamsForSingleTarget(stack, I_2.getDiscoveryFQDN(), ModifyProxyConfigOrchestratorService.MODIFY_PROXY_STATE);
         inOrder.verify(hostOrchestrator).runOrchestratorState(stateParams2);
         inOrder.verify(healthDetailsService).getInstanceHealthDetails(stack, I_2);
-        inOrder.verify(orchestratorStateParamsProvider)
+        inOrder.verify(orchestratorParamsProvider)
                 .createStateParamsForSingleTarget(stack, I_3.getDiscoveryFQDN(), ModifyProxyConfigOrchestratorService.MODIFY_PROXY_STATE);
         inOrder.verify(hostOrchestrator).runOrchestratorState(stateParams3);
         inOrder.verify(healthDetailsService).getInstanceHealthDetails(stack, I_3);
-        inOrder.verify(orchestratorStateParamsProvider)
+        inOrder.verify(orchestratorParamsProvider)
                 .createStateParamsForSingleTarget(stack, I_1.getDiscoveryFQDN(), ModifyProxyConfigOrchestratorService.MODIFY_PROXY_STATE);
         inOrder.verify(hostOrchestrator).runOrchestratorState(stateParams1);
         inOrder.verify(healthDetailsService).getInstanceHealthDetails(stack, I_1);
@@ -124,16 +124,16 @@ class ModifyProxyConfigOrchestratorServiceTest {
                                 "Please either fix your proxy configuration settings and try the operation again, or repair the failed instance. Details: %s",
                         I_2.getInstanceId(), issue);
 
-        verify(orchestratorStateParamsProvider)
+        verify(orchestratorParamsProvider)
                 .createStateParamsForSingleTarget(stack, I_2.getDiscoveryFQDN(), ModifyProxyConfigOrchestratorService.MODIFY_PROXY_STATE);
         verify(hostOrchestrator).runOrchestratorState(stateParams2);
         verify(healthDetailsService).getInstanceHealthDetails(stack, I_2);
 
-        verify(orchestratorStateParamsProvider, never())
+        verify(orchestratorParamsProvider, never())
                 .createStateParamsForSingleTarget(stack, I_3.getDiscoveryFQDN(), ModifyProxyConfigOrchestratorService.MODIFY_PROXY_STATE);
         verify(hostOrchestrator, never()).runOrchestratorState(stateParams3);
         verify(healthDetailsService, never()).getInstanceHealthDetails(stack, I_3);
-        verify(orchestratorStateParamsProvider, never())
+        verify(orchestratorParamsProvider, never())
                 .createStateParamsForSingleTarget(stack, I_1.getDiscoveryFQDN(), ModifyProxyConfigOrchestratorService.MODIFY_PROXY_STATE);
         verify(hostOrchestrator, never()).runOrchestratorState(stateParams1);
         verify(healthDetailsService, never()).getInstanceHealthDetails(stack, I_1);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/upgrade/ccm/UpgradeCcmOrchestratorServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/upgrade/ccm/UpgradeCcmOrchestratorServiceTest.java
@@ -1,11 +1,11 @@
 package com.sequenceiq.freeipa.service.upgrade.ccm;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,9 +14,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorRunParams;
 import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateParams;
 import com.sequenceiq.freeipa.entity.Stack;
-import com.sequenceiq.freeipa.service.orchestrator.OrchestratorStateParamsProvider;
+import com.sequenceiq.freeipa.service.orchestrator.OrchestratorParamsProvider;
 
 @ExtendWith(MockitoExtension.class)
 class UpgradeCcmOrchestratorServiceTest {
@@ -24,7 +25,7 @@ class UpgradeCcmOrchestratorServiceTest {
     private static final long STACK_ID = 123L;
 
     @Mock
-    private OrchestratorStateParamsProvider orchestratorStateParamsProvider;
+    private OrchestratorParamsProvider orchestratorParamsProvider;
 
     @Mock
     private HostOrchestrator hostOrchestrator;
@@ -38,37 +39,48 @@ class UpgradeCcmOrchestratorServiceTest {
     @Mock
     private OrchestratorStateParams stateParams;
 
-    @BeforeEach
-    void setUp() {
-        when(orchestratorStateParamsProvider.createStateParams(eq(STACK_ID), any())).thenReturn(stateParams);
-    }
+    @Mock
+    private OrchestratorRunParams runParams;
 
     @Test
     void testApplyUpgradeState() throws CloudbreakOrchestratorException {
+        when(orchestratorParamsProvider.createStateParams(eq(STACK_ID), any())).thenReturn(stateParams);
         underTest.applyUpgradeState(STACK_ID);
         verifyState("upgradeccm");
     }
 
     @Test
     void testReconfigureNginx() throws CloudbreakOrchestratorException {
+        when(orchestratorParamsProvider.createStateParams(eq(STACK_ID), any())).thenReturn(stateParams);
         underTest.reconfigureNginx(STACK_ID);
         verifyState("nginx");
     }
 
     @Test
     void testFinalize() throws CloudbreakOrchestratorException {
+        when(orchestratorParamsProvider.createStateParams(eq(STACK_ID), any())).thenReturn(stateParams);
         underTest.finalizeConfiguration(STACK_ID);
         verifyState("upgradeccm/finalize");
     }
 
     @Test
     void testDisableMina() throws CloudbreakOrchestratorException {
+        when(orchestratorParamsProvider.createStateParams(eq(STACK_ID), any())).thenReturn(stateParams);
         underTest.disableMina(STACK_ID);
         verifyState("upgradeccm/disable-ccmv1");
     }
 
+    @Test
+    void testCcmV2ConnectivityCheck() {
+        when(orchestratorParamsProvider.createRunParams(eq(STACK_ID), eq("ccmv2-connectivity-check.sh someCidr"), anyString()))
+                .thenReturn(runParams);
+        underTest.checkCcmV2Connectivity(STACK_ID, "someCidr");
+        verify(orchestratorParamsProvider).createRunParams(eq(STACK_ID), eq("ccmv2-connectivity-check.sh someCidr"), anyString());
+        verify(hostOrchestrator).runShellCommandOnNodes(runParams);
+    }
+
     private void verifyState(String state) throws CloudbreakOrchestratorException {
-        verify(orchestratorStateParamsProvider).createStateParams(STACK_ID, state);
+        verify(orchestratorParamsProvider).createStateParams(STACK_ID, state);
         verify(hostOrchestrator).runOrchestratorState(stateParams);
     }
 

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -143,7 +143,7 @@ public interface HostOrchestrator extends HostRecipeExecutor {
 
     void runOrchestratorGrainRunner(OrchestratorGrainRunnerParams grainRunnerParams) throws CloudbreakOrchestratorFailedException;
 
-    Map<String, String> getFreeDiskSpaceByNodes(Set<Node> nodes, List<GatewayConfig> gatewayConfigs);
+    Map<String, String> runShellCommandOnNodes(OrchestratorRunParams runParams);
 
     void removeDeadSaltMinions(GatewayConfig gatewayConfig) throws CloudbreakOrchestratorFailedException;
 

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/OrchestratorRunParams.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/OrchestratorRunParams.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.cloudbreak.orchestrator.host;
+
+import java.util.List;
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+
+public record OrchestratorRunParams(
+        Set<Node> nodes,
+        List<GatewayConfig> gatewayConfigs,
+        String command,
+        String errorMessage) {
+}


### PR DESCRIPTION
Added call to a connectivity checker script in case of CCM upgrade from CCMv1 in order to fail fast if no CCMv2 connection is available from the FreeIPA nodes.

Refactored orchestrator shell command runner to be more generic.

See https://github.com/hortonworks/cloudbreak-images/pull/828