### PR TITLE
CB-22251 CB core doesn't wait for FreeIPA cleanup

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/freeipa/FreeIpaCleanupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/freeipa/FreeIpaCleanupService.java
@@ -50,7 +50,7 @@ public class FreeIpaCleanupService {
 
     private static final int POLL_INTERVAL = 5000;
 
-    private static final int WAIT_SEC = 600;
+    private static final int WAIT_SEC = 3600;
 
     private static final Set<CleanupStep> STEPS_TO_SKIP_ON_RECOVER = Set.of(REMOVE_HOSTS, REMOVE_VAULT_ENTRIES, REMOVE_USERS, REMOVE_ROLES);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/CleanupFreeIpaHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/CleanupFreeIpaHandlerTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster;
 
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationEvent.CLEANUP_FREEIPA_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationEvent.CLEANUP_FREEIPA_FINISHED_EVENT;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -81,7 +82,7 @@ class CleanupFreeIpaHandlerTest {
 
         underTest.accept(cleanupFreeIpaEvent);
 
-        verify(eventBus).notify(eq(CLEANUP_FREEIPA_FINISHED_EVENT.event()), any(Event.class));
+        verify(eventBus).notify(eq(CLEANUP_FREEIPA_FAILED_EVENT.event()), any(Event.class));
     }
 
     @Test
@@ -93,6 +94,6 @@ class CleanupFreeIpaHandlerTest {
 
         underTest.accept(cleanupFreeIpaEvent);
 
-        verify(eventBus).notify(eq(CLEANUP_FREEIPA_FINISHED_EVENT.event()), any(Event.class));
+        verify(eventBus).notify(eq(CLEANUP_FREEIPA_FAILED_EVENT.event()), any(Event.class));
     }
 }


### PR DESCRIPTION
Increase the timeout to one hour on CB side.
In case of failure/timeout do not proceed with the upscale/provision. If the issue is intermittent, retry would work for these cases too.

See detailed description in the commit message.