### PR TITLE
CB-22187 Fix DB SSL for old NiFi Registry versions

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -92,6 +92,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CFM_VERSION_2_2_3_0 = () -> "2.2.3.0";
 
+    public static final Versioned CFM_VERSION_2_2_6_200 = () -> "2.2.6.200";
+
     public static final Versioned FLINK_VERSION_1_15_1 = () -> "1.15.1";
 
     public static final Versioned CDPD_VERSION_7_2_11 = () -> "7.2.11";

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/BlueprintView.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/BlueprintView.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.template.BlueprintProcessingException;
 import com.sequenceiq.cloudbreak.template.processor.BlueprintTextProcessor;
 
@@ -90,7 +89,6 @@ public class BlueprintView {
         return componentsByHostGroup;
     }
 
-    @VisibleForTesting
     public BlueprintTextProcessor getProcessor() {
         return processor;
     }


### PR DESCRIPTION
* [CFM-3228](https://jira.cloudera.com/browse/CFM-3228) made some improvements to NiFi Registry so that it employs a more up-to-date PostgreSQL JDBC driver; see CFM 2.2.6.200 (for CDH 7.2.16.p200) and 2.2.7.0 (for CDH 7.2.17.p0). This commit fixes the behavior of earlier NiFi Registry versions that do not contain the aforementioned change.
  * CFM parcel versions < 2.2.6.200: Use `sslmode=require`.
  * CFM parcel versions >= 2.2.6.200: No change, keep using `sslmode=verify-full`.
  * Applicable to all cloud providers, external and embedded DB servers.
* Some code cleanup.
* Testing:
  * Manual test with DH using multiple runtimes: 7.2.15.p100, 7.2.16.p200, 7.2.17.p0.
  * Added new UT & adapted existing ones.
