### PR TITLE
CB-21512 save rotation step progress

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/rotation/secret/AbstractRotationExecutor.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/rotation/secret/AbstractRotationExecutor.java
@@ -1,0 +1,82 @@
+package com.sequenceiq.cloudbreak.rotation.secret;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.util.CheckedConsumer;
+
+public abstract class AbstractRotationExecutor<C extends RotationContext> implements RotationExecutor<C> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractRotationExecutor.class);
+
+    @Inject
+    private Optional<SecretRotationProgressService> secretRotationProgressService;
+
+    public final void executeRotate(RotationContext context, SecretType secretType) {
+        invokeRotationPhaseWithProgressCheck(context, secretType, RotationFlowExecutionType.ROTATE, this::rotate,
+                () -> String.format("Execution of rotation failed at %s step for %s regarding secret %s.", getType(), context.getResourceCrn(), secretType));
+    }
+
+    public final void executeRollback(RotationContext context, SecretType secretType) {
+        invokeRotationPhaseWithProgressCheck(context, secretType, RotationFlowExecutionType.ROLLBACK, this::rollback,
+                () -> String.format("Rollback of rotation failed at %s step for %s regarding secret %s.", getType(), context.getResourceCrn(), secretType));
+    }
+
+    public final void executeFinalize(RotationContext context, SecretType secretType) {
+        invokeRotationPhaseWithProgressCheck(context, secretType, RotationFlowExecutionType.FINALIZE, this::finalize,
+                () -> String.format("Finalization of rotation failed at %s step for %s regarding secret %s.", getType(), context.getResourceCrn(), secretType));
+    }
+
+    public final void executePreValidation(RotationContext context) {
+        invokeRotationPhase(context, this::preValidate,
+                () -> String.format("Pre validation of rotation failed at %s step for %s", getType(), context.getResourceCrn()));
+    }
+
+    public final void executePostValidation(RotationContext context) {
+        invokeRotationPhase(context, this::postValidate,
+                () -> String.format("Post validation of rotation failed at %s step for %s", getType(), context.getResourceCrn()));
+    }
+
+    private void logAndThrow(Exception e, String errorMessage) {
+        LOGGER.error(errorMessage, e);
+        throw new SecretRotationException(errorMessage, e, getType());
+    }
+
+    private void invokeRotationPhaseWithProgressCheck(RotationContext context, SecretType secretType, RotationFlowExecutionType executionType,
+            CheckedConsumer<C, Exception> rotationPhaseLogic, Supplier<String> errorMessageSupplier) {
+        secretRotationProgressService.ifPresentOrElse(progressService -> {
+            Optional latestStepProgress = progressService.latestStep(context.getResourceCrn(), secretType, getType(), executionType);
+            if (latestStepProgress.isEmpty() || !progressService.isFinished(latestStepProgress.get())) {
+                try {
+                    rotationPhaseLogic.accept(castContext(context));
+                    latestStepProgress.ifPresent(progressService::finished);
+                } catch (Exception e) {
+                    latestStepProgress.ifPresent(progressService::finished);
+                    logAndThrow(e, errorMessageSupplier.get());
+                }
+            } else {
+                LOGGER.info("{} is already finished for {} step regarding {} secret, thus skipping it.", executionType, getType(), secretType);
+            }
+        }, () -> invokeRotationPhase(context, rotationPhaseLogic, errorMessageSupplier));
+    }
+
+    private void invokeRotationPhase(RotationContext context, CheckedConsumer<C, Exception> rotationPhaseLogic, Supplier<String> errorMessageSupplier) {
+        try {
+            rotationPhaseLogic.accept(castContext(context));
+        } catch (Exception e) {
+            logAndThrow(e, errorMessageSupplier.get());
+        }
+    }
+
+    private C castContext(RotationContext context) {
+        if (getContextClass().isAssignableFrom(context.getClass())) {
+            return (C) context;
+        }
+        throw new SecretRotationException(String.format("Type of provided context for rotation step %s is not correct.", getType()), getType());
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/rotation/secret/CustomJobExecutor.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/rotation/secret/CustomJobExecutor.java
@@ -7,7 +7,7 @@ import com.sequenceiq.cloudbreak.rotation.secret.step.CommonSecretRotationStep;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 
 @Component
-public class CustomJobExecutor implements RotationExecutor<CustomJobRotationContext> {
+public class CustomJobExecutor extends AbstractRotationExecutor<CustomJobRotationContext> {
 
     @Override
     public void rotate(CustomJobRotationContext rotationContext) throws Exception {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/rotation/secret/RotationExecutor.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/rotation/secret/RotationExecutor.java
@@ -1,13 +1,8 @@
 package com.sequenceiq.cloudbreak.rotation.secret;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 
 public interface RotationExecutor<C extends RotationContext> {
-
-    Logger LOGGER = LoggerFactory.getLogger(RotationExecutor.class);
 
     void rotate(C rotationContext) throws Exception;
 
@@ -22,61 +17,4 @@ public interface RotationExecutor<C extends RotationContext> {
     SecretRotationStep getType();
 
     Class<C> getContextClass();
-
-    default C castContext(RotationContext context) {
-        if (getContextClass().isAssignableFrom(context.getClass())) {
-            return (C) context;
-        }
-        throw new SecretRotationException(String.format("Type of provided context for rotation step %s is not correct.", getType()), getType());
-    }
-
-    default void executeRotate(RotationContext context) {
-        try {
-            rotate(castContext(context));
-        } catch (Exception e) {
-            String errorMessage = String.format("Rotation failed at %s step for %s", getType(), context.getResourceCrn());
-            logAndThrow(e, errorMessage);
-        }
-    }
-
-    default void executeRollback(RotationContext context) {
-        try {
-            rollback(castContext(context));
-        } catch (Exception e) {
-            String errorMessage = String.format("Rollback of rotation failed at %s step for %s", getType(), context.getResourceCrn());
-            logAndThrow(e, errorMessage);
-        }
-    }
-
-    default void executeFinalize(RotationContext context) {
-        try {
-            finalize(castContext(context));
-        } catch (Exception e) {
-            String errorMessage = String.format("Finalize rotation failed at %s step for %s", getType(), context.getResourceCrn());
-            logAndThrow(e, errorMessage);
-        }
-    }
-
-    default void executePreValidation(RotationContext context) {
-        try {
-            preValidate(castContext(context));
-        } catch (Exception e) {
-            String errorMessage = String.format("Pre validation of rotation failed at %s step for %s", getType(), context.getResourceCrn());
-            logAndThrow(e, errorMessage);
-        }
-    }
-
-    default void executePostValidation(RotationContext context) {
-        try {
-            postValidate(castContext(context));
-        } catch (Exception e) {
-            String errorMessage = String.format("Post validation of rotation failed at %s step for %s", getType(), context.getResourceCrn());
-            logAndThrow(e, errorMessage);
-        }
-    }
-
-    private void logAndThrow(Exception e, String errorMessage) {
-        LOGGER.error(errorMessage, e);
-        throw new SecretRotationException(errorMessage, e, getType());
-    }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/rotation/secret/SecretRotationProgressService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/rotation/secret/SecretRotationProgressService.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.cloudbreak.rotation.secret;
+
+import java.util.Optional;
+
+import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
+
+public interface SecretRotationProgressService<E> {
+
+    boolean isFinished(E entity);
+
+    void finished(E entity);
+
+    Optional<E> latestStep(String resourceCrn, SecretType secretType, SecretRotationStep step, RotationFlowExecutionType executionType);
+
+    void deleteAll(String resourceCrn, SecretType secretType);
+
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/CheckedConsumer.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/CheckedConsumer.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.cloudbreak.util;
+
+@FunctionalInterface
+public interface CheckedConsumer<T, E extends Throwable> {
+
+    void accept(T t) throws E;
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/rotation/secret/AbstractRotationExecutorTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/rotation/secret/AbstractRotationExecutorTest.java
@@ -1,0 +1,195 @@
+package com.sequenceiq.cloudbreak.rotation.secret;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
+
+@ExtendWith(MockitoExtension.class)
+public class AbstractRotationExecutorTest {
+
+    @Mock
+    private SecretRotationProgressService secretRotationProgressService;
+
+    @InjectMocks
+    private TestExecutor underTest;
+
+    @BeforeEach
+    public void mockProgressService() throws IllegalAccessException {
+        FieldUtils.writeField(underTest, "secretRotationProgressService", Optional.of(secretRotationProgressService), true);
+    }
+
+    @Test
+    public void testRotateWhenNoProgress() {
+        when(secretRotationProgressService.latestStep(any(), any(), any(), any())).thenReturn(Optional.empty());
+
+        underTest.executeRotate(new RotationContext(""), TestSecretType.TEST);
+
+        verify(secretRotationProgressService, times(1)).latestStep(any(), any(), any(), any());
+        verify(secretRotationProgressService, times(0)).isFinished(any());
+        verify(secretRotationProgressService, times(0)).finished(any());
+    }
+
+    @Test
+    public void testRotateWhenStepOngoing() {
+        when(secretRotationProgressService.latestStep(any(), any(), any(), any())).thenReturn(Optional.of("anything"));
+        when(secretRotationProgressService.isFinished(any())).thenReturn(Boolean.FALSE);
+        doNothing().when(secretRotationProgressService).finished(any());
+
+        underTest.executeRotate(new RotationContext(""), TestSecretType.TEST);
+
+        verify(secretRotationProgressService, times(1)).latestStep(any(), any(), any(), any());
+        verify(secretRotationProgressService, times(1)).isFinished(any());
+        verify(secretRotationProgressService, times(1)).finished(any());
+    }
+
+    @Test
+    public void testRotateFailureWhenStepOngoing() {
+        when(secretRotationProgressService.latestStep(any(), any(), any(), any())).thenReturn(Optional.of("anything"));
+        when(secretRotationProgressService.isFinished(any())).thenReturn(Boolean.FALSE);
+        doNothing().when(secretRotationProgressService).finished(any());
+
+        assertThrows(SecretRotationException.class, () -> underTest.executeRotate(new RotationContext(null), TestSecretType.TEST));
+
+        verify(secretRotationProgressService, times(1)).latestStep(any(), any(), any(), any());
+        verify(secretRotationProgressService, times(1)).isFinished(any());
+        verify(secretRotationProgressService, times(1)).finished(any());
+    }
+
+    @Test
+    public void testRotateWhenStepAlreadyFinished() {
+        when(secretRotationProgressService.latestStep(any(), any(), any(), any())).thenReturn(Optional.of("anything"));
+        when(secretRotationProgressService.isFinished(any())).thenReturn(Boolean.TRUE);
+
+        underTest.executeRotate(new RotationContext(""), TestSecretType.TEST);
+
+        verify(secretRotationProgressService, times(1)).latestStep(any(), any(), any(), any());
+        verify(secretRotationProgressService, times(1)).isFinished(any());
+        verify(secretRotationProgressService, times(0)).finished(any());
+    }
+
+    @Test
+    public void testPreValidation() {
+        underTest.executePreValidation(new RotationContext(""));
+
+        verifyNoInteractions(secretRotationProgressService);
+    }
+
+    @Test
+    public void testPreValidationFailure() {
+        assertThrows(SecretRotationException.class, () -> underTest.executePreValidation(new RotationContext(null)));
+
+        verifyNoInteractions(secretRotationProgressService);
+    }
+
+    @Test
+    public void testPostValidation() {
+        underTest.executePostValidation(new RotationContext(""));
+
+        verifyNoInteractions(secretRotationProgressService);
+    }
+
+    @Test
+    public void testPostValidationFailure() {
+        assertThrows(SecretRotationException.class, () -> underTest.executePostValidation(new RotationContext(null)));
+
+        verifyNoInteractions(secretRotationProgressService);
+    }
+
+    @Test
+    public void testRollback() throws IllegalAccessException {
+        FieldUtils.writeField(underTest, "secretRotationProgressService", Optional.empty(), true);
+
+        underTest.executeRollback(new RotationContext(""), TestSecretType.TEST);
+
+        verifyNoInteractions(secretRotationProgressService);
+    }
+
+    @Test
+    public void testRollbackFailure() throws IllegalAccessException {
+        FieldUtils.writeField(underTest, "secretRotationProgressService", Optional.empty(), true);
+
+        assertThrows(SecretRotationException.class, () -> underTest.executeRollback(new RotationContext(null), TestSecretType.TEST));
+
+        verifyNoInteractions(secretRotationProgressService);
+    }
+
+    @Test
+    public void testFinalize() throws IllegalAccessException {
+        FieldUtils.writeField(underTest, "secretRotationProgressService", Optional.empty(), true);
+
+        underTest.executeFinalize(new RotationContext(""), TestSecretType.TEST);
+
+        verifyNoInteractions(secretRotationProgressService);
+    }
+
+    @Test
+    public void testFinalizeFailure() throws IllegalAccessException {
+        FieldUtils.writeField(underTest, "secretRotationProgressService", Optional.empty(), true);
+
+        assertThrows(SecretRotationException.class, () -> underTest.executeFinalize(new RotationContext(null), TestSecretType.TEST));
+
+        verifyNoInteractions(secretRotationProgressService);
+    }
+
+    private static class TestExecutor extends AbstractRotationExecutor<RotationContext> {
+
+        @Override
+        public void rotate(RotationContext rotationContext) throws Exception {
+            simulateFailure(rotationContext);
+        }
+
+        @Override
+        public void rollback(RotationContext rotationContext) throws Exception {
+            simulateFailure(rotationContext);
+        }
+
+        @Override
+        public void finalize(RotationContext rotationContext) throws Exception {
+            simulateFailure(rotationContext);
+        }
+
+        @Override
+        public void preValidate(RotationContext rotationContext) throws Exception {
+            simulateFailure(rotationContext);
+        }
+
+        @Override
+        public void postValidate(RotationContext rotationContext) throws Exception {
+            simulateFailure(rotationContext);
+        }
+
+        private void simulateFailure(RotationContext rotationContext) {
+            if (rotationContext.getResourceCrn() == null) {
+                throw new CloudbreakServiceException("oops");
+            }
+        }
+
+        @Override
+        public SecretRotationStep getType() {
+            return TestSecretRotationStep.STEP;
+        }
+
+        @Override
+        public Class<RotationContext> getContextClass() {
+            return RotationContext.class;
+        }
+    }
+
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/rotation/secret/TestRotationContext.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/rotation/secret/TestRotationContext.java
@@ -1,6 +1,4 @@
-package com.sequenceiq.flow.rotation;
-
-import com.sequenceiq.cloudbreak.rotation.secret.RotationContext;
+package com.sequenceiq.cloudbreak.rotation.secret;
 
 public class TestRotationContext extends RotationContext {
 

--- a/common/src/test/java/com/sequenceiq/cloudbreak/rotation/secret/TestSecretRotationStep.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/rotation/secret/TestSecretRotationStep.java
@@ -1,7 +1,8 @@
-package com.sequenceiq.flow.rotation;
+package com.sequenceiq.cloudbreak.rotation.secret;
 
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 
 public enum TestSecretRotationStep implements SecretRotationStep {
-    TEST_STEP
+    STEP
+
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/rotation/secret/TestSecretType.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/rotation/secret/TestSecretType.java
@@ -1,16 +1,17 @@
-package com.sequenceiq.flow.rotation;
+package com.sequenceiq.cloudbreak.rotation.secret;
+
+import static com.sequenceiq.cloudbreak.rotation.secret.TestSecretRotationStep.STEP;
 
 import java.util.List;
 
-import com.sequenceiq.cloudbreak.rotation.secret.SecretType;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 
 public enum TestSecretType implements SecretType {
     TEST,
-    TEST2;
+    TEST_2;
 
     @Override
     public List<SecretRotationStep> getSteps() {
-        return List.of(TestSecretRotationStep.TEST_STEP);
+        return List.of(STEP);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/rotation/context/provider/CMDBPasswordRotationContextProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/rotation/context/provider/CMDBPasswordRotationContextProvider.java
@@ -109,6 +109,7 @@ public class CMDBPasswordRotationContextProvider implements RotationContextProvi
                 .build();
 
         CustomJobRotationContext customJobRotationContext = CustomJobRotationContext.builder()
+                .withResourceCrn(stack.getResourceCrn())
                 .withRotationJob(() -> waitForClouderaManagerToStartup(stack))
                 .withRollbackJob(() -> waitForClouderaManagerToStartup(stack))
                 .build();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/CMServiceConfigRotationExecutor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/CMServiceConfigRotationExecutor.java
@@ -10,14 +10,14 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.rotation.context.CMServiceConfigRotationContext;
-import com.sequenceiq.cloudbreak.rotation.secret.RotationExecutor;
+import com.sequenceiq.cloudbreak.rotation.secret.AbstractRotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 
 @Component
-public class CMServiceConfigRotationExecutor implements RotationExecutor<CMServiceConfigRotationContext> {
+public class CMServiceConfigRotationExecutor extends AbstractRotationExecutor<CMServiceConfigRotationContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CMServiceConfigRotationExecutor.class);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/CMUserRotationExecutor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/CMUserRotationExecutor.java
@@ -10,8 +10,8 @@ import com.sequenceiq.cloudbreak.cluster.api.ClusterSecurityService;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.rotation.CloudbreakSecretRotationStep;
 import com.sequenceiq.cloudbreak.rotation.context.CMUserRotationContext;
+import com.sequenceiq.cloudbreak.rotation.secret.AbstractRotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.RotationContext;
-import com.sequenceiq.cloudbreak.rotation.secret.RotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationException;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
@@ -21,7 +21,7 @@ import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 
 @Component
-public class CMUserRotationExecutor implements RotationExecutor<CMUserRotationContext> {
+public class CMUserRotationExecutor extends AbstractRotationExecutor<CMUserRotationContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CMUserRotationExecutor.class);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/ClusterProxyRotationExecutor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/ClusterProxyRotationExecutor.java
@@ -10,12 +10,12 @@ import com.sequenceiq.cloudbreak.core.flow2.cluster.provision.service.ClusterPro
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.rotation.CloudbreakSecretRotationStep;
 import com.sequenceiq.cloudbreak.rotation.context.ClusterProxyRotationContext;
-import com.sequenceiq.cloudbreak.rotation.secret.RotationExecutor;
+import com.sequenceiq.cloudbreak.rotation.secret.AbstractRotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 
 @Component
-public class ClusterProxyRotationExecutor implements RotationExecutor<ClusterProxyRotationContext> {
+public class ClusterProxyRotationExecutor extends AbstractRotationExecutor<ClusterProxyRotationContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClusterProxyRotationExecutor.class);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/RedbeamsPollerRotationExecutor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/RedbeamsPollerRotationExecutor.java
@@ -13,14 +13,14 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.ExternalDatabaseService;
 import com.sequenceiq.cloudbreak.dto.StackDto;
-import com.sequenceiq.cloudbreak.rotation.secret.RotationExecutor;
+import com.sequenceiq.cloudbreak.rotation.secret.AbstractRotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.context.PollerRotationContext;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.redbeams.rotation.RedbeamsSecretType;
 
 @Component
-public class RedbeamsPollerRotationExecutor implements RotationExecutor<PollerRotationContext> {
+public class RedbeamsPollerRotationExecutor extends AbstractRotationExecutor<PollerRotationContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RedbeamsPollerRotationExecutor.class);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/SaltPillarRotationExecutor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/SaltPillarRotationExecutor.java
@@ -17,13 +17,13 @@ import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
 import com.sequenceiq.cloudbreak.rotation.CloudbreakSecretRotationStep;
 import com.sequenceiq.cloudbreak.rotation.ExitCriteriaProvider;
 import com.sequenceiq.cloudbreak.rotation.context.SaltPillarRotationContext;
-import com.sequenceiq.cloudbreak.rotation.secret.RotationExecutor;
+import com.sequenceiq.cloudbreak.rotation.secret.AbstractRotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 import com.sequenceiq.cloudbreak.service.salt.SaltStateParamsService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 
 @Component
-public class SaltPillarRotationExecutor implements RotationExecutor<SaltPillarRotationContext> {
+public class SaltPillarRotationExecutor extends AbstractRotationExecutor<SaltPillarRotationContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SaltPillarRotationExecutor.class);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/SaltRunOrchestratorStateRotationExecutor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/SaltRunOrchestratorStateRotationExecutor.java
@@ -12,11 +12,11 @@ import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateParams;
 import com.sequenceiq.cloudbreak.rotation.CloudbreakSecretRotationStep;
 import com.sequenceiq.cloudbreak.rotation.context.SaltRunOrchestratorStateRotationContext;
-import com.sequenceiq.cloudbreak.rotation.secret.RotationExecutor;
+import com.sequenceiq.cloudbreak.rotation.secret.AbstractRotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 
 @Component
-public class SaltRunOrchestratorStateRotationExecutor implements RotationExecutor<SaltRunOrchestratorStateRotationContext> {
+public class SaltRunOrchestratorStateRotationExecutor extends AbstractRotationExecutor<SaltRunOrchestratorStateRotationContext> {
 
     @Inject
     private HostOrchestrator hostOrchestrator;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/SaltStateApplyRotationExecutor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/SaltStateApplyRotationExecutor.java
@@ -15,11 +15,11 @@ import com.google.common.base.Joiner;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.rotation.context.SaltStateApplyRotationContext;
-import com.sequenceiq.cloudbreak.rotation.secret.RotationExecutor;
+import com.sequenceiq.cloudbreak.rotation.secret.AbstractRotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 
 @Component
-public class SaltStateApplyRotationExecutor implements RotationExecutor<SaltStateApplyRotationContext> {
+public class SaltStateApplyRotationExecutor extends AbstractRotationExecutor<SaltStateApplyRotationContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SaltStateApplyRotationExecutor.class);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/UserDataRotationExecutor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/UserDataRotationExecutor.java
@@ -30,7 +30,7 @@ import com.sequenceiq.cloudbreak.cloud.rotation.UserDataRotationContext;
 import com.sequenceiq.cloudbreak.converter.spi.ResourceToCloudResourceConverter;
 import com.sequenceiq.cloudbreak.converter.spi.StackToCloudStackConverter;
 import com.sequenceiq.cloudbreak.dto.StackDto;
-import com.sequenceiq.cloudbreak.rotation.secret.RotationExecutor;
+import com.sequenceiq.cloudbreak.rotation.secret.AbstractRotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationException;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 import com.sequenceiq.cloudbreak.rotation.secret.userdata.UserDataSecretModifier;
@@ -46,7 +46,7 @@ import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
 
 @Component
-public class UserDataRotationExecutor implements RotationExecutor<UserDataRotationContext> {
+public class UserDataRotationExecutor extends AbstractRotationExecutor<UserDataRotationContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UserDataRotationExecutor.class);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/JpaTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/JpaTest.java
@@ -29,6 +29,7 @@ import org.springframework.data.repository.support.Repositories;
         "com.sequenceiq.cloudbreak.workspace.repository",
         "com.sequenceiq.cloudbreak.workspace.model",
         "com.sequenceiq.flow.domain",
+        "com.sequenceiq.flow.rotation",
         "com.sequenceiq.cloudbreak.ha.domain",
         "com.sequenceiq.cloudbreak.structuredevent.repository",
         "com.sequenceiq.cloudbreak.structuredevent.domain"

--- a/core/src/test/java/com/sequenceiq/cloudbreak/rotation/executor/CMServiceConfigRotationExecutorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/rotation/executor/CMServiceConfigRotationExecutorTest.java
@@ -2,10 +2,15 @@ package com.sequenceiq.cloudbreak.rotation.executor;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -17,6 +22,7 @@ import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterModificationService;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.rotation.context.CMServiceConfigRotationContext;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationProgressService;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
@@ -33,8 +39,17 @@ public class CMServiceConfigRotationExecutorTest {
     @Mock
     private StackDtoService stackService;
 
+    @Mock
+    private SecretRotationProgressService secretRotationProgressService;
+
     @InjectMocks
     private CMServiceConfigRotationExecutor underTest;
+
+    @BeforeEach
+    public void mockProgressService() throws IllegalAccessException {
+        FieldUtils.writeField(underTest, "secretRotationProgressService", Optional.of(secretRotationProgressService), true);
+        lenient().when(secretRotationProgressService.latestStep(any(), any(), any(), any())).thenReturn(Optional.empty());
+    }
 
     @Test
     public void testRotation() throws Exception {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/rotation/saltboot/UserDataRotationExecutorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/rotation/saltboot/UserDataRotationExecutorTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +42,7 @@ import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.rotation.executor.UserDataRotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationException;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationProgressService;
 import com.sequenceiq.cloudbreak.rotation.secret.step.CommonSecretRotationStep;
 import com.sequenceiq.cloudbreak.rotation.secret.userdata.UserDataSecretModifier;
 import com.sequenceiq.cloudbreak.service.image.userdata.UserDataService;
@@ -127,9 +129,14 @@ class UserDataRotationExecutorTest {
     @Mock
     private CloudStack cloudStack;
 
+    @Mock
+    private SecretRotationProgressService secretRotationProgressService;
+
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws IllegalAccessException {
         lenient().when(cloudStackConverter.convert(any())).thenReturn(cloudStack);
+        FieldUtils.writeField(underTest, "secretRotationProgressService", Optional.of(secretRotationProgressService), true);
+        lenient().when(secretRotationProgressService.latestStep(any(), any(), any(), any())).thenReturn(Optional.empty());
     }
 
     @Test

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/rotation/CloudbreakPollerRotationExecutor.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/rotation/CloudbreakPollerRotationExecutor.java
@@ -12,12 +12,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.rotation.CloudbreakSecretType;
-import com.sequenceiq.cloudbreak.rotation.secret.RotationExecutor;
+import com.sequenceiq.cloudbreak.rotation.secret.AbstractRotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.context.PollerRotationContext;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 
 @Component
-public class CloudbreakPollerRotationExecutor implements RotationExecutor<PollerRotationContext> {
+public class CloudbreakPollerRotationExecutor extends AbstractRotationExecutor<PollerRotationContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CloudbreakPollerRotationExecutor.class);
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/rotation/RedbeamsPollerRotationExecutor.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/rotation/RedbeamsPollerRotationExecutor.java
@@ -11,13 +11,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.rotation.secret.RotationExecutor;
+import com.sequenceiq.cloudbreak.rotation.secret.AbstractRotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.context.PollerRotationContext;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 import com.sequenceiq.redbeams.rotation.RedbeamsSecretType;
 
 @Component
-public class RedbeamsPollerRotationExecutor implements RotationExecutor<PollerRotationContext> {
+public class RedbeamsPollerRotationExecutor extends AbstractRotationExecutor<PollerRotationContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RedbeamsPollerRotationExecutor.class);
 

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/rotation/CloudbreakPollerRotationExecutorTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/rotation/CloudbreakPollerRotationExecutorTest.java
@@ -5,13 +5,19 @@ import static com.sequenceiq.cloudbreak.rotation.secret.RotationFlowExecutionTyp
 import static com.sequenceiq.cloudbreak.rotation.secret.RotationFlowExecutionType.ROLLBACK;
 import static com.sequenceiq.cloudbreak.rotation.secret.RotationFlowExecutionType.ROTATE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.util.Optional;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -19,6 +25,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationException;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationProgressService;
 import com.sequenceiq.cloudbreak.rotation.secret.context.PollerRotationContext;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,21 +36,31 @@ class CloudbreakPollerRotationExecutorTest {
     @Mock
     private SdxRotationService sdxRotationService;
 
+    @Mock
+    private SecretRotationProgressService secretRotationProgressService;
+
     @InjectMocks
     private CloudbreakPollerRotationExecutor underTest;
+
+    @BeforeEach
+    public void mockProgressService() throws IllegalAccessException {
+        FieldUtils.writeField(underTest, "secretRotationProgressService", Optional.of(secretRotationProgressService), true);
+        lenient().when(secretRotationProgressService.latestStep(any(), any(), any(), any())).thenReturn(Optional.empty());
+    }
 
     @Test
     void rotateShouldThrowSecretRotationExceptionIfCloudbreakRotationFailed() {
         doThrow(new RuntimeException("error")).when(sdxRotationService).rotateCloudbreakSecret(anyString(),
                 eq(DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD), eq(ROTATE));
         SecretRotationException secretRotationException = assertThrows(SecretRotationException.class,
-                () -> underTest.executeRotate(new PollerRotationContext(RESOURCE_CRN, DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD)));
-        Assertions.assertEquals("Rotation failed at CLOUDBREAK_ROTATE_POLLING step for resourceCrn", secretRotationException.getMessage());
+                () -> underTest.executeRotate(new PollerRotationContext(RESOURCE_CRN, DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD), null));
+        Assertions.assertEquals("Execution of rotation failed at CLOUDBREAK_ROTATE_POLLING step for resourceCrn regarding secret null.",
+                secretRotationException.getMessage());
     }
 
     @Test
     void rotateShouldSucceed() {
-        underTest.executeRotate(new PollerRotationContext(RESOURCE_CRN, DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD));
+        underTest.executeRotate(new PollerRotationContext(RESOURCE_CRN, DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD), null);
         verify(sdxRotationService, times(1)).rotateCloudbreakSecret(eq(RESOURCE_CRN),
                 eq(DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD), eq(ROTATE));
     }
@@ -53,13 +70,14 @@ class CloudbreakPollerRotationExecutorTest {
         doThrow(new RuntimeException("error")).when(sdxRotationService).rotateCloudbreakSecret(anyString(),
                 eq(DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD), eq(ROLLBACK));
         SecretRotationException secretRotationException = assertThrows(SecretRotationException.class,
-                () -> underTest.executeRollback(new PollerRotationContext(RESOURCE_CRN, DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD)));
-        Assertions.assertEquals("Rollback of rotation failed at CLOUDBREAK_ROTATE_POLLING step for resourceCrn", secretRotationException.getMessage());
+                () -> underTest.executeRollback(new PollerRotationContext(RESOURCE_CRN, DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD), null));
+        Assertions.assertEquals("Rollback of rotation failed at CLOUDBREAK_ROTATE_POLLING step for resourceCrn regarding secret null.",
+                secretRotationException.getMessage());
     }
 
     @Test
     void rollbackShouldSucceed() {
-        underTest.executeRollback(new PollerRotationContext(RESOURCE_CRN, DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD));
+        underTest.executeRollback(new PollerRotationContext(RESOURCE_CRN, DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD), null);
         verify(sdxRotationService, times(1)).rotateCloudbreakSecret(eq(RESOURCE_CRN),
                 eq(DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD), eq(ROLLBACK));
     }
@@ -69,13 +87,14 @@ class CloudbreakPollerRotationExecutorTest {
         doThrow(new RuntimeException("error")).when(sdxRotationService).rotateCloudbreakSecret(anyString(),
                 eq(DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD), eq(FINALIZE));
         SecretRotationException secretRotationException = assertThrows(SecretRotationException.class,
-                () -> underTest.executeFinalize(new PollerRotationContext(RESOURCE_CRN, DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD)));
-        Assertions.assertEquals("Finalize rotation failed at CLOUDBREAK_ROTATE_POLLING step for resourceCrn", secretRotationException.getMessage());
+                () -> underTest.executeFinalize(new PollerRotationContext(RESOURCE_CRN, DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD), null));
+        Assertions.assertEquals("Finalization of rotation failed at CLOUDBREAK_ROTATE_POLLING step for resourceCrn regarding secret null.",
+                secretRotationException.getMessage());
     }
 
     @Test
     void finalizeShouldSucceed() {
-        underTest.executeFinalize(new PollerRotationContext(RESOURCE_CRN, DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD));
+        underTest.executeFinalize(new PollerRotationContext(RESOURCE_CRN, DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD), null);
         verify(sdxRotationService, times(1)).rotateCloudbreakSecret(eq(RESOURCE_CRN),
                 eq(DATALAKE_EXTERNAL_DATABASE_ROOT_PASSWORD), eq(FINALIZE));
     }

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/rotation/RedbeamsPollerRotationExecutorTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/rotation/RedbeamsPollerRotationExecutorTest.java
@@ -5,13 +5,19 @@ import static com.sequenceiq.cloudbreak.rotation.secret.RotationFlowExecutionTyp
 import static com.sequenceiq.cloudbreak.rotation.secret.RotationFlowExecutionType.ROTATE;
 import static com.sequenceiq.redbeams.rotation.RedbeamsSecretType.REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.util.Optional;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -19,6 +25,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationException;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationProgressService;
 import com.sequenceiq.cloudbreak.rotation.secret.context.PollerRotationContext;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,21 +36,31 @@ class RedbeamsPollerRotationExecutorTest {
     @Mock
     private SdxRotationService sdxRotationService;
 
+    @Mock
+    private SecretRotationProgressService secretRotationProgressService;
+
     @InjectMocks
     private RedbeamsPollerRotationExecutor underTest;
+
+    @BeforeEach
+    public void mockProgressService() throws IllegalAccessException {
+        FieldUtils.writeField(underTest, "secretRotationProgressService", Optional.of(secretRotationProgressService), true);
+        lenient().when(secretRotationProgressService.latestStep(any(), any(), any(), any())).thenReturn(Optional.empty());
+    }
 
     @Test
     void rotateShouldThrowSecretRotationExceptionIfCloudbreakRotationFailed() {
         doThrow(new RuntimeException("error")).when(sdxRotationService).rotateRedbeamsSecret(anyString(),
                 eq(REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD), eq(ROTATE));
         SecretRotationException secretRotationException = assertThrows(SecretRotationException.class,
-                () -> underTest.executeRotate(new PollerRotationContext(RESOURCE_CRN, REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD)));
-        Assertions.assertEquals("Rotation failed at REDBEAMS_ROTATE_POLLING step for resourceCrn", secretRotationException.getMessage());
+                () -> underTest.executeRotate(new PollerRotationContext(RESOURCE_CRN, REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD), null));
+        Assertions.assertEquals("Execution of rotation failed at REDBEAMS_ROTATE_POLLING step for resourceCrn regarding secret null.",
+                secretRotationException.getMessage());
     }
 
     @Test
     void rotateShouldSucceed() {
-        underTest.executeRotate(new PollerRotationContext(RESOURCE_CRN, REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD));
+        underTest.executeRotate(new PollerRotationContext(RESOURCE_CRN, REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD), null);
         verify(sdxRotationService, times(1)).rotateRedbeamsSecret(eq(RESOURCE_CRN),
                 eq(REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD), eq(ROTATE));
     }
@@ -53,13 +70,14 @@ class RedbeamsPollerRotationExecutorTest {
         doThrow(new RuntimeException("error")).when(sdxRotationService).rotateRedbeamsSecret(anyString(),
                 eq(REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD), eq(ROLLBACK));
         SecretRotationException secretRotationException = assertThrows(SecretRotationException.class,
-                () -> underTest.executeRollback(new PollerRotationContext(RESOURCE_CRN, REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD)));
-        Assertions.assertEquals("Rollback of rotation failed at REDBEAMS_ROTATE_POLLING step for resourceCrn", secretRotationException.getMessage());
+                () -> underTest.executeRollback(new PollerRotationContext(RESOURCE_CRN, REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD), null));
+        Assertions.assertEquals("Rollback of rotation failed at REDBEAMS_ROTATE_POLLING step for resourceCrn regarding secret null.",
+                secretRotationException.getMessage());
     }
 
     @Test
     void rollbackShouldSucceed() {
-        underTest.executeRollback(new PollerRotationContext(RESOURCE_CRN, REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD));
+        underTest.executeRollback(new PollerRotationContext(RESOURCE_CRN, REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD), null);
         verify(sdxRotationService, times(1)).rotateRedbeamsSecret(eq(RESOURCE_CRN),
                 eq(REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD), eq(ROLLBACK));
     }
@@ -69,13 +87,14 @@ class RedbeamsPollerRotationExecutorTest {
         doThrow(new RuntimeException("error")).when(sdxRotationService).rotateRedbeamsSecret(anyString(),
                 eq(REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD), eq(FINALIZE));
         SecretRotationException secretRotationException = assertThrows(SecretRotationException.class,
-                () -> underTest.executeFinalize(new PollerRotationContext(RESOURCE_CRN, REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD)));
-        Assertions.assertEquals("Finalize rotation failed at REDBEAMS_ROTATE_POLLING step for resourceCrn", secretRotationException.getMessage());
+                () -> underTest.executeFinalize(new PollerRotationContext(RESOURCE_CRN, REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD), null));
+        Assertions.assertEquals("Finalization of rotation failed at REDBEAMS_ROTATE_POLLING step for resourceCrn regarding secret null.",
+                secretRotationException.getMessage());
     }
 
     @Test
     void finalizeShouldSucceed() {
-        underTest.executeFinalize(new PollerRotationContext(RESOURCE_CRN, REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD));
+        underTest.executeFinalize(new PollerRotationContext(RESOURCE_CRN, REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD), null);
         verify(sdxRotationService, times(1)).rotateRedbeamsSecret(eq(RESOURCE_CRN),
                 eq(REDBEAMS_EXTERNAL_DATABASE_ROOT_PASSWORD), eq(FINALIZE));
     }

--- a/environment/src/test/java/com/sequenceiq/environment/service/integration/JpaTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/service/integration/JpaTest.java
@@ -24,6 +24,7 @@ import org.springframework.data.repository.support.Repositories;
 @DataJpaTest(properties = {
         "spring.jpa.properties.hibernate.session_factory.statement_inspector=com.sequenceiq.environment.service.integration.SqlStatementInspector"})
 @EntityScan(basePackages = {"com.sequenceiq.flow.domain",
+        "com.sequenceiq.flow.rotation",
         "com.sequenceiq.environment",
         "com.sequenceiq.cloudbreak.ha.domain",
         "com.sequenceiq.cloudbreak.structuredevent.domain"})

--- a/environment/src/test/java/com/sequenceiq/environment/service/integration/testconfiguration/TestConfigurationForServiceIntegration.java
+++ b/environment/src/test/java/com/sequenceiq/environment/service/integration/testconfiguration/TestConfigurationForServiceIntegration.java
@@ -14,6 +14,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.FreeIpaV1Endpoint;
 
 @TestConfiguration
 @EntityScan(basePackages = {"com.sequenceiq.flow.domain",
+        "com.sequenceiq.flow.rotation",
         "com.sequenceiq.environment",
         "com.sequenceiq.cloudbreak.ha.domain",
         "com.sequenceiq.cloudbreak.structuredevent.domain"})

--- a/flow/src/main/java/com/sequenceiq/flow/rotation/SecretRotationActions.java
+++ b/flow/src/main/java/com/sequenceiq/flow/rotation/SecretRotationActions.java
@@ -16,6 +16,7 @@ import org.springframework.statemachine.action.Action;
 
 import com.sequenceiq.cloudbreak.rotation.secret.RotationFlowExecutionType;
 import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationException;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationProgressService;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 import com.sequenceiq.cloudbreak.rotation.secret.usage.SecretRotationUsageProcessor;
 import com.sequenceiq.flow.core.AbstractAction;
@@ -47,6 +48,9 @@ public class SecretRotationActions {
 
     @Inject
     private Optional<SecretRotationUsageProcessor> secretRotationUsageProcessor;
+
+    @Inject
+    private SecretRotationProgressService secretRotationProgressService;
 
     @Bean(name = "PRE_VALIDATE_ROTATION_STATE")
     public Action<?, ?> executePreValidationAction() {
@@ -177,6 +181,7 @@ public class SecretRotationActions {
                     LOGGER.debug("Execution type is not set or not explicit ROLLBACK, set flow failed for: {}", context.getResourceCrn());
                     flow.setFlowFailed(payload.getException());
                 }
+                secretRotationProgressService.deleteAll(context.getResourceCrn(), payload.getSecretType());
                 secretRotationUsageProcessor.ifPresent(processor -> processor.rotationFailed(context.getSecretType(), resourceCrn,
                         message, context.getExecutionType()));
                 LOGGER.debug("Secret rotation failed, change resource status for {}", resourceCrn);

--- a/flow/src/main/java/com/sequenceiq/flow/rotation/entity/RotationFlowExecutionTypeConverter.java
+++ b/flow/src/main/java/com/sequenceiq/flow/rotation/entity/RotationFlowExecutionTypeConverter.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.flow.rotation.entity;
+
+import com.sequenceiq.cloudbreak.converter.DefaultEnumConverter;
+import com.sequenceiq.cloudbreak.rotation.secret.RotationFlowExecutionType;
+
+public class RotationFlowExecutionTypeConverter extends DefaultEnumConverter<RotationFlowExecutionType> {
+
+    @Override
+    public RotationFlowExecutionType getDefault() {
+        return RotationFlowExecutionType.ROTATE;
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/rotation/entity/SecretRotationStepConverter.java
+++ b/flow/src/main/java/com/sequenceiq/flow/rotation/entity/SecretRotationStepConverter.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.flow.rotation.entity;
+
+import javax.persistence.AttributeConverter;
+
+import com.sequenceiq.cloudbreak.rotation.secret.serialization.SecretRotationEnumSerializationUtil;
+import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
+
+public class SecretRotationStepConverter implements AttributeConverter<SecretRotationStep, String> {
+    @Override
+    public String convertToDatabaseColumn(SecretRotationStep attribute) {
+        return SecretRotationEnumSerializationUtil.enumToMapString((Enum) attribute);
+    }
+
+    @Override
+    public SecretRotationStep convertToEntityAttribute(String dbData) {
+        try {
+            return (SecretRotationStep) SecretRotationEnumSerializationUtil.getEnum(SecretRotationEnumSerializationUtil.mapStringToMap(dbData));
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/rotation/entity/SecretRotationStepProgress.java
+++ b/flow/src/main/java/com/sequenceiq/flow/rotation/entity/SecretRotationStepProgress.java
@@ -1,0 +1,104 @@
+package com.sequenceiq.flow.rotation.entity;
+
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+
+import com.sequenceiq.cloudbreak.rotation.secret.RotationFlowExecutionType;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretType;
+import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
+
+@Entity
+public class SecretRotationStepProgress {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "secretrotationstepprogress_generator")
+    @SequenceGenerator(name = "secretrotationstepprogress_generator", sequenceName = "secretrotationstepprogress_id_seq", allocationSize = 1)
+    private Long id;
+
+    private String resourceCrn;
+
+    @Convert(converter = SecretTypeConverter.class)
+    private SecretType secretType;
+
+    @Convert(converter = SecretRotationStepConverter.class)
+    private SecretRotationStep secretRotationStep;
+
+    @Convert(converter = RotationFlowExecutionTypeConverter.class)
+    private RotationFlowExecutionType executionType;
+
+    private Long created;
+
+    private Long finished;
+
+    public SecretRotationStepProgress() {
+    }
+
+    public SecretRotationStepProgress(String resourceCrn, SecretType secretType, SecretRotationStep secretRotationStep,
+            RotationFlowExecutionType executionType, Long created) {
+        this.resourceCrn = resourceCrn;
+        this.secretType = secretType;
+        this.secretRotationStep = secretRotationStep;
+        this.executionType = executionType;
+        this.created = created;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getResourceCrn() {
+        return resourceCrn;
+    }
+
+    public void setResourceCrn(String resourceCrn) {
+        this.resourceCrn = resourceCrn;
+    }
+
+    public SecretType getSecretType() {
+        return secretType;
+    }
+
+    public void setSecretType(SecretType secretType) {
+        this.secretType = secretType;
+    }
+
+    public SecretRotationStep getSecretRotationStep() {
+        return secretRotationStep;
+    }
+
+    public void setSecretRotationStep(SecretRotationStep secretRotationStep) {
+        this.secretRotationStep = secretRotationStep;
+    }
+
+    public RotationFlowExecutionType getExecutionType() {
+        return executionType;
+    }
+
+    public void setExecutionType(RotationFlowExecutionType executionType) {
+        this.executionType = executionType;
+    }
+
+    public Long getCreated() {
+        return created;
+    }
+
+    public void setCreated(Long created) {
+        this.created = created;
+    }
+
+    public Long getFinished() {
+        return finished;
+    }
+
+    public void setFinished(Long finished) {
+        this.finished = finished;
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/rotation/entity/SecretTypeConverter.java
+++ b/flow/src/main/java/com/sequenceiq/flow/rotation/entity/SecretTypeConverter.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.flow.rotation.entity;
+
+import javax.persistence.AttributeConverter;
+
+import com.sequenceiq.cloudbreak.rotation.secret.SecretType;
+import com.sequenceiq.cloudbreak.rotation.secret.serialization.SecretRotationEnumSerializationUtil;
+
+public class SecretTypeConverter implements AttributeConverter<SecretType, String> {
+    @Override
+    public String convertToDatabaseColumn(SecretType attribute) {
+        return SecretRotationEnumSerializationUtil.enumToMapString((Enum) attribute);
+    }
+
+    @Override
+    public SecretType convertToEntityAttribute(String dbData) {
+        try {
+            return (SecretType) SecretRotationEnumSerializationUtil.getEnum(SecretRotationEnumSerializationUtil.mapStringToMap(dbData));
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/rotation/repository/SecretRotationStepProgressRepository.java
+++ b/flow/src/main/java/com/sequenceiq/flow/rotation/repository/SecretRotationStepProgressRepository.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.flow.rotation.repository;
+
+import java.util.Set;
+
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.sequenceiq.cloudbreak.rotation.secret.RotationFlowExecutionType;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretType;
+import com.sequenceiq.flow.rotation.entity.SecretRotationStepProgress;
+
+@Transactional(TxType.REQUIRED)
+public interface SecretRotationStepProgressRepository extends CrudRepository<SecretRotationStepProgress, Long> {
+
+    Set<SecretRotationStepProgress> findAllByResourceCrnAndExecutionType(String resourceCrn, RotationFlowExecutionType executionType);
+
+    void deleteByResourceCrnAndSecretType(String resourceCrn, SecretType secretType);
+}

--- a/flow/src/main/java/com/sequenceiq/flow/rotation/service/SecretRotationConfig.java
+++ b/flow/src/main/java/com/sequenceiq/flow/rotation/service/SecretRotationConfig.java
@@ -13,9 +13,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.google.common.collect.Maps;
+import com.sequenceiq.cloudbreak.rotation.secret.AbstractRotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.RotationContext;
 import com.sequenceiq.cloudbreak.rotation.secret.RotationContextProvider;
-import com.sequenceiq.cloudbreak.rotation.secret.RotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.SecretType;
 import com.sequenceiq.cloudbreak.rotation.secret.application.ApplicationSecretRotationInformation;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
@@ -30,7 +30,7 @@ public class SecretRotationConfig {
     private Optional<List<RotationContextProvider>> rotationContextProviders;
 
     @Inject
-    private Optional<List<RotationExecutor<? extends RotationContext>>> rotationExecutors;
+    private Optional<List<AbstractRotationExecutor<? extends RotationContext>>> rotationExecutors;
 
     @Bean
     public Map<SecretType, RotationContextProvider> rotationContextProviderMap() {
@@ -49,14 +49,14 @@ public class SecretRotationConfig {
     }
 
     @Bean
-    public Map<SecretRotationStep, RotationExecutor<? extends RotationContext>> rotationExecutorMap() {
+    public Map<SecretRotationStep, AbstractRotationExecutor<? extends RotationContext>> rotationExecutorMap() {
         if (applicationSecretRotationInformation.isPresent() && rotationExecutors.isPresent()) {
             Class<? extends SecretType> supportedSecretType = applicationSecretRotationInformation.get().supportedSecretType();
             Set<SecretRotationStep> supportedSteps = Arrays.stream(supportedSecretType.getEnumConstants())
                     .flatMap(secretType -> secretType.getSteps().stream())
                     .collect(Collectors.toSet());
-            Map<SecretRotationStep, RotationExecutor<? extends RotationContext>> beans = Maps.newHashMap();
-            for (RotationExecutor<? extends RotationContext> rotationExecutor : rotationExecutors.get()) {
+            Map<SecretRotationStep, AbstractRotationExecutor<? extends RotationContext>> beans = Maps.newHashMap();
+            for (AbstractRotationExecutor<? extends RotationContext> rotationExecutor : rotationExecutors.get()) {
                 if (supportedSteps.contains(rotationExecutor.getType())) {
                     beans.put(rotationExecutor.getType(), rotationExecutor);
                 }

--- a/flow/src/main/java/com/sequenceiq/flow/rotation/service/SecretRotationStepProgressService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/rotation/service/SecretRotationStepProgressService.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.flow.rotation.service;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.rotation.secret.RotationFlowExecutionType;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationProgressService;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretType;
+import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
+import com.sequenceiq.flow.rotation.entity.SecretRotationStepProgress;
+import com.sequenceiq.flow.rotation.repository.SecretRotationStepProgressRepository;
+
+@Service
+public class SecretRotationStepProgressService implements SecretRotationProgressService<SecretRotationStepProgress> {
+
+    @Inject
+    private Optional<SecretRotationStepProgressRepository> repository;
+
+    @Override
+    public boolean isFinished(SecretRotationStepProgress entity) {
+        return entity.getFinished() != null;
+    }
+
+    @Override
+    public void finished(SecretRotationStepProgress entity) {
+        repository.ifPresent(repo -> {
+            entity.setFinished(System.currentTimeMillis());
+            repo.save(entity);
+        });
+    }
+
+    @Override
+    public Optional<SecretRotationStepProgress> latestStep(String resourceCrn, SecretType secretType,
+            SecretRotationStep step, RotationFlowExecutionType executionType) {
+        if (repository.isPresent()) {
+            Optional<SecretRotationStepProgress> latestStepProgress = repository.get().findAllByResourceCrnAndExecutionType(resourceCrn, executionType)
+                    .stream()
+                    .filter(progress -> secretType.equals(progress.getSecretType()) && step.equals(progress.getSecretRotationStep()))
+                    .findFirst();
+            if (latestStepProgress.isEmpty()) {
+                SecretRotationStepProgress progress = new SecretRotationStepProgress(resourceCrn, secretType, step, executionType, System.currentTimeMillis());
+                return Optional.of(repository.get().save(progress));
+            }
+            return latestStepProgress;
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void deleteAll(String resourceCrn, SecretType secretType) {
+        repository.ifPresent(repo -> repo.deleteByResourceCrnAndSecretType(resourceCrn, secretType));
+    }
+}

--- a/flow/src/main/resources/schema/flow/20230729163000_CB-21512_add_secretrotationstepprogress.sql
+++ b/flow/src/main/resources/schema/flow/20230729163000_CB-21512_add_secretrotationstepprogress.sql
@@ -1,0 +1,18 @@
+-- // secret rotation step progress
+-- Migration SQL that makes the change goes here.
+
+CREATE TABLE IF NOT EXISTS secretrotationstepprogress (
+    id bigserial NOT NULL,
+    created bigint,
+    finished bigint,
+    resourcecrn character varying(255),
+    secrettype character varying(255),
+    secretrotationstep character varying(255),
+    executiontype character varying(255),
+    PRIMARY KEY (id)
+);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP TABLE IF EXISTS secretrotationstepprogress;

--- a/flow/src/test/java/com/sequenceiq/flow/rotation/service/SecretRotationStepProgressServiceTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/rotation/service/SecretRotationStepProgressServiceTest.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.flow.rotation.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.rotation.secret.RotationFlowExecutionType;
+import com.sequenceiq.cloudbreak.rotation.secret.TestSecretRotationStep;
+import com.sequenceiq.cloudbreak.rotation.secret.TestSecretType;
+import com.sequenceiq.flow.rotation.entity.SecretRotationStepProgress;
+import com.sequenceiq.flow.rotation.repository.SecretRotationStepProgressRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class SecretRotationStepProgressServiceTest {
+
+    @Mock
+    private SecretRotationStepProgressRepository repository;
+
+    @InjectMocks
+    private SecretRotationStepProgressService underTest;
+
+    @BeforeEach
+    public void mockRepository() throws IllegalAccessException {
+        FieldUtils.writeField(underTest, "repository", Optional.of(repository), true);
+    }
+
+    @Test
+    public void testWhenNoProgress() {
+        when(repository.findAllByResourceCrnAndExecutionType(any(), any())).thenReturn(Set.of());
+        when(repository.save(any())).thenReturn(new SecretRotationStepProgress());
+
+        assertTrue(underTest.latestStep("", TestSecretType.TEST, TestSecretRotationStep.STEP, RotationFlowExecutionType.ROTATE).isPresent());
+
+        verify(repository, times(1)).findAllByResourceCrnAndExecutionType(any(), any());
+        verify(repository, times(1)).save(any());
+    }
+
+    @Test
+    public void testWhenProgressPresent() {
+        when(repository.findAllByResourceCrnAndExecutionType(any(), any())).thenReturn(Set.of(
+                new SecretRotationStepProgress("", TestSecretType.TEST, TestSecretRotationStep.STEP, RotationFlowExecutionType.ROTATE, null)));
+
+        assertTrue(underTest.latestStep("", TestSecretType.TEST, TestSecretRotationStep.STEP, RotationFlowExecutionType.ROTATE).isPresent());
+
+        verify(repository, times(1)).findAllByResourceCrnAndExecutionType(any(), any());
+        verify(repository, times(0)).save(any());
+    }
+}

--- a/flow/src/test/java/com/sequenceiq/flow/rotation/service/SecretRotationValidatorTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/rotation/service/SecretRotationValidatorTest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.flow.rotation.service;
 
+import static com.sequenceiq.cloudbreak.rotation.secret.TestSecretType.TEST;
+import static com.sequenceiq.cloudbreak.rotation.secret.TestSecretType.TEST_2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -13,7 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.rotation.secret.SecretType;
-import com.sequenceiq.flow.rotation.TestSecretType;
+import com.sequenceiq.cloudbreak.rotation.secret.TestSecretType;
 
 @ExtendWith(MockitoExtension.class)
 class SecretRotationValidatorTest {
@@ -39,7 +41,7 @@ class SecretRotationValidatorTest {
     @Test
     void mapSecretTypesShouldSucceed() {
         List<SecretType> secretTypes =
-                underTest.mapSecretTypes(List.of("TEST", "TEST2"), TestSecretType.class);
-        assertThat(secretTypes).containsExactly(TestSecretType.TEST, TestSecretType.TEST2);
+                underTest.mapSecretTypes(List.of("TEST", "TEST_2"), TestSecretType.class);
+        assertThat(secretTypes).containsExactly(TEST, TEST_2);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/rotation/executor/UserDataRotationExecutor.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/rotation/executor/UserDataRotationExecutor.java
@@ -27,7 +27,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.rotation.UserDataRotationContext;
-import com.sequenceiq.cloudbreak.rotation.secret.RotationExecutor;
+import com.sequenceiq.cloudbreak.rotation.secret.AbstractRotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationException;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 import com.sequenceiq.cloudbreak.rotation.secret.userdata.UserDataSecretModifier;
@@ -45,7 +45,7 @@ import com.sequenceiq.freeipa.service.resource.ResourceService;
 import com.sequenceiq.freeipa.service.stack.StackService;
 
 @Component
-public class UserDataRotationExecutor implements RotationExecutor<UserDataRotationContext> {
+public class UserDataRotationExecutor extends AbstractRotationExecutor<UserDataRotationContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UserDataRotationExecutor.class);
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/rotation/UserDataRotationExecutorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/rotation/UserDataRotationExecutorTest.java
@@ -12,7 +12,9 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.rotation.UserDataRotationContext;
 import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationException;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationProgressService;
 import com.sequenceiq.cloudbreak.rotation.secret.userdata.UserDataSecretModifier;
 import com.sequenceiq.cloudbreak.service.secret.domain.RotationSecret;
 import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
@@ -66,9 +69,14 @@ class UserDataRotationExecutorTest {
     @Mock
     private CloudStack cloudStack;
 
+    @Mock
+    private SecretRotationProgressService secretRotationProgressService;
+
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws IllegalAccessException {
         lenient().when(cloudStackConverter.convert(any())).thenReturn(cloudStack);
+        FieldUtils.writeField(underTest, "secretRotationProgressService", Optional.of(secretRotationProgressService), true);
+        lenient().when(secretRotationProgressService.latestStep(any(), any(), any(), any())).thenReturn(Optional.empty());
     }
 
     @Test

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/rotation/ServiceConfigRotationExecutor.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/rotation/ServiceConfigRotationExecutor.java
@@ -16,12 +16,12 @@ import com.google.common.io.BaseEncoding;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
-import com.sequenceiq.cloudbreak.rotation.secret.RotationExecutor;
+import com.sequenceiq.cloudbreak.rotation.secret.AbstractRotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationException;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 
 @Component
-public class ServiceConfigRotationExecutor implements RotationExecutor<ServiceConfigRotationContext> {
+public class ServiceConfigRotationExecutor extends AbstractRotationExecutor<ServiceConfigRotationContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ServiceConfigRotationExecutor.class);
 

--- a/orchestrator-api/src/test/java/com/sequenceiq/cloudbreak/orchestrator/rotation/ServiceConfigRotationExecutorTest.java
+++ b/orchestrator-api/src/test/java/com/sequenceiq/cloudbreak/orchestrator/rotation/ServiceConfigRotationExecutorTest.java
@@ -6,14 +6,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -29,6 +33,7 @@ import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
 import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationException;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationProgressService;
 
 @ExtendWith(MockitoExtension.class)
 class ServiceConfigRotationExecutorTest {
@@ -54,6 +59,9 @@ class ServiceConfigRotationExecutorTest {
     @Mock
     private HostOrchestrator hostOrchestrator;
 
+    @Mock
+    private SecretRotationProgressService secretRotationProgressService;
+
     @InjectMocks
     private ServiceConfigRotationExecutor underTest;
 
@@ -61,6 +69,12 @@ class ServiceConfigRotationExecutorTest {
     private ArgumentCaptor<GatewayConfig> gatewayConfigCaptor;
 
     private GatewayConfig gatewayConfig = GatewayConfig.builder().build();
+
+    @BeforeEach
+    public void setUp() throws IllegalAccessException {
+        FieldUtils.writeField(underTest, "secretRotationProgressService", Optional.of(secretRotationProgressService), true);
+        lenient().when(secretRotationProgressService.latestStep(any(), any(), any(), any())).thenReturn(Optional.empty());
+    }
 
     @Test
     public void rotateWithOldSaltBootSecrets() throws Exception {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/rotation/RootPasswordRotationExecutor.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/rotation/RootPasswordRotationExecutor.java
@@ -19,8 +19,8 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.ExternalDatabaseStatus;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.rotation.secret.AbstractRotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.RotationContext;
-import com.sequenceiq.cloudbreak.rotation.secret.RotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationException;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 import com.sequenceiq.cloudbreak.service.secret.domain.RotationSecret;
@@ -35,7 +35,7 @@ import com.sequenceiq.redbeams.service.dbserverconfig.DatabaseServerConfigServic
 import com.sequenceiq.redbeams.service.stack.DBStackService;
 
 @Component
-public class RootPasswordRotationExecutor implements RotationExecutor<RotationContext> {
+public class RootPasswordRotationExecutor extends AbstractRotationExecutor<RotationContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RootPasswordRotationExecutor.class);
 

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/rotation/context/provider/RootPasswordRotationExecutorTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/rotation/context/provider/RootPasswordRotationExecutorTest.java
@@ -12,7 +12,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
+import java.util.Optional;
 
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -29,6 +32,7 @@ import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.ExternalDatabaseStatus;
 import com.sequenceiq.cloudbreak.rotation.secret.RotationContext;
 import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationException;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationProgressService;
 import com.sequenceiq.cloudbreak.service.secret.domain.RotationSecret;
 import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
 import com.sequenceiq.redbeams.converter.cloud.CredentialToCloudCredentialConverter;
@@ -79,8 +83,17 @@ class RootPasswordRotationExecutorTest {
     @Mock
     private DatabaseServerConfigService databaseServerConfigService;
 
+    @Mock
+    private SecretRotationProgressService secretRotationProgressService;
+
     @InjectMocks
     private RootPasswordRotationExecutor underTest;
+
+    @BeforeEach
+    void mockProgressService() throws IllegalAccessException {
+        FieldUtils.writeField(underTest, "secretRotationProgressService", Optional.of(secretRotationProgressService), true);
+        lenient().when(secretRotationProgressService.latestStep(any(), any(), any(), any())).thenReturn(Optional.empty());
+    }
 
     @Test
     void preValidationShouldSucceed() throws Exception {

--- a/secret-engine/build.gradle
+++ b/secret-engine/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   }
   implementation group: 'com.fasterxml.jackson.core',   name: 'jackson-databind', version: { strictly jacksonDatabindVersion }
 
+  testImplementation project(path: ':common', configuration: 'tests')
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion
 }
 

--- a/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/service/rotation/VaultRotationExecutor.java
+++ b/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/service/rotation/VaultRotationExecutor.java
@@ -8,7 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.rotation.secret.RotationExecutor;
+import com.sequenceiq.cloudbreak.rotation.secret.AbstractRotationExecutor;
 import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationException;
 import com.sequenceiq.cloudbreak.rotation.secret.step.CommonSecretRotationStep;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
@@ -17,7 +17,7 @@ import com.sequenceiq.cloudbreak.service.secret.domain.RotationSecret;
 import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
 
 @Component
-public class VaultRotationExecutor implements RotationExecutor<VaultRotationContext> {
+public class VaultRotationExecutor extends AbstractRotationExecutor<VaultRotationContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(VaultRotationExecutor.class);
 


### PR DESCRIPTION
- before and after every step execution we will save the details in database
- if pod restart happens, we can query database and continue rotation from the given step

See detailed description in the commit message.