### PR TITLE
CB-22198 Fix create external db in 2.73 -> upgrade on 2.72 -> back to 2.73: upgrade is needed again

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/StackDto.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/StackDto.java
@@ -31,6 +31,7 @@ import com.sequenceiq.cloudbreak.domain.Network;
 import com.sequenceiq.cloudbreak.domain.Orchestrator;
 import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
+import com.sequenceiq.cloudbreak.domain.stack.Database;
 import com.sequenceiq.cloudbreak.domain.stack.StackParameters;
 import com.sequenceiq.cloudbreak.domain.view.ClusterComponentView;
 import com.sequenceiq.cloudbreak.logger.MdcContextInfoProvider;
@@ -52,6 +53,8 @@ public class StackDto implements OrchestratorAware, StackDtoDelegate, MdcContext
     private ClusterView cluster;
 
     private Network network;
+
+    private Database database;
 
     private Workspace workspace;
 
@@ -79,13 +82,14 @@ public class StackDto implements OrchestratorAware, StackDtoDelegate, MdcContext
 
     private Map<InstanceGroupView, List<String>> availabilityZonesByInstanceGroup;
 
-    public StackDto(StackView stack, ClusterView cluster, Network network, Workspace workspace, Tenant tenant, Map<String, InstanceGroupDto> instanceGroups,
-            Set<Resource> resources, Blueprint blueprint, GatewayView gateway, Orchestrator orchestrator,
+    public StackDto(StackView stack, ClusterView cluster, Network network, Database database, Workspace workspace, Tenant tenant, Map<String,
+            InstanceGroupDto> instanceGroups, Set<Resource> resources, Blueprint blueprint, GatewayView gateway, Orchestrator orchestrator,
             FileSystem fileSystem, FileSystem additionalFileSystem, Set<ClusterComponentView> clusterComponents, List<StackParameters> stackParameters,
             SecurityConfig securityConfig, Map<InstanceGroupView, List<String>> availabilityZonesByInstanceGroup) {
         this.stack = stack;
         this.cluster = cluster;
         this.network = network;
+        this.database = database;
         this.workspace = workspace;
         this.instanceGroups = instanceGroups;
         this.resources = resources;
@@ -165,6 +169,10 @@ public class StackDto implements OrchestratorAware, StackDtoDelegate, MdcContext
 
     public Network getNetwork() {
         return network;
+    }
+
+    public Database getDatabase() {
+        return database;
     }
 
     public Set<Resource> getResources() {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/StackDtoDelegate.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/StackDtoDelegate.java
@@ -21,6 +21,7 @@ import com.sequenceiq.cloudbreak.domain.Orchestrator;
 import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
 import com.sequenceiq.cloudbreak.domain.StackAuthentication;
+import com.sequenceiq.cloudbreak.domain.stack.Database;
 import com.sequenceiq.cloudbreak.domain.stack.ResourceUtil;
 import com.sequenceiq.cloudbreak.domain.view.ClusterComponentView;
 import com.sequenceiq.cloudbreak.view.ClusterView;
@@ -151,6 +152,8 @@ public interface StackDtoDelegate {
 
     Network getNetwork();
 
+    Database getDatabase();
+
     List<InstanceGroupDto> getInstanceGroupDtos();
 
     Set<String> getAvailabilityZonesByInstanceGroup(Long instanceGroupId);
@@ -228,7 +231,11 @@ public interface StackDtoDelegate {
     }
 
     default DatabaseAvailabilityType getExternalDatabaseCreationType() {
-        return getStack().getExternalDatabaseCreationType();
+        return getDatabase().getExternalDatabaseAvailabilityType();
+    }
+
+    default String getExternalDatabaseEngineVersion() {
+        return getDatabase().getExternalDatabaseEngineVersion();
     }
 
     default String getTenantName() {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/util/DatabaseParameterFallbackUtil.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/util/DatabaseParameterFallbackUtil.java
@@ -1,9 +1,12 @@
 package com.sequenceiq.cloudbreak.util;
 
+import java.util.Optional;
+
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.domain.stack.Database;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.view.StackView;
 
 // TODO It's only needed for handling backward compatibility, can be removed in CB-22002
 public class DatabaseParameterFallbackUtil {
@@ -27,10 +30,53 @@ public class DatabaseParameterFallbackUtil {
     }
 
     public static String getExternalDatabaseEngineVersion(Database database, String fallbackExternalDatabaseEngineVersion) {
-        return database != null ? database.getExternalDatabaseEngineVersion() : fallbackExternalDatabaseEngineVersion;
+        String result;
+        if (database != null) {
+            String dbEngineVersion = Optional.of(database).map(Database::getExternalDatabaseEngineVersion).orElse("");
+            if (fallbackExternalDatabaseEngineVersion != null && !dbEngineVersion.equals(fallbackExternalDatabaseEngineVersion)) {
+                result = fallbackExternalDatabaseEngineVersion;
+            } else {
+                result = dbEngineVersion;
+            }
+        } else {
+            result = fallbackExternalDatabaseEngineVersion;
+        }
+        return result;
     }
 
     public static DatabaseAvailabilityType getExternalDatabaseCreationType(Database database, DatabaseAvailabilityType fallbackExternalDatabaseCreationType) {
         return database != null ? database.getExternalDatabaseAvailabilityType() : fallbackExternalDatabaseCreationType;
+    }
+
+    public static Database getOrCreateDatabase(Stack stack) {
+        if (stack.getDatabase() == null) {
+            Database database = new Database();
+            database.setExternalDatabaseAvailabilityType(stack.getExternalDatabaseCreationType());
+            database.setExternalDatabaseEngineVersion(stack.getExternalDatabaseEngineVersion());
+            return database;
+        } else {
+            if (!stack.getDatabase().getExternalDatabaseEngineVersion().equals(stack.getExternalDatabaseEngineVersion())) {
+                Database database = new Database();
+                database.setExternalDatabaseAvailabilityType(stack.getExternalDatabaseCreationType());
+                database.setExternalDatabaseEngineVersion(stack.getExternalDatabaseEngineVersion());
+                return database;
+            } else {
+                return stack.getDatabase();
+            }
+        }
+    }
+
+    public static Database getOrCreateDatabase(Database database, StackView stack) {
+        if (database == null) {
+            Database result = new Database();
+            result.setExternalDatabaseEngineVersion(stack.getExternalDatabaseEngineVersion());
+            result.setExternalDatabaseAvailabilityType(stack.getExternalDatabaseCreationType());
+            return result;
+        } else {
+            if (!stack.getExternalDatabaseEngineVersion().equals(database.getExternalDatabaseEngineVersion())) {
+                database.setExternalDatabaseEngineVersion(stack.getExternalDatabaseEngineVersion());
+            }
+            return database;
+        }
     }
 }

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/dto/StackDtoTest.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/dto/StackDtoTest.java
@@ -46,7 +46,7 @@ class StackDtoTest {
         InstanceGroupView instanceGroupView = mock(InstanceGroupView.class);
         when(instanceGroupView.getTemplate()).thenReturn(mock(Template.class));
         instanceGroups.put("worker", new InstanceGroupDto(instanceGroupView, workerInstanceMetadataViews));
-        StackDto stackDto = new StackDto(null, null, null, null, null, instanceGroups, null, null, null, null, null, null, null, null, null, null);
+        StackDto stackDto = new StackDto(null, null, null, null, null, null, instanceGroups, null, null, null, null, null, null, null, null, null, null);
         Set<Node> allFunctioningNodes = stackDto.getAllFunctioningNodes();
         assertThat(allFunctioningNodes, hasItem(hasProperty("hostname", equalTo("fqdn2"))));
         assertThat(allFunctioningNodes, hasItem(hasProperty("hostname", equalTo("fqdn3"))));

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/util/DatabaseParameterFallbackUtilTest.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/util/DatabaseParameterFallbackUtilTest.java
@@ -25,8 +25,11 @@ public class DatabaseParameterFallbackUtilTest {
         Database database = new Database();
         database.setExternalDatabaseEngineVersion("2.0");
         String fallbackDatabaseEngineVersion = "fallback2.0";
-        assertEquals("2.0", DatabaseParameterFallbackUtil.getExternalDatabaseEngineVersion(database, fallbackDatabaseEngineVersion));
+        assertEquals("2.0", DatabaseParameterFallbackUtil.getExternalDatabaseEngineVersion(database, "2.0"));
+        assertEquals(fallbackDatabaseEngineVersion, DatabaseParameterFallbackUtil.getExternalDatabaseEngineVersion(database, fallbackDatabaseEngineVersion));
         assertEquals(fallbackDatabaseEngineVersion, DatabaseParameterFallbackUtil.getExternalDatabaseEngineVersion(null, fallbackDatabaseEngineVersion));
+        assertEquals(fallbackDatabaseEngineVersion, DatabaseParameterFallbackUtil.getExternalDatabaseEngineVersion(
+                new Database(), fallbackDatabaseEngineVersion));
     }
 
     @Test

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackToStackV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackToStackV4ResponseConverter.java
@@ -167,7 +167,7 @@ public class StackToStackV4ResponseConverter {
         response.setTimeToLive(getStackTimeToLive(stack));
         response.setVariant(Strings.isNullOrEmpty(source.getPlatformVariant()) ? source.getCloudPlatform() : source.getPlatformVariant());
         response.setExternalDatabase(externalDatabaseToDatabaseResponseConverter
-                .convert(source.getExternalDatabaseCreationType(), source.getExternalDatabaseEngineVersion()));
+                .convert(stack.getExternalDatabaseCreationType(), stack.getExternalDatabaseEngineVersion()));
         response.setJavaVersion(source.getJavaVersion());
         datalakeService.addSharedServiceResponse(source.getDatalakeCrn(), response);
         filterExposedServicesByType(source.getType(), response.getCluster());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/PostgresConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/PostgresConfigService.java
@@ -35,7 +35,6 @@ import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigProviderFactory;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbServerConfigurer;
 import com.sequenceiq.cloudbreak.service.upgrade.rds.UpgradeRdsBackupRestoreStateParamsProvider;
 import com.sequenceiq.cloudbreak.view.ClusterView;
-import com.sequenceiq.cloudbreak.view.StackView;
 
 @Service
 public class PostgresConfigService {
@@ -180,10 +179,9 @@ public class PostgresConfigService {
         } else {
             postgresConfig.putAll(embeddedDatabaseConfigProvider.collectEmbeddedDatabaseConfigs(stackDto));
         }
-        StackView stack = stackDto.getStack();
-        if (StringUtils.isNotBlank(stack.getExternalDatabaseEngineVersion())) {
-            LOGGER.debug("Configuring embedded DB version to [{}]", stack.getExternalDatabaseEngineVersion());
-            postgresConfig.put(POSTGRES_VERSION, stack.getExternalDatabaseEngineVersion());
+        if (StringUtils.isNotBlank(stackDto.getExternalDatabaseEngineVersion())) {
+            LOGGER.debug("Configuring embedded DB version to [{}]", stackDto.getExternalDatabaseEngineVersion());
+            postgresConfig.put(POSTGRES_VERSION, stackDto.getExternalDatabaseEngineVersion());
         }
         if (CollectionUtils.isNotEmpty(databasesReusedDuringRecovery)) {
             postgresConfig.put("recovery_reused_databases", databasesReusedDuringRecovery);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
@@ -359,8 +359,8 @@ public class ClusterRepairFlowEventChainFactory implements FlowEventChainFactory
                 entitlementService.isEmbeddedPostgresUpgradeEnabled(Crn.safeFromString(stackView.getResourceCrn()).getAccountId());
         boolean upgradeRequested = event.isUpgrade();
         boolean embeddedDBOnAttachedDisk = embeddedDatabaseService.isAttachedDiskForEmbeddedDatabaseCreated(stackDto);
-        String currentDbVersion = StringUtils.isNotEmpty(stackView.getExternalDatabaseEngineVersion())
-                ? stackView.getExternalDatabaseEngineVersion() : DEFAULT_DB_VERSION;
+        String currentDbVersion = StringUtils.isNotEmpty(stackDto.getExternalDatabaseEngineVersion())
+                ? stackDto.getExternalDatabaseEngineVersion() : DEFAULT_DB_VERSION;
         boolean versionsAreDifferent = !targetMajorVersion.getMajorVersion().equals(currentDbVersion);
         if (embeddedPostgresUpgradeEnabled && upgradeRequested && embeddedDBOnAttachedDisk && versionsAreDifferent) {
             LOGGER.debug("Embedded db upgrade is possible and needed.");

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackDtoRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackDtoRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.domain.Network;
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
+import com.sequenceiq.cloudbreak.domain.stack.Database;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.view.delegate.StackViewDelegate;
 
@@ -120,6 +121,11 @@ public interface StackDtoRepository extends Repository<Stack, Long> {
             "LEFT JOIN s.network n " +
             "WHERE s.id = :stackId")
     Optional<Network> getNetworkByStackById(@Param("stackId") long stackId);
+
+    @Query("SELECT d FROM Stack s " +
+            "LEFT JOIN s.database d " +
+            "WHERE s.id = :stackId")
+    Optional<Database> getDatabaseByStackById(@Param("stackId") long stackId);
 
     @Query(BASE_QUERY
             + "WHERE s.id = :stackId "

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/AbstractRdsConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/AbstractRdsConfigProvider.java
@@ -22,6 +22,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.RdsSslMode;
+import com.sequenceiq.cloudbreak.domain.stack.Database;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.view.RdsConfigWithoutCluster;
@@ -31,6 +32,7 @@ import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.cluster.EmbeddedDatabaseService;
 import com.sequenceiq.cloudbreak.service.secret.domain.RotationSecret;
 import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
+import com.sequenceiq.cloudbreak.util.DatabaseParameterFallbackUtil;
 import com.sequenceiq.cloudbreak.util.PasswordUtil;
 import com.sequenceiq.cloudbreak.view.ClusterView;
 import com.sequenceiq.cloudbreak.view.StackView;
@@ -148,7 +150,8 @@ public abstract class AbstractRdsConfigProvider {
             } else {
                 LOGGER.debug("Creating postgres Database for {}", getRdsType().name());
                 String databaseHost = stack.getPrimaryGatewayInstance().getDiscoveryFQDN();
-                newRdsConfig = createNewRdsConfigForEmbeddedDatabase(stack, cluster, databaseHost, getDb(), getDbUser(), getDbPort());
+                newRdsConfig = createNewRdsConfigForEmbeddedDatabase(stack, cluster, DatabaseParameterFallbackUtil.getOrCreateDatabase(stack), databaseHost,
+                        getDb(), getDbUser(), getDbPort());
             }
             populateNewRdsConfig(stack, cluster, newRdsConfig);
         }
@@ -175,7 +178,7 @@ public abstract class AbstractRdsConfigProvider {
             } else {
                 LOGGER.debug("Creating postgres Database for {}", getRdsType().name());
                 String databaseHost = stackDto.getPrimaryGatewayInstance().getDiscoveryFQDN();
-                newRdsConfig = createNewRdsConfigForEmbeddedDatabase(stack, cluster, databaseHost, getDb(), getDbUser(), getDbPort());
+                newRdsConfig = createNewRdsConfigForEmbeddedDatabase(stack, cluster, stackDto.getDatabase(), databaseHost, getDb(), getDbUser(), getDbPort());
             }
             populateNewRdsConfig(stack.getCreator(), stackDto.getWorkspaceId(), cluster.getId(), newRdsConfig);
         }
@@ -197,14 +200,14 @@ public abstract class AbstractRdsConfigProvider {
      * @param dbPort     port for database connections (through gateway)
      * @return RDSConfig object for database
      */
-    private RDSConfig createNewRdsConfigForEmbeddedDatabase(StackView stack, ClusterView cluster, String databaseHost, String dbName, String dbUserName,
-            String dbPort) {
+    private RDSConfig createNewRdsConfigForEmbeddedDatabase(StackView stack, ClusterView cluster, Database database, String databaseHost, String dbName,
+            String dbUserName, String dbPort) {
         RDSConfig rdsConfig = new RDSConfig();
         rdsConfig.setName(getRdsType().name() + '_' + stack.getName() + stack.getId());
         rdsConfig.setConnectionUserName(dbUserName);
         rdsConfig.setConnectionPassword(PasswordUtil.generatePassword());
         rdsConfig.setConnectionURL(String.format("jdbc:postgresql://%s:%s/%s", databaseHost, dbPort, dbName));
-        rdsConfig.setSslMode(RdsSslMode.fromBoolean(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stack, cluster)));
+        rdsConfig.setSslMode(RdsSslMode.fromBoolean(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stack, cluster, database)));
         rdsConfig.setDatabaseEngine(DatabaseVendor.POSTGRES);
         rdsConfig.setType(getRdsType().name());
         rdsConfig.setConnectionDriver(DatabaseVendor.POSTGRES.connectionDriver());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackDtoService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackDtoService.java
@@ -31,6 +31,7 @@ import com.sequenceiq.cloudbreak.domain.Network;
 import com.sequenceiq.cloudbreak.domain.Orchestrator;
 import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
+import com.sequenceiq.cloudbreak.domain.stack.Database;
 import com.sequenceiq.cloudbreak.domain.stack.DnsResolverType;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.StackParameters;
@@ -45,6 +46,7 @@ import com.sequenceiq.cloudbreak.service.gateway.GatewayService;
 import com.sequenceiq.cloudbreak.service.orchestrator.OrchestratorService;
 import com.sequenceiq.cloudbreak.service.resource.ResourceService;
 import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
+import com.sequenceiq.cloudbreak.util.DatabaseParameterFallbackUtil;
 import com.sequenceiq.cloudbreak.view.AvailabilityZoneView;
 import com.sequenceiq.cloudbreak.view.ClusterView;
 import com.sequenceiq.cloudbreak.view.GatewayView;
@@ -176,6 +178,7 @@ public class StackDtoService {
         }
         ClusterView cluster = clusterDtoRepository.findByStackId(stackView.getId()).orElse(null);
         Network network = stackDtoRepository.getNetworkByStackById(stackView.getId()).orElse(null);
+        Database database = createDatabase(stackDtoRepository.getDatabaseByStackById(stackView.getId()).orElse(null), stackView);
         Workspace workspace = workspaceService.getByIdWithoutAuth(stackView.getWorkspaceId());
         Blueprint blueprint = null;
         GatewayView gateway = null;
@@ -202,8 +205,12 @@ public class StackDtoService {
                                     e -> instanceGroups.stream().filter(ig -> ig.getId().equals(e.getKey())).findFirst().get(),
                                     e -> e.getValue().stream().map(AvailabilityZoneView::getAvailabilityZone).collect(Collectors.toList())));
         }
-        return new StackDto(stackView, cluster, network, workspace, workspace.getTenant(), groupListMap, resources, blueprint, gateway,
+        return new StackDto(stackView, cluster, network, database, workspace, workspace.getTenant(), groupListMap, resources, blueprint, gateway,
                 orchestrator, fileSystem, additionalFileSystem, components, parameters, securityConfig, availabilityZonesByStackId);
+    }
+
+    private Database createDatabase(Database database, StackView stack) {
+        return DatabaseParameterFallbackUtil.getOrCreateDatabase(database, stack);
     }
 
     public List<InstanceGroupDto> getInstanceMetadataByInstanceGroup(Long stackId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/UpgradeEmbeddedDBPreparationStateParamsProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/UpgradeEmbeddedDBPreparationStateParamsProvider.java
@@ -28,8 +28,8 @@ public class UpgradeEmbeddedDBPreparationStateParamsProvider {
     private TargetMajorVersion targetMajorVersion;
 
     public Map<String, Object> createParamsForEmbeddedDBUpgradePreparation(StackDto stackDto) {
-        String originalVersion = StringUtils.isNotEmpty(stackDto.getStack().getExternalDatabaseEngineVersion())
-                ? stackDto.getStack().getExternalDatabaseEngineVersion() : DEFAULT_ORIGINAL_POSTGRES_VERSION;
+        String originalVersion = StringUtils.isNotEmpty(stackDto.getDatabase().getExternalDatabaseEngineVersion())
+                ? stackDto.getDatabase().getExternalDatabaseEngineVersion() : DEFAULT_ORIGINAL_POSTGRES_VERSION;
         Map<String, Object> params = new HashMap<>();
         Map<String, Object> postgresParams = new HashMap<>();
         params.put("postgres", postgresParams);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/UpgradeEmbeddedDBStateParamsProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/UpgradeEmbeddedDBStateParamsProvider.java
@@ -32,8 +32,8 @@ public class UpgradeEmbeddedDBStateParamsProvider {
     private TargetMajorVersion targetMajorVersion;
 
     public Map<String, Object> createParamsForEmbeddedDBUpgrade(StackDto stackDto) {
-        String originalVersion = StringUtils.isNotEmpty(stackDto.getStack().getExternalDatabaseEngineVersion())
-                ? stackDto.getStack().getExternalDatabaseEngineVersion() : DEFAULT_ORIGINAL_POSTGRES_VERSION;
+        String originalVersion = StringUtils.isNotEmpty(stackDto.getExternalDatabaseEngineVersion())
+                ? stackDto.getExternalDatabaseEngineVersion() : DEFAULT_ORIGINAL_POSTGRES_VERSION;
         Map<String, Object> params = new HashMap<>();
         Map<String, Object> postgresParams = new HashMap<>();
         params.put("postgres", postgresParams);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/PostgresConfigServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/PostgresConfigServiceTest.java
@@ -89,7 +89,6 @@ class PostgresConfigServiceTest {
     @Test
     void decorateServicePillarWithPostgresIfNeededTestCertsWhenSslDisabledFromDatabaseSslService() {
         Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
-        when(stack.getStack()).thenReturn(new Stack());
         Cluster cluster = new Cluster();
         cluster.setDbSslEnabled(false);
         cluster.setDbSslRootCertBundle(null);
@@ -134,7 +133,6 @@ class PostgresConfigServiceTest {
     void decorateServicePillarWithPostgresWhenReusedDatabaseListWasEmpty() {
         Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
         ReflectionTestUtils.setField(underTest, "databasesReusedDuringRecovery", List.of());
-        when(stack.getStack()).thenReturn(new Stack());
         Cluster cluster = new Cluster();
         cluster.setDbSslEnabled(false);
         when(stack.getCluster()).thenReturn(cluster);
@@ -150,12 +148,9 @@ class PostgresConfigServiceTest {
     void decorateServicePillarWithPostgresWhenReusedDatabaseListIsNotEmpty() {
         Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
         ReflectionTestUtils.setField(underTest, "databasesReusedDuringRecovery", List.of("HIVE"));
-        Stack stackView = new Stack();
-        stackView.setExternalDatabaseEngineVersion(DBVERSION);
-        when(stack.getStack()).thenReturn(stackView);
+        when(stack.getExternalDatabaseEngineVersion()).thenReturn(DBVERSION);
         Cluster cluster = new Cluster();
         cluster.setDbSslEnabled(false);
-        stackView.setCluster(cluster);
         when(stack.getCluster()).thenReturn(cluster);
         when(databaseSslService.getDbSslDetailsForCreationAndUpdateInCluster(stack)).thenReturn(new DatabaseSslDetails(new HashSet<>(), false));
 
@@ -185,14 +180,12 @@ class PostgresConfigServiceTest {
         Set<String> rootCerts = new LinkedHashSet<>();
         rootCerts.add("cert1");
         rootCerts.add("cert2");
-        Stack stackView = new Stack();
-        stackView.setExternalDatabaseEngineVersion(DBVERSION);
         Cluster cluster = new Cluster();
         cluster.setDbSslRootCertBundle(null);
         cluster.setDatabaseServerCrn("crn");
         cluster.setId(CLUSTER_ID);
-        when(stack.getStack()).thenReturn(stackView);
         when(stack.getCluster()).thenReturn(cluster);
+        when(stack.getExternalDatabaseEngineVersion()).thenReturn(DBVERSION);
         when(dbServerConfigurer.isRemoteDatabaseRequested(any())).thenReturn(true);
         when(databaseSslService.getSslCertsFilePath()).thenReturn(SSL_CERTS_FILE_PATH);
         when(databaseSslService.getDbSslDetailsForCreationAndUpdateInCluster(stack)).thenReturn(new DatabaseSslDetails(rootCerts, sslEnabledForStack));
@@ -286,13 +279,11 @@ class PostgresConfigServiceTest {
         Set<String> rootCerts = new LinkedHashSet<>();
         rootCerts.add("cert1");
         rootCerts.add("cert2");
-        Stack stackView = new Stack();
-        stackView.setExternalDatabaseEngineVersion(DBVERSION);
         Cluster cluster = new Cluster();
         cluster.setDbSslRootCertBundle(null);
         cluster.setDatabaseServerCrn("crn");
         cluster.setId(CLUSTER_ID);
-        when(stack.getStack()).thenReturn(stackView);
+        when(stack.getExternalDatabaseEngineVersion()).thenReturn(DBVERSION);
         when(stack.getCluster()).thenReturn(cluster);
         when(dbServerConfigurer.isRemoteDatabaseRequested(any())).thenReturn(true);
         when(databaseSslService.getSslCertsFilePath()).thenReturn(SSL_CERTS_FILE_PATH);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/DatabaseSslServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/DatabaseSslServiceTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -27,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.domain.stack.Database;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.dto.DatabaseSslDetails;
@@ -148,7 +151,7 @@ class DatabaseSslServiceTest {
         assertThat(result.getSslCerts()).isEqualTo(sslCerts);
         assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class), isNull());
         verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
         verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
         verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
@@ -170,7 +173,7 @@ class DatabaseSslServiceTest {
         assertThat(result.getSslCerts()).isEqualTo(sslCerts);
         assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class), isNull());
         verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
         verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
     }
@@ -194,7 +197,7 @@ class DatabaseSslServiceTest {
         assertThat(result.getSslCerts()).isEqualTo(sslCerts);
         assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class), isNull());
         verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
         verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
     }
@@ -204,7 +207,7 @@ class DatabaseSslServiceTest {
         DatabaseSslDetails sslDetails = new DatabaseSslDetails(Set.of(), false);
         when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
         when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
-        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView)).thenReturn(false);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(eq(stackView), eq(clusterView), isNull())).thenReturn(false);
         when(stackView.getType()).thenReturn(StackType.DATALAKE);
         when(clusterView.getId()).thenReturn(CLUSTER_ID);
 
@@ -224,7 +227,7 @@ class DatabaseSslServiceTest {
         DatabaseSslDetails sslDetails = new DatabaseSslDetails(Set.of(), false);
         when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
         when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
-        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView)).thenReturn(false);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView, null)).thenReturn(false);
         when(stackView.getType()).thenReturn(StackType.WORKLOAD);
         when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.empty());
         when(clusterView.getId()).thenReturn(CLUSTER_ID);
@@ -251,7 +254,7 @@ class DatabaseSslServiceTest {
         when(datalakeStack.getCluster()).thenReturn(datalakeCluster);
         when(datalakeCluster.getDatabaseServerCrn()).thenReturn(DATABASE_SERVER_CRN_DATALAKE);
         when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN_DATALAKE)).thenReturn(false);
-        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(datalakeStack, datalakeCluster)).thenReturn(false);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(eq(datalakeStack), eq(datalakeCluster), any())).thenReturn(false);
         when(clusterView.getId()).thenReturn(CLUSTER_ID);
 
         DatabaseSslDetails result = underTest.getDbSslDetailsForCreationAndUpdateInCluster(stackDto);
@@ -280,7 +283,7 @@ class DatabaseSslServiceTest {
         DatabaseSslDetails sslDetails = new DatabaseSslDetails(sslCerts, false);
         when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
         when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
-        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView)).thenReturn(false);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView, null)).thenReturn(false);
         when(stackView.getType()).thenReturn(StackType.WORKLOAD);
         when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.of(datalakeStack));
         when(datalakeStack.getCluster()).thenReturn(datalakeCluster);
@@ -305,7 +308,7 @@ class DatabaseSslServiceTest {
         DatabaseSslDetails sslDetails = new DatabaseSslDetails(sslCerts, false);
         when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
         when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
-        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView)).thenReturn(true);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView, null)).thenReturn(true);
         when(stackView.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
         when(freeipaClientService.getRootCertificateByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(CERT_EMBEDDED);
         when(clusterView.getId()).thenReturn(CLUSTER_ID);
@@ -331,7 +334,7 @@ class DatabaseSslServiceTest {
         DatabaseSslDetails sslDetails = new DatabaseSslDetails(Set.of(), false);
         when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
         when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
-        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView)).thenReturn(true);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView, null)).thenReturn(true);
         when(stackView.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
         when(freeipaClientService.getRootCertificateByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(rootCertificate);
 
@@ -357,7 +360,7 @@ class DatabaseSslServiceTest {
         assertThat(illegalStateException).hasMessage("Mismatching sslDetails.sslEnabledForStack in RedbeamsDbCertificateProvider response. " +
                 "Expecting false because the stack uses an embedded DB, but it was true.");
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class), isNull());
         verify(stackView, never()).getType();
         verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
         verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
@@ -369,13 +372,13 @@ class DatabaseSslServiceTest {
         DatabaseSslDetails sslDetails = new DatabaseSslDetails(Set.of(), false);
         when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
         when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
-        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView)).thenReturn(false);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView, null)).thenReturn(false);
         when(stackView.getType()).thenReturn(StackType.WORKLOAD);
         when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.of(datalakeStack));
         when(datalakeStack.getCluster()).thenReturn(datalakeCluster);
         when(datalakeCluster.getDatabaseServerCrn()).thenReturn(DATABASE_SERVER_CRN_DATALAKE);
         when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN_DATALAKE)).thenReturn(false);
-        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(datalakeStack, datalakeCluster)).thenReturn(true);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(eq(datalakeStack), eq(datalakeCluster), any(Database.class))).thenReturn(true);
         when(stackView.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
         when(freeipaClientService.getRootCertificateByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(CERT_EMBEDDED);
         when(clusterView.getId()).thenReturn(CLUSTER_ID);
@@ -401,7 +404,7 @@ class DatabaseSslServiceTest {
         when(datalakeStack.getCluster()).thenReturn(datalakeCluster);
         when(datalakeCluster.getDatabaseServerCrn()).thenReturn(DATABASE_SERVER_CRN_DATALAKE);
         when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN_DATALAKE)).thenReturn(false);
-        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(datalakeStack, datalakeCluster)).thenReturn(true);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(eq(datalakeStack), eq(datalakeCluster), any(Database.class))).thenReturn(true);
         when(stackView.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
         when(freeipaClientService.getRootCertificateByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(CERT_EMBEDDED);
         when(clusterView.getId()).thenReturn(CLUSTER_ID);
@@ -415,7 +418,7 @@ class DatabaseSslServiceTest {
         assertThat(result.getSslCerts()).contains(CERT_EMBEDDED);
         assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView);
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView, null);
         verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
     }
 
@@ -434,7 +437,7 @@ class DatabaseSslServiceTest {
         assertThat(result.getSslCerts()).isEqualTo(sslCerts);
         assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class), isNull());
         verify(clusterView, never()).getDbSslEnabled();
         verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
         verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
@@ -457,7 +460,7 @@ class DatabaseSslServiceTest {
         assertThat(result.getSslCerts()).isEqualTo(sslCerts);
         assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class), isNull());
         verify(clusterView, never()).getDbSslEnabled();
         verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
         verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
@@ -482,7 +485,7 @@ class DatabaseSslServiceTest {
         assertThat(result.getSslCerts()).isEqualTo(sslCerts);
         assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class), isNull());
         verify(clusterView, never()).getDbSslEnabled();
         verify(datalakeCluster, never()).getDbSslEnabled();
         verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
@@ -506,7 +509,7 @@ class DatabaseSslServiceTest {
         assertThat(result.getSslCerts()).isEmpty();
         assertThat(result.isSslEnabledForStack()).isFalse();
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class), isNull());
         verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
         verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
         verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
@@ -530,7 +533,7 @@ class DatabaseSslServiceTest {
         assertThat(result.getSslCerts()).isEmpty();
         assertThat(result.isSslEnabledForStack()).isFalse();
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class), isNull());
         verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
         verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
     }
@@ -568,7 +571,7 @@ class DatabaseSslServiceTest {
         assertThat(result.getSslCerts()).isEqualTo(sslCerts);
         assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class), isNull());
         verify(clusterView, never()).getDbSslEnabled();
         verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
         verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
@@ -607,7 +610,7 @@ class DatabaseSslServiceTest {
         assertThat(result.getSslCerts()).isEqualTo(sslCerts);
         assertThat(result.isSslEnabledForStack()).isFalse();
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class), isNull());
         verify(datalakeCluster, never()).getDbSslEnabled();
         verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
         verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
@@ -633,7 +636,7 @@ class DatabaseSslServiceTest {
         assertThat(result.getSslCerts()).contains(CERT_EMBEDDED);
         assertThat(result.isSslEnabledForStack()).isTrue();
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class), isNull());
         verify(stackView, never()).getType();
         verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
         verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
@@ -655,7 +658,7 @@ class DatabaseSslServiceTest {
 
         assertThat(illegalStateException).hasMessage("Got a blank FreeIPA root certificate.");
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class), isNull());
         verify(stackView, never()).getType();
         verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
         verify(clusterService, never()).updateDbSslCert(anyLong(), any(DatabaseSslDetails.class));
@@ -673,7 +676,7 @@ class DatabaseSslServiceTest {
         assertThat(illegalStateException).hasMessage("Mismatching sslDetails.sslEnabledForStack in RedbeamsDbCertificateProvider response. " +
                 "Expecting false because the stack uses an embedded DB, but it was true.");
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class), isNull());
         verify(clusterView, never()).getDbSslEnabled();
         verify(stackView, never()).getType();
         verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
@@ -705,7 +708,7 @@ class DatabaseSslServiceTest {
         assertThat(result.getSslCerts()).isEqualTo(Set.of(CERT_EMBEDDED));
         assertThat(result.isSslEnabledForStack()).isFalse();
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class), isNull());
         verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
     }
 
@@ -735,7 +738,7 @@ class DatabaseSslServiceTest {
         assertThat(result.getSslCerts()).contains(CERT_EMBEDDED);
         assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
 
-        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class), isNull());
         verify(clusterView, never()).getDbSslEnabled();
         verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/EmbeddedDatabaseServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/EmbeddedDatabaseServiceTest.java
@@ -36,6 +36,7 @@ import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
 import com.sequenceiq.cloudbreak.domain.VolumeUsageType;
+import com.sequenceiq.cloudbreak.domain.stack.Database;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
@@ -147,7 +148,7 @@ public class EmbeddedDatabaseServiceTest {
         StackView stack = createStackView(1);
         when(cloudParameterCache.isVolumeAttachmentSupported(CLOUDPLATFORM)).thenReturn(true);
         // WHEN
-        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabledByStackView(stack, null);
+        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabledByStackView(stack, null, null);
         // THEN
         assertTrue(actualResult);
     }
@@ -158,7 +159,7 @@ public class EmbeddedDatabaseServiceTest {
         StackView stack = createStackView(0);
         when(cloudParameterCache.isVolumeAttachmentSupported(CLOUDPLATFORM)).thenReturn(false);
         // WHEN
-        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabledByStackView(stack, null);
+        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabledByStackView(stack, null, null);
         // THEN
         assertFalse(actualResult);
     }
@@ -167,9 +168,10 @@ public class EmbeddedDatabaseServiceTest {
     public void testIsEmbeddedDatabaseOnAttachedDiskEnabledByStackViewWhenExternalDBUsed() {
         // GIVEN
         StackView stack = createStackView(0);
-        when(stack.getExternalDatabaseCreationType()).thenReturn(DatabaseAvailabilityType.NON_HA);
+        Database database = new Database();
+        database.setExternalDatabaseAvailabilityType(DatabaseAvailabilityType.NON_HA);
         // WHEN
-        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabledByStackView(stack, null);
+        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabledByStackView(stack, null, database);
         // THEN
         assertFalse(actualResult);
     }
@@ -181,7 +183,7 @@ public class EmbeddedDatabaseServiceTest {
         Cluster cluster = new Cluster();
         cluster.setDatabaseServerCrn("dbcrn");
         // WHEN
-        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabledByStackView(stack, cluster);
+        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabledByStackView(stack, cluster, null);
         // THEN
         assertFalse(actualResult);
     }
@@ -190,9 +192,10 @@ public class EmbeddedDatabaseServiceTest {
     public void testIsEmbeddedDatabaseOnAttachedDiskEnabledByStackViewWhenEmbeddedDbOnRootDisk() {
         // GIVEN
         StackView stack = createStackView(0);
-        when(stack.getExternalDatabaseCreationType()).thenReturn(DatabaseAvailabilityType.ON_ROOT_VOLUME);
+        Database database = new Database();
+        database.setExternalDatabaseAvailabilityType(DatabaseAvailabilityType.ON_ROOT_VOLUME);
         // WHEN
-        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabledByStackView(stack, null);
+        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabledByStackView(stack, null, database);
         // THEN
         assertFalse(actualResult);
     }
@@ -300,7 +303,7 @@ public class EmbeddedDatabaseServiceTest {
         lenient().when(entitlementService.databaseWireEncryptionEnabled(ACCOUNT_ID)).thenReturn(dlEntitlementEnabled);
         lenient().when(entitlementService.databaseWireEncryptionDatahubEnabled(ACCOUNT_ID)).thenReturn(dhEntitlementEnabled);
 
-        assertThat(underTest.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView)).isEqualTo(resultExpected);
+        assertThat(underTest.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView, null)).isEqualTo(resultExpected);
     }
 
     private void isSslEnforcementForEmbeddedDatabaseEnabledTestInternalBlueprintOnly(Optional<Blueprint> blueprintOptional, boolean resultExpected) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/consumption/ConsumptionServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/consumption/ConsumptionServiceTest.java
@@ -291,7 +291,7 @@ class ConsumptionServiceTest {
     private StackDto stackDto(CloudPlatform cloudPlatform, StackType stackType, boolean hasBlueprint, boolean hasBlueprintText) {
         StackView stack = stack(cloudPlatform, stackType);
         Blueprint blueprint = hasBlueprint ? blueprint(hasBlueprintText) : null;
-        return new StackDto(stack, null, null, null, null, null, null, blueprint, null, null, null, null, null, null, null, null);
+        return new StackDto(stack, null, null, null, null, null, null, null, blueprint, null, null, null, null, null, null, null, null);
     }
 
     private Blueprint blueprint(boolean hasBlueprintText) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/AbstractRdsConfigProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/AbstractRdsConfigProviderTest.java
@@ -133,7 +133,7 @@ class AbstractRdsConfigProviderTest {
         when(stackDto.getCluster()).thenReturn(testCluster);
         when(stackDto.getStack()).thenReturn(testStack);
         when(rdsConfigWithoutClusterService.findByClusterId(anyLong())).thenReturn(Set.of(rdsConfigWithoutCluster));
-        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(testStack, testCluster)).thenReturn(sslEnforcement);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(testStack, testCluster, null)).thenReturn(sslEnforcement);
 
         Map<String, Object> result = underTest.createServicePillarConfigMapIfNeeded(stackDto);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/TargetedUpscaleSupportServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/TargetedUpscaleSupportServiceTest.java
@@ -130,6 +130,6 @@ public class TargetedUpscaleSupportServiceTest {
     private StackDto getStackDto() {
         Stack stack = new Stack();
         stack.setResourceCrn(DATAHUB_CRN);
-        return new StackDto(stack, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+        return new StackDto(stack, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/UpgradeEmbeddedDBPreparationStateParamsProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/UpgradeEmbeddedDBPreparationStateParamsProviderTest.java
@@ -13,8 +13,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
+import com.sequenceiq.cloudbreak.domain.stack.Database;
 import com.sequenceiq.cloudbreak.dto.StackDto;
-import com.sequenceiq.cloudbreak.view.StackView;
 
 @ExtendWith(MockitoExtension.class)
 class UpgradeEmbeddedDBPreparationStateParamsProviderTest {
@@ -25,9 +25,9 @@ class UpgradeEmbeddedDBPreparationStateParamsProviderTest {
     @Test
     void testCreateParamsIfDbVersionIsSet() {
         StackDto stackDto = mock(StackDto.class);
-        StackView stackView = mock(StackView.class);
-        when(stackView.getExternalDatabaseEngineVersion()).thenReturn("version");
-        when(stackDto.getStack()).thenReturn(stackView);
+        Database database = new Database();
+        database.setExternalDatabaseEngineVersion("version");
+        when(stackDto.getDatabase()).thenReturn(database);
         ReflectionTestUtils.setField(underTest, "targetMajorVersion", TargetMajorVersion.VERSION_11);
         Map<String, Object> actualResult = underTest.createParamsForEmbeddedDBUpgradePreparation(stackDto);
         Map<String, String> upgradeParams = (Map<String, String>) ((Map<String, Object>) actualResult.get("postgres")).get("upgrade");
@@ -40,8 +40,8 @@ class UpgradeEmbeddedDBPreparationStateParamsProviderTest {
     @Test
     void testCreateParamsIfDbVersionIsNotSet() {
         StackDto stackDto = mock(StackDto.class);
-        StackView stackView = mock(StackView.class);
-        when(stackDto.getStack()).thenReturn(stackView);
+        Database database = new Database();
+        when(stackDto.getDatabase()).thenReturn(database);
         ReflectionTestUtils.setField(underTest, "targetMajorVersion", TargetMajorVersion.VERSION_11);
         Map<String, Object> actualResult = underTest.createParamsForEmbeddedDBUpgradePreparation(stackDto);
         Map<String, String> upgradeParams = (Map<String, String>) ((Map<String, Object>) actualResult.get("postgres")).get("upgrade");

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/UpgradeEmbeddedDBStateParamsProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/UpgradeEmbeddedDBStateParamsProviderTest.java
@@ -14,7 +14,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.cloudbreak.dto.StackDto;
-import com.sequenceiq.cloudbreak.view.StackView;
 
 @ExtendWith(MockitoExtension.class)
 class UpgradeEmbeddedDBStateParamsProviderTest {
@@ -25,9 +24,7 @@ class UpgradeEmbeddedDBStateParamsProviderTest {
     @Test
     void testCreateParamsIfDbVersionIsSet() {
         StackDto stackDto = mock(StackDto.class);
-        StackView stackView = mock(StackView.class);
-        when(stackView.getExternalDatabaseEngineVersion()).thenReturn("version");
-        when(stackDto.getStack()).thenReturn(stackView);
+        when(stackDto.getExternalDatabaseEngineVersion()).thenReturn("version");
         ReflectionTestUtils.setField(underTest, "targetMajorVersion", TargetMajorVersion.VERSION_11);
         Map<String, Object> actualResult = underTest.createParamsForEmbeddedDBUpgrade(stackDto);
         Map<String, String> upgradeParams = (Map<String, String>) ((Map<String, Object>) actualResult.get("postgres")).get("upgrade");
@@ -40,8 +37,6 @@ class UpgradeEmbeddedDBStateParamsProviderTest {
     @Test
     void testCreateParamsIfDbVersionIsNotSet() {
         StackDto stackDto = mock(StackDto.class);
-        StackView stackView = mock(StackView.class);
-        when(stackDto.getStack()).thenReturn(stackView);
         ReflectionTestUtils.setField(underTest, "targetMajorVersion", TargetMajorVersion.VERSION_11);
         Map<String, Object> actualResult = underTest.createParamsForEmbeddedDBUpgrade(stackDto);
         Map<String, String> upgradeParams = (Map<String, String>) ((Map<String, Object>) actualResult.get("postgres")).get("upgrade");

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/database/DatabaseParameterFallbackUtil.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/database/DatabaseParameterFallbackUtil.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.datalake.service.sdx.database;
 
+import java.util.Optional;
+
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.entity.SdxDatabase;
@@ -38,7 +40,18 @@ public class DatabaseParameterFallbackUtil {
     }
 
     public static String getDatabaseEngineVersion(SdxDatabase sdxDatabase, String fallbackDatabaseEngineVersion) {
-        return sdxDatabase != null ? sdxDatabase.getDatabaseEngineVersion() : fallbackDatabaseEngineVersion;
+        String result;
+        if (sdxDatabase != null) {
+            String dbEngineVersion = Optional.of(sdxDatabase).map(SdxDatabase::getDatabaseEngineVersion).orElse("");
+            if (fallbackDatabaseEngineVersion != null && !dbEngineVersion.equals(fallbackDatabaseEngineVersion)) {
+                result = fallbackDatabaseEngineVersion;
+            } else {
+                result = dbEngineVersion;
+            }
+        } else {
+            result = fallbackDatabaseEngineVersion;
+        }
+        return result;
     }
 
     public static boolean isCreateDatabase(SdxDatabase sdxDatabase, boolean fallbackCreateDatabase) {

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/database/DatabaseParameterFallbackUtilTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/database/DatabaseParameterFallbackUtilTest.java
@@ -44,7 +44,7 @@ public class DatabaseParameterFallbackUtilTest {
         SdxDatabase sdxDatabase = new SdxDatabase();
         sdxDatabase.setDatabaseEngineVersion("2.0");
         String fallbackDatabaseEngineVersion = "fallback2.0";
-        assertEquals("2.0", DatabaseParameterFallbackUtil.getDatabaseEngineVersion(sdxDatabase, fallbackDatabaseEngineVersion));
+        assertEquals("fallback2.0", DatabaseParameterFallbackUtil.getDatabaseEngineVersion(sdxDatabase, fallbackDatabaseEngineVersion));
         assertEquals(fallbackDatabaseEngineVersion, DatabaseParameterFallbackUtil.getDatabaseEngineVersion(null, fallbackDatabaseEngineVersion));
     }
 


### PR DESCRIPTION
CB-22198 Fix create external db in 2.73 -> upgrade on 2.72 -> back to 2.73: upgrade is needed again

The issue:
* In case of external database creation is happening on 2.73, the new Database entity will be created in cbdb.
* If we upgrade this database on 2.72 branch, the database entity won't be updated, the upgrade will be successful
* If we switch back to 2.73, cloudbreak will check the database entity, but it won't contain the right version

The fix:
If the db version is set in stack and database entity as well and they are not equal, the db version will be from stack

This fix is needed because of backward compatibiltiy and will be removed with this 2 jira ticket: CB-21369, CB-22002
