### PR TITLE
CB-22077 cloud-azure module should be enhanced to fetch and populate Availability zones for cloud resources

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/VmTypeMeta.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/VmTypeMeta.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.cloud.model;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class VmTypeMeta {
@@ -26,6 +28,8 @@ public class VmTypeMeta {
     private VolumeParameterConfig ephemeralConfig;
 
     private VolumeParameterConfig st1Config;
+
+    private List<String> availabilityZones = new ArrayList<>();
 
     private Map<String, Object> properties = new HashMap<>();
 
@@ -69,6 +73,14 @@ public class VmTypeMeta {
         this.st1Config = st1Config;
     }
 
+    public List<String> getAvailabilityZones() {
+        return availabilityZones;
+    }
+
+    public void setAvailabilityZones(List<String> availabilityZones) {
+        this.availabilityZones = availabilityZones;
+    }
+
     public Map<String, Object> getProperties() {
         return properties;
     }
@@ -100,6 +112,7 @@ public class VmTypeMeta {
                 + ", ssdConfig=" + ssdConfig
                 + ", ephemeralConfig=" + ephemeralConfig
                 + ", st1Config=" + st1Config
+                + ", availabilityZones=" + availabilityZones
                 + ", properties=" + properties
                 + '}';
     }
@@ -115,6 +128,8 @@ public class VmTypeMeta {
         private VolumeParameterConfig ephemeralConfig;
 
         private VolumeParameterConfig st1Config;
+
+        private List<String> availabilityZones;
 
         private final Map<String, Object> properties = new HashMap<>();
 
@@ -175,6 +190,11 @@ public class VmTypeMeta {
             return this;
         }
 
+        public VmTypeMetaBuilder withAvailabilityZones(List<String> azs) {
+            availabilityZones = azs;
+            return this;
+        }
+
         public VmTypeMetaBuilder withProperty(String name, String value) {
             properties.put(name, value);
             return this;
@@ -224,6 +244,7 @@ public class VmTypeMeta {
             vmTypeMeta.setMagneticConfig(magneticConfig);
             vmTypeMeta.setSsdConfig(ssdConfig);
             vmTypeMeta.setSt1Config(st1Config);
+            vmTypeMeta.setAvailabilityZones(availabilityZones);
             vmTypeMeta.setProperties(properties);
             return vmTypeMeta;
         }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureDisk.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureDisk.java
@@ -1,0 +1,130 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import java.util.Map;
+
+import com.google.common.base.Objects;
+
+public class AzureDisk {
+    private String diskName;
+
+    private int diskSize;
+
+    private AzureDiskType diskType;
+
+    private String region;
+
+    private String resourceGroupName;
+
+    private Map<String, String> tags;
+
+    private String diskEncryptionSetId;
+
+    private String availabilityZone;
+
+    public AzureDisk(String diskName, int diskSize, AzureDiskType diskType, String region, String resourceGroupName,
+            Map<String, String> tags, String diskEncryptionSetId, String availabilityZone) {
+        this.diskName = diskName;
+        this.diskSize = diskSize;
+        this.diskType = diskType;
+        this.region = region;
+        this.resourceGroupName = resourceGroupName;
+        this.tags = tags;
+        this.diskEncryptionSetId = diskEncryptionSetId;
+        this.availabilityZone = availabilityZone;
+    }
+
+    public String getDiskName() {
+        return diskName;
+    }
+
+    public void setDiskName(String diskName) {
+        this.diskName = diskName;
+    }
+
+    public int getDiskSize() {
+        return diskSize;
+    }
+
+    public void setDiskSize(int diskSize) {
+        this.diskSize = diskSize;
+    }
+
+    public AzureDiskType getDiskType() {
+        return diskType;
+    }
+
+    public void setDiskType(AzureDiskType diskType) {
+        this.diskType = diskType;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getResourceGroupName() {
+        return resourceGroupName;
+    }
+
+    public void setResourceGroupName(String resourceGroupName) {
+        this.resourceGroupName = resourceGroupName;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags;
+    }
+
+    public String getDiskEncryptionSetId() {
+        return diskEncryptionSetId;
+    }
+
+    public void setDiskEncryptionSetId(String diskEncryptionSetId) {
+        this.diskEncryptionSetId = diskEncryptionSetId;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public void setAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+    }
+
+    @Override
+    public String toString() {
+        return "AzureDisk{" +
+                "diskName='" + diskName + '\'' +
+                ", diskSize='" + diskSize + '\'' +
+                ", diskType=" + diskType +
+                ", region='" + region + '\'' +
+                ", resourceGroupName='" + resourceGroupName + '\'' +
+                ", tags=" + tags +
+                ", diskEncryptionSetId='" + diskEncryptionSetId + '\'' +
+                ", availabilityZone='" + availabilityZone + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AzureDisk azureDisk = (AzureDisk) o;
+        return Objects.equal(diskName, azureDisk.diskName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(diskName);
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResources.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResources.java
@@ -234,6 +234,7 @@ public class AzurePlatformResources implements PlatformResources {
     public CloudVmTypes virtualMachines(ExtendedCloudCredential cloudCredential, Region region, Map<String, String> filters) {
         AzureClient client = azureClientService.getClient(cloudCredential);
         Set<VirtualMachineSize> vmTypes = client.getVmTypes(region.value());
+        Map<String, List<String>> availabilityZones = client.getAvailabilityZones(region.value());
 
         Map<String, Set<VmType>> cloudVmResponses = new HashMap<>();
         Map<String, VmType> defaultCloudVmResponses = new HashMap<>();
@@ -254,6 +255,11 @@ public class AzurePlatformResources implements PlatformResources {
             } else {
                 builder.withResourceDiskAttached(false);
             }
+
+            List<String> azs = availabilityZones.getOrDefault(virtualMachineSize.name(), new ArrayList<>());
+            LOGGER.debug("Availability Zones for VM type {} are {}", virtualMachineSize.name(), azs);
+
+            builder.withAvailabilityZones(azs);
 
             VmType vmType = VmType.vmTypeWithMeta(virtualMachineSize.name(), builder.create(), true);
             types.add(vmType);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +39,7 @@ import com.azure.resourcemanager.authorization.models.RoleAssignments;
 import com.azure.resourcemanager.compute.ComputeManager;
 import com.azure.resourcemanager.compute.fluent.models.DiskEncryptionSetInner;
 import com.azure.resourcemanager.compute.fluent.models.DiskInner;
+import com.azure.resourcemanager.compute.fluent.models.ResourceSkuInner;
 import com.azure.resourcemanager.compute.models.AvailabilitySet;
 import com.azure.resourcemanager.compute.models.CachingTypes;
 import com.azure.resourcemanager.compute.models.Disk;
@@ -48,6 +51,7 @@ import com.azure.resourcemanager.compute.models.Encryption;
 import com.azure.resourcemanager.compute.models.EncryptionSetIdentity;
 import com.azure.resourcemanager.compute.models.KeyForDiskEncryptionSet;
 import com.azure.resourcemanager.compute.models.OperatingSystemStateTypes;
+import com.azure.resourcemanager.compute.models.ResourceSkuLocationInfo;
 import com.azure.resourcemanager.compute.models.SourceVault;
 import com.azure.resourcemanager.compute.models.VirtualMachine;
 import com.azure.resourcemanager.compute.models.VirtualMachineCustomImage;
@@ -102,6 +106,7 @@ import com.azure.storage.common.StorageSharedKeyCredential;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.sequenceiq.cloudbreak.client.ProviderAuthenticationFailedException;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureDisk;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureDiskType;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureLoadBalancerFrontend;
 import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
@@ -269,18 +274,17 @@ public class AzureClient {
                 .findAny();
     }
 
-    public Disk createManagedDisk(
-            String diskName, int diskSize, AzureDiskType diskType, String region, String resourceGroupName, Map<String, String> tags,
-            String diskEncryptionSetId) {
-        LOGGER.debug("create managed disk with name={}", diskName);
-        Disk.DefinitionStages.WithCreate withCreate = azure.disks().define(diskName)
-                .withRegion(RegionUtil.findByLabelOrName(region))
-                .withExistingResourceGroup(resourceGroupName)
+    public Disk createManagedDisk(AzureDisk azureDisk) {
+        LOGGER.debug("create managed disk with name={}", azureDisk.getDiskName());
+        Disk.DefinitionStages.WithCreate withCreate = azure.disks().define(azureDisk.getDiskName())
+                .withRegion(RegionUtil.findByLabelOrName(azureDisk.getRegion()))
+                .withExistingResourceGroup(azureDisk.getResourceGroupName())
                 .withData()
-                .withSizeInGB(diskSize)
-                .withTags(tags)
-                .withSku(convertAzureDiskTypeToDiskSkuTypes(diskType));
-        setupDiskEncryptionWithDesIfNeeded(diskEncryptionSetId, withCreate);
+                .withSizeInGB(azureDisk.getDiskSize())
+                .withTags(azureDisk.getTags())
+                .withSku(convertAzureDiskTypeToDiskSkuTypes(azureDisk.getDiskType()))
+                .withAvailabilityZone(AvailabilityZoneId.fromString(azureDisk.getAvailabilityZone()));
+        setupDiskEncryptionWithDesIfNeeded(azureDisk.getDiskEncryptionSetId(), withCreate);
         return withCreate.create();
     }
 
@@ -974,6 +978,34 @@ public class AzureClient {
             return matcher.group(1);
         }
         return null;
+    }
+
+    public Map<String, List<String>> getAvailabilityZones(String region) throws ProviderAuthenticationFailedException {
+        return handleException(() -> {
+            Map<String, List<String>> zoneInfo = new HashMap<>();
+            if (!StringUtils.isEmpty(region)) {
+                String criteria = "location eq '" + RegionUtil.findByLabelOrName(region).name() + "'";
+                LOGGER.debug("Fetch AZ info from Azure for region {} and criteria {}", region, criteria);
+                AzureListResult<ResourceSkuInner> azureResult = azureListResultFactory.create(azure
+                        .virtualMachines()
+                        .manager()
+                        .serviceClient()
+                        .getResourceSkus()
+                        .list(criteria, null, com.azure.core.util.Context.NONE));
+
+                azureResult.getStream().forEach(sku -> {
+                    List<ResourceSkuLocationInfo> locations = sku.locationInfo();
+                    if (locations != null) {
+                        locations.stream().forEach(loc -> {
+                            zoneInfo.put(sku.name(), loc.zones());
+                        });
+                    }
+                });
+            } else {
+                LOGGER.error("Region is not provided so not fetching the zone information");
+            }
+            return zoneInfo;
+        });
     }
 
     public void updateAdministratorLoginPassword(String resourceGroupName, String serverName, String newPassword) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilder.java
@@ -30,6 +30,7 @@ import com.azure.resourcemanager.compute.models.Disk;
 import com.azure.resourcemanager.compute.models.VirtualMachine;
 import com.azure.resourcemanager.resources.fluentcore.arm.AvailabilityZoneId;
 import com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureDisk;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureDiskType;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureResourceGroupMetadataProvider;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
@@ -117,6 +118,7 @@ public class AzureVolumeResourceBuilder extends AbstractAzureComputeBuilder {
                     .withName(resourceNameService.volumeSet(stackName, groupName, privateId, hashableString))
                     .withGroup(group.getName())
                     .withStatus(CommonStatus.REQUESTED)
+                    .withAvailabilityZone(availabilityZone)
                     .withParameters(Map.of(CloudResource.ATTRIBUTES, new VolumeSetAttributes.Builder()
                             .withAvailabilityZone(availabilityZone)
                             .withDeleteOnTermination(Boolean.TRUE)
@@ -170,8 +172,9 @@ public class AzureVolumeResourceBuilder extends AbstractAzureComputeBuilder {
                         Disk result = client.getDiskByName(resourceGroupName, volume.getId());
                         if (result == null) {
                             result = client.createManagedDisk(
-                                    volume.getId(), volume.getSize(), AzureDiskType.getByValue(
-                                            volume.getType()), region, resourceGroupName, cloudStack.getTags(), diskEncryptionSetId);
+                                    new AzureDisk(volume.getId(), volume.getSize(), AzureDiskType.getByValue(
+                                            volume.getType()), region, resourceGroupName, cloudStack.getTags(), diskEncryptionSetId,
+                                    resource.getAvailabilityZone()));
                         } else {
                             LOGGER.info("Managed disk for resource group: {}, name: {} already exists: {}", resourceGroupName, volume.getId(), result);
                         }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResourcesTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResourcesTest.java
@@ -6,11 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -32,6 +35,7 @@ import com.sequenceiq.cloudbreak.cloud.model.ExtendedCloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStoreMetadata;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.cloud.model.VmType;
 
 @ExtendWith(MockitoExtension.class)
 class AzurePlatformResourcesTest {
@@ -60,6 +64,7 @@ class AzurePlatformResourcesTest {
         virtualMachineSizes.add(createVirtualMachineSize("Standard_DS2_v2", 20000));
         virtualMachineSizes.add(createVirtualMachineSize("Standard_E64ds_v4", 1400000));
         when(azureClient.getVmTypes(region.value())).thenReturn(virtualMachineSizes);
+        when(azureClient.getAvailabilityZones(region.value())).thenReturn(Map.of());
 
         CloudVmTypes actual = underTest.virtualMachines(cloudCredential, region, Map.of());
 
@@ -76,6 +81,17 @@ class AzurePlatformResourcesTest {
                             .anyMatch(cloudVMResponse -> virtualMachineSize.name().equals(cloudVMResponse.value()));
                     assertTrue(virtualMachineSizeCouldBeFoundInResult);
                 });
+        virtualMachineSizes.forEach(virtualMachineSize -> {
+            List<String> availabilityZones = actual.getCloudVmResponses()
+                    .get(region.value())
+                    .stream()
+                    .filter(vmType -> virtualMachineSize.name().equals(vmType.value()))
+                    .findFirst()
+                    .map(vmType -> vmType.getMetaData().getAvailabilityZones())
+                    .orElse(null);
+            assertEquals(availabilityZones, Collections.emptyList());
+
+        });
     }
 
     @Test
@@ -89,6 +105,12 @@ class AzurePlatformResourcesTest {
         virtualMachineSizes.add(createVirtualMachineSize("Standard_E64ds_v4", 1400000));
         virtualMachineSizes.add(e64sVmTypeWithoutResourceDisk);
         when(azureClient.getVmTypes(region.value())).thenReturn(virtualMachineSizes);
+        Map<String, List<String>> zoneInfo = new HashMap<>();
+        zoneInfo.put("Standard_D2s_v4", List.of("1", "2"));
+        zoneInfo.put("Standard_E64s_v4", List.of("2", "3"));
+        zoneInfo.put("Standard_DS2_v2", List.of("1"));
+        zoneInfo.put("Standard_E64ds_v4", List.of("1", "2", "3"));
+        when(azureClient.getAvailabilityZones(region.value())).thenReturn(zoneInfo);
 
         CloudVmTypes actual = underTest.virtualMachines(cloudCredential, region, Map.of());
 
@@ -97,6 +119,18 @@ class AzurePlatformResourcesTest {
         assertFalse(actual.getCloudVmResponses().isEmpty());
         assertNotNull(actual.getCloudVmResponses().get(region.value()));
         assertEquals(virtualMachineSizes.size(), actual.getCloudVmResponses().get(region.value()).size());
+        virtualMachineSizes.forEach(virtualMachineSize -> {
+            VmType matchingVm = actual.getCloudVmResponses()
+                    .get(region.value())
+                    .stream()
+                    .filter(vmType -> virtualMachineSize.name().equals(vmType.value()))
+                    .findFirst()
+                    .orElse(null);
+            if (matchingVm == null) {
+                fail("VM from input is not present in response");
+            }
+            assertEquals(zoneInfo.get(matchingVm.value()), matchingVm.getMetaData().getAvailabilityZones());
+        });
     }
 
     @Test

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientTest.java
@@ -13,10 +13,13 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,15 +33,23 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.core.management.Region;
 import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.resourcemanager.compute.ComputeManager;
+import com.azure.resourcemanager.compute.fluent.ComputeManagementClient;
+import com.azure.resourcemanager.compute.fluent.ResourceSkusClient;
 import com.azure.resourcemanager.compute.fluent.models.DiskInner;
+import com.azure.resourcemanager.compute.fluent.models.ResourceSkuInner;
 import com.azure.resourcemanager.compute.fluent.models.VirtualMachineInner;
 import com.azure.resourcemanager.compute.models.CachingTypes;
 import com.azure.resourcemanager.compute.models.Disk;
 import com.azure.resourcemanager.compute.models.DiskSkuTypes;
 import com.azure.resourcemanager.compute.models.Disks;
 import com.azure.resourcemanager.compute.models.Encryption;
+import com.azure.resourcemanager.compute.models.ResourceSkuLocationInfo;
 import com.azure.resourcemanager.compute.models.VirtualMachine;
+import com.azure.resourcemanager.compute.models.VirtualMachines;
 import com.azure.resourcemanager.keyvault.models.AccessPolicy;
 import com.azure.resourcemanager.keyvault.models.AccessPolicyEntry;
 import com.azure.resourcemanager.keyvault.models.KeyPermissions;
@@ -51,7 +62,10 @@ import com.azure.resourcemanager.postgresql.PostgreSqlManager;
 import com.azure.resourcemanager.postgresql.models.Server;
 import com.azure.resourcemanager.postgresql.models.Server.Update;
 import com.azure.resourcemanager.postgresql.models.Servers;
+import com.azure.resourcemanager.resources.fluentcore.arm.AvailabilityZoneId;
 import com.azure.resourcemanager.resources.fluentcore.model.implementation.IndexableRefreshableWrapperImpl;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureDisk;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureDiskType;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureLoadBalancerFrontend;
 import com.sequenceiq.cloudbreak.cloud.azure.util.AzureExceptionHandler;
 import com.sequenceiq.common.api.type.LoadBalancerType;
@@ -343,5 +357,84 @@ class AzureClientTest {
         verify(server, times(1)).update();
         verify(update, times(1)).withAdministratorLoginPassword(eq(NEW_PASSWORD));
         verify(update, times(1)).apply();
+    }
+
+    static Object[] zoneInfoFromAzure() {
+        Map<String, List<String>> azureZoneInfo = new HashMap<>();
+        azureZoneInfo.put("instanceType1", List.of("1"));
+        azureZoneInfo.put("instanceType2", List.of("1", "2"));
+        azureZoneInfo.put("instanceType3", List.of("1", "2", "3"));
+        return new Object[] {Collections.emptyMap(),
+                Map.of("instanceType1", List.of("1")),
+                azureZoneInfo
+                };
+    }
+
+    @ParameterizedTest
+    @MethodSource("zoneInfoFromAzure")
+    void testGetAvailabilityZones(Map<String, List<String>> azureZoneInfo) {
+        VirtualMachines virtualMachines = mock(VirtualMachines.class);
+        when(azureResourceManager.virtualMachines()).thenReturn(virtualMachines);
+        ComputeManager computeManager = mock(ComputeManager.class);
+        when(virtualMachines.manager()).thenReturn(computeManager);
+        ComputeManagementClient computeManagementClient = mock(ComputeManagementClient.class);
+        when(computeManager.serviceClient()).thenReturn(computeManagementClient);
+        ResourceSkusClient resourceSkusClient = mock(ResourceSkusClient.class);
+        when(computeManagementClient.getResourceSkus()).thenReturn(resourceSkusClient);
+        PagedIterable<ResourceSkuInner> pagedIterable = mock(PagedIterable.class);
+        when(resourceSkusClient.list(any(), any(), any())).thenReturn(pagedIterable);
+        AzureListResult<ResourceSkuInner> azureListResult = mock(AzureListResult.class);
+        when(azureListResultFactory.create(pagedIterable)).thenReturn(azureListResult);
+        List<ResourceSkuInner> list = getResourceSkus(azureZoneInfo);
+        when(azureListResult.getStream()).thenReturn(list.stream());
+        Map<String, List<String>> zoneInfo = underTest.getAvailabilityZones("westus2");
+        Assertions.assertEquals(azureZoneInfo.size(), zoneInfo.size());
+        azureZoneInfo.entrySet().stream().forEach(entry -> {
+            Assertions.assertEquals(true, zoneInfo.containsKey(entry.getKey()));
+            Assertions.assertEquals(entry.getValue(), zoneInfo.get(entry.getKey()));
+        });
+    }
+
+    static Object[] azureZones() {
+        return new Object[]{null, "1", "2", "3"};
+    }
+
+    @ParameterizedTest(name = "testCreateManagedDiskWithAvailabilityZoneForAZ{0}")
+    @MethodSource("azureZones")
+    public void testCreateManagedDiskWithAvailabilityZone(String availabilityZone) {
+        Disk.DefinitionStages.WithCreate withCreate = setUpForDiskCreation();
+        underTest.createManagedDisk(new AzureDisk("volume-1", 100, AzureDiskType.STANDARD_SSD_LRS, "westus2", "my-rg",
+                Map.of(), null, availabilityZone));
+        verify(withCreate, times(1)).withAvailabilityZone(eq(AvailabilityZoneId.fromString(availabilityZone)));
+    }
+
+    private Disk.DefinitionStages.WithCreate setUpForDiskCreation() {
+        Disks disks = mock(Disks.class);
+        when(azureResourceManager.disks()).thenReturn(disks);
+        Disk.DefinitionStages.Blank withBlank = mock(Disk.DefinitionStages.Blank.class);
+        when(disks.define(any())).thenReturn(withBlank);
+        Disk.DefinitionStages.WithGroup withGroup = mock(Disk.DefinitionStages.WithGroup.class);
+        when(withBlank.withRegion(Region.US_WEST2)).thenReturn(withGroup);
+        Disk.DefinitionStages.WithDiskSource withDiskSource = mock(Disk.DefinitionStages.WithDiskSource.class);
+        when(withGroup.withExistingResourceGroup("my-rg")).thenReturn(withDiskSource);
+        Disk.DefinitionStages.WithDataDiskSource withDataDiskSource = mock(Disk.DefinitionStages.WithDataDiskSource.class);
+        when(withDiskSource.withData()).thenReturn(withDataDiskSource);
+        Disk.DefinitionStages.WithCreate withCreate = mock(Disk.DefinitionStages.WithCreate.class);
+        when(withDataDiskSource.withSizeInGB(100)).thenReturn(withCreate);
+        when(withCreate.withTags(any())).thenReturn(withCreate);
+        when(withCreate.withSku(any())).thenReturn(withCreate);
+        when(withCreate.withAvailabilityZone(any())).thenReturn(withCreate);
+        return withCreate;
+    }
+
+    private List<ResourceSkuInner> getResourceSkus(Map<String, List<String>> instanceInformation) {
+        return instanceInformation.entrySet().stream().map(entry -> {
+                ResourceSkuInner resourceSkuInner = mock(ResourceSkuInner.class);
+                ResourceSkuLocationInfo resourceSkuLocationInfo = mock(ResourceSkuLocationInfo.class);
+                when(resourceSkuInner.name()).thenReturn(entry.getKey());
+                when(resourceSkuInner.locationInfo()).thenReturn(List.of(resourceSkuLocationInfo));
+                when(resourceSkuLocationInfo.zones()).thenReturn(entry.getValue());
+                return resourceSkuInner;
+        }).collect(Collectors.toList());
     }
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilderTest.java
@@ -6,10 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -39,6 +36,7 @@ import org.springframework.core.task.AsyncTaskExecutor;
 import com.azure.resourcemanager.compute.models.Disk;
 import com.azure.resourcemanager.compute.models.VirtualMachine;
 import com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureDisk;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureDiskType;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureResourceGroupMetadataProvider;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
@@ -346,7 +344,7 @@ public class AzureVolumeResourceBuilderTest {
     void buildTestWhenNoVolumeSet() throws Exception {
         List<CloudResource> result = underTest.build(context, cloudInstance, PRIVATE_ID, auth, group, List.of(), cloudStack);
 
-        verify(azureClient, never()).createManagedDisk(anyString(), anyInt(), any(AzureDiskType.class), anyString(), anyString(), anyMap(), anyString());
+        verify(azureClient, never()).createManagedDisk(any());
 
         assertThat(result).isNotNull();
         assertThat(result).hasSize(0);
@@ -362,7 +360,7 @@ public class AzureVolumeResourceBuilderTest {
 
         List<CloudResource> result = underTest.build(context, cloudInstance, PRIVATE_ID, auth, group, List.of(volumeSetResource), cloudStack);
 
-        verify(azureClient, never()).createManagedDisk(anyString(), anyInt(), any(AzureDiskType.class), anyString(), anyString(), anyMap(), anyString());
+        verify(azureClient, never()).createManagedDisk(any());
 
         assertThat(result).isNotNull();
         assertThat(result).hasSize(1);
@@ -384,7 +382,7 @@ public class AzureVolumeResourceBuilderTest {
 
         List<CloudResource> result = underTest.build(context, cloudInstance, PRIVATE_ID, auth, group, List.of(volumeSetResource), cloudStack);
 
-        verify(azureClient, never()).createManagedDisk(anyString(), anyInt(), any(AzureDiskType.class), anyString(), anyString(), anyMap(), anyString());
+        verify(azureClient, never()).createManagedDisk(any());
 
         assertThat(result).isNotNull();
         assertThat(result).hasSize(1);
@@ -402,7 +400,8 @@ public class AzureVolumeResourceBuilderTest {
                 .withParameters(Map.of(CloudResource.ATTRIBUTES, new VolumeSetAttributes(AVAILABILITY_ZONE, true, FSTAB, volumes, VOLUME_SIZE, VOLUME_TYPE)))
                 .withName(VOLUME_NAME).build();
 
-        when(azureClient.createManagedDisk(VOLUME_ID, VOLUME_SIZE, AzureDiskType.STANDARD_SSD_LRS, REGION, RESOURCE_GROUP, Map.of(), null)).thenReturn(disk);
+        when(azureClient.createManagedDisk(new AzureDisk(VOLUME_ID, VOLUME_SIZE, AzureDiskType.STANDARD_SSD_LRS, REGION, RESOURCE_GROUP,
+                Map.of(), null, null))).thenReturn(disk);
 
         List<CloudResource> result = underTest.build(context, cloudInstance, PRIVATE_ID, auth, group, List.of(volumeSetResource), cloudStack);
 
@@ -424,7 +423,8 @@ public class AzureVolumeResourceBuilderTest {
 
         when(instanceTemplate.getStringParameter(AzureInstanceTemplate.DISK_ENCRYPTION_SET_ID)).thenReturn(DISK_ENCRYPTION_SET_ID);
 
-        when(azureClient.createManagedDisk(VOLUME_ID, VOLUME_SIZE, AzureDiskType.STANDARD_SSD_LRS, REGION, RESOURCE_GROUP, Map.of(), null)).thenReturn(disk);
+        when(azureClient.createManagedDisk(new AzureDisk(VOLUME_ID, VOLUME_SIZE, AzureDiskType.STANDARD_SSD_LRS, REGION, RESOURCE_GROUP,
+                        Map.of(), null, null))).thenReturn(disk);
 
         List<CloudResource> result = underTest.build(context, cloudInstance, PRIVATE_ID, auth, group, List.of(volumeSetResource), cloudStack);
 
@@ -447,8 +447,8 @@ public class AzureVolumeResourceBuilderTest {
         when(instanceTemplate.getParameter(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, Object.class)).thenReturn(true);
         when(instanceTemplate.getStringParameter(AzureInstanceTemplate.DISK_ENCRYPTION_SET_ID)).thenReturn(DISK_ENCRYPTION_SET_ID);
 
-        when(azureClient.createManagedDisk(VOLUME_ID, VOLUME_SIZE, AzureDiskType.STANDARD_SSD_LRS, REGION, RESOURCE_GROUP, Map.of(), DISK_ENCRYPTION_SET_ID))
-                .thenReturn(disk);
+        when(azureClient.createManagedDisk(new AzureDisk(VOLUME_ID, VOLUME_SIZE, AzureDiskType.STANDARD_SSD_LRS, REGION, RESOURCE_GROUP, Map.of(),
+                DISK_ENCRYPTION_SET_ID, null))).thenReturn(disk);
 
         List<CloudResource> result = underTest.build(context, cloudInstance, PRIVATE_ID, auth, group, List.of(volumeSetResource), cloudStack);
 


### PR DESCRIPTION
cloud-azure module should be enhanced to fetch and populate Availability zones for cloud resources

Added AzureDisk DTO to populate information needed for creating the disk. It is needed because 7 attributes for disk were being passed as argument to the method. AZ cannot be added as another argument since maximum number of allowed arguments are  7. 

Equals and hashCode has been overridden to only use diskName since diskName is unique and disk should be treated equal if diskname is same. Also, Overriding equals and hashCode is only needed for unit tests to pass since unit tests are using as part of verification.


See detailed description in the commit message.