### PR TITLE
CB-22257 Load balancer metadata validation before persist

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/LoadBalancerMetadataHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/LoadBalancerMetadataHandler.java
@@ -1,12 +1,9 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer.handler;
 
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -19,7 +16,6 @@ import com.sequenceiq.cloudbreak.eventbus.Event;
 import com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer.LoadBalancerMetadataFailure;
 import com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer.LoadBalancerMetadataRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer.LoadBalancerMetadataSuccess;
-import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.service.stack.flow.MetadataSetupService;
 import com.sequenceiq.cloudbreak.view.StackView;
@@ -61,16 +57,6 @@ public class LoadBalancerMetadataHandler extends ExceptionCatcherEventHandler<Lo
             List<CloudLoadBalancerMetadata> loadBalancerStatuses = loadBalancerMetadataService.collectMetadata(cloudContext,
                 request.getCloudCredential(), request.getTypesPresentInStack(), request.getCloudResources());
 
-            Set<CloudLoadBalancerMetadata> failedStatues = loadBalancerStatuses.stream()
-                .filter(this::isMissingMetadata)
-                .collect(Collectors.toSet());
-            if (!failedStatues.isEmpty()) {
-                Set<String> names = failedStatues.stream()
-                    .map(CloudLoadBalancerMetadata::getName)
-                    .collect(Collectors.toSet());
-                throw new CloudbreakException("Creation failed for load balancers: " + names);
-            }
-
             LOGGER.info("Persisting load balancer metadata to the database: {}", loadBalancerStatuses);
             metadataSetupService.saveLoadBalancerMetadata(stack, loadBalancerStatuses);
 
@@ -80,11 +66,5 @@ public class LoadBalancerMetadataHandler extends ExceptionCatcherEventHandler<Lo
             LOGGER.warn("Failed to fetch cloud load balancer metadata.", e);
             return new LoadBalancerMetadataFailure(request.getResourceId(), e);
         }
-    }
-
-    private boolean isMissingMetadata(CloudLoadBalancerMetadata metadataStatus) {
-        return metadataStatus.getType() == null ||
-            !(StringUtils.isNotEmpty(metadataStatus.getIp()) ||
-            StringUtils.isNotEmpty(metadataStatus.getCloudDns()) && StringUtils.isNotEmpty(metadataStatus.getHostedZoneId()));
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupServiceTest.java
@@ -612,6 +612,22 @@ class MetadataSetupServiceTest {
         assertEquals(gw2DiscoveryFQDN, gws.get(0).getDiscoveryFQDN());
     }
 
+    @Test
+    void testLoadBalancerMetadataValidation() {
+        StackIdView stackIdView = new StackIdViewImpl(STACK_ID, STACK_NAME, "no");
+        Iterable<CloudLoadBalancerMetadata> cloudLoadBalancerMetadata =
+                List.of(CloudLoadBalancerMetadata
+                        .builder()
+                        .withName("LoadBalancerTest")
+                        .withType(LoadBalancerType.PUBLIC)
+                        .build());
+
+        CloudbreakServiceException thrown = assertThrows(CloudbreakServiceException.class,
+                () -> underTest.saveLoadBalancerMetadata(stack, cloudLoadBalancerMetadata));
+
+        assertEquals("Load balancer metadata collection failed", thrown.getMessage());
+    }
+
     private Image createImage() {
         return new Image(null, null, null, null, null, null, "image-id", null);
     }


### PR DESCRIPTION
Context: Metadata wasn't being validated in the create stack workflow. Validation moved to Metadata service to ensure the data will be validated before persists for all cases.

Test:
An exception was thrown during metadata collection and the load balancer wasn't created with inconsistent data.
Tested with public/private/gateway_private/outbound LB 