### PR TITLE
CB-21683 RDS root password rotation improvements

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/CMUserRotationExecutor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/CMUserRotationExecutor.java
@@ -36,7 +36,7 @@ public class CMUserRotationExecutor implements RotationExecutor<CMUserRotationCo
 
     @Override
     public void rotate(CMUserRotationContext rotationContext) throws Exception {
-        LOGGER.info("Starting rotation of CM user for resource {} by creating a new user.", rotationContext.getResourceCrn());
+        LOGGER.info("Starting rotation of CM user by creating a new user.");
         RotationSecret userRotationSecret = secretService.getRotation(rotationContext.getUserSecret());
         RotationSecret passwordRotationSecret = secretService.getRotation(rotationContext.getPasswordSecret());
         if (userRotationSecret.isRotation() && passwordRotationSecret.isRotation()) {
@@ -56,7 +56,7 @@ public class CMUserRotationExecutor implements RotationExecutor<CMUserRotationCo
 
     @Override
     public void rollback(CMUserRotationContext rotationContext) {
-        LOGGER.info("Starting to rollback rotation of CM user for resource {} by deleting the new user", rotationContext.getResourceCrn());
+        LOGGER.info("Starting to rollback rotation of CM user by deleting the new user");
         RotationSecret userRotationSecret = secretService.getRotation(rotationContext.getUserSecret());
         if (userRotationSecret.isRotation()) {
             deleteUser(userRotationSecret.getSecret(), rotationContext);
@@ -67,7 +67,7 @@ public class CMUserRotationExecutor implements RotationExecutor<CMUserRotationCo
 
     @Override
     public void finalize(CMUserRotationContext rotationContext) {
-        LOGGER.info("Finalizing rotation of CM user for resource {} by deleting the old user", rotationContext.getResourceCrn());
+        LOGGER.info("Finalizing rotation of CM user by deleting the old user");
         RotationSecret userRotationSecret = secretService.getRotation(rotationContext.getUserSecret());
         if (userRotationSecret.isRotation()) {
             deleteUser(userRotationSecret.getBackupSecret(), rotationContext);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/ClusterProxyRotationExecutor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/ClusterProxyRotationExecutor.java
@@ -27,14 +27,14 @@ public class ClusterProxyRotationExecutor implements RotationExecutor<ClusterPro
 
     @Override
     public void rotate(ClusterProxyRotationContext rotationContext) {
-        LOGGER.info("Reregistring stack {} in cluster proxy for secret rotation.", rotationContext.getResourceCrn());
+        LOGGER.info("Reregistring stack in cluster proxy for secret rotation.");
         StackDto stackDto = stackDtoService.getByCrn(rotationContext.getResourceCrn());
         clusterProxyService.reRegisterCluster(stackDto.getId());
     }
 
     @Override
     public void rollback(ClusterProxyRotationContext rotationContext) {
-        LOGGER.info("Reregistring stack {} in cluster proxy for rollback of secret rotation.", rotationContext.getResourceCrn());
+        LOGGER.info("Reregistring stack in cluster proxy for rollback of secret rotation.");
         StackDto stackDto = stackDtoService.getByCrn(rotationContext.getResourceCrn());
         clusterProxyService.reRegisterCluster(stackDto.getId());
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/RedbeamsPollerRotationExecutor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/RedbeamsPollerRotationExecutor.java
@@ -32,29 +32,26 @@ public class RedbeamsPollerRotationExecutor implements RotationExecutor<PollerRo
 
     @Override
     public void rotate(PollerRotationContext rotationContext) {
-        LOGGER.info("Rotate redbeams secret started for {}", rotationContext.getResourceCrn());
+        LOGGER.info("Rotate redbeams secret: {}", rotationContext.getSecretType());
         StackDto stackDto = getStackDto(rotationContext.getResourceCrn());
         externalDatabaseService.rotateDatabaseSecret(stackDto.getCluster().getDatabaseServerCrn(),
                 (RedbeamsSecretType) rotationContext.getSecretType(), ROTATE);
-        LOGGER.info("Rotate redbeams secret finished for {}", rotationContext.getResourceCrn());
     }
 
     @Override
     public void rollback(PollerRotationContext rotationContext) {
-        LOGGER.info("Rollback redbeams secret started for {}", rotationContext.getResourceCrn());
+        LOGGER.info("Rollback redbeams secret: {}", rotationContext.getSecretType());
         StackDto stackDto = getStackDto(rotationContext.getResourceCrn());
         externalDatabaseService.rotateDatabaseSecret(stackDto.getCluster().getDatabaseServerCrn(),
                 (RedbeamsSecretType) rotationContext.getSecretType(), ROLLBACK);
-        LOGGER.info("Rollback redbeams secret finished for {}", rotationContext.getResourceCrn());
     }
 
     @Override
     public void finalize(PollerRotationContext rotationContext) {
-        LOGGER.info("Finalize redbeams secret started for {}", rotationContext.getResourceCrn());
+        LOGGER.info("Finalize redbeams secret: {}", rotationContext.getSecretType());
         StackDto stackDto = getStackDto(rotationContext.getResourceCrn());
         externalDatabaseService.rotateDatabaseSecret(stackDto.getCluster().getDatabaseServerCrn(),
                 (RedbeamsSecretType) rotationContext.getSecretType(), FINALIZE);
-        LOGGER.info("Finalize redbeams secret finished for {}", rotationContext.getResourceCrn());
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/SaltPillarRotationExecutor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/rotation/executor/SaltPillarRotationExecutor.java
@@ -44,24 +44,23 @@ public class SaltPillarRotationExecutor implements RotationExecutor<SaltPillarRo
         updateSaltPillar(rotationContext, "rotation");
     }
 
-    private void updateSaltPillar(SaltPillarRotationContext rotationContext, String rotationState) throws CloudbreakOrchestratorFailedException {
-        LOGGER.debug("Salt pillar {} for {}", rotationState, rotationContext.getResourceCrn());
-        StackDto stackDto = stackDtoService.getByCrn(rotationContext.getResourceCrn());
-        Map<String, SaltPillarProperties> servicePillar = rotationContext.getServicePillarGenerator().apply(rotationContext.getResourceCrn());
-        hostOrchestrator.saveCustomPillars(new SaltConfig(servicePillar),
-                new ClusterDeletionBasedExitCriteriaModel(stackDto.getId(), stackDto.getCluster().getId()),
-                saltStateParamsService.createStateParams(stackDto, null, true, MAX_RETRY, MAX_RETRY_ON_ERROR));
-        LOGGER.debug("Salt pillar {} finished for {}", rotationState, rotationContext.getResourceCrn());
-    }
-
     @Override
     public void rollback(SaltPillarRotationContext rotationContext) throws Exception {
         updateSaltPillar(rotationContext, "rollback");
     }
 
+    private void updateSaltPillar(SaltPillarRotationContext rotationContext, String rotationState) throws CloudbreakOrchestratorFailedException {
+        StackDto stackDto = stackDtoService.getByCrn(rotationContext.getResourceCrn());
+        Map<String, SaltPillarProperties> servicePillar = rotationContext.getServicePillarGenerator().apply(rotationContext.getResourceCrn());
+        LOGGER.info("Salt pillar {}, keys: {}", rotationState, servicePillar.keySet());
+        hostOrchestrator.saveCustomPillars(new SaltConfig(servicePillar),
+                new ClusterDeletionBasedExitCriteriaModel(stackDto.getId(), stackDto.getCluster().getId()),
+                saltStateParamsService.createStateParams(stackDto, null, true, MAX_RETRY, MAX_RETRY_ON_ERROR));
+    }
+
     @Override
     public void finalize(SaltPillarRotationContext rotationContext) {
-        LOGGER.debug("Finalize salt pillar for {}", rotationContext.getResourceCrn());
+        LOGGER.info("Finalize salt pillar rotation, nothing to do.");
     }
 
     @Override

--- a/core/src/test/java/com/sequenceiq/cloudbreak/rotation/executor/SaltPillarRotationExecutorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/rotation/executor/SaltPillarRotationExecutorTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Assertions;
@@ -70,6 +71,7 @@ class SaltPillarRotationExecutorTest {
         when(stackDto.getCluster()).thenReturn(cluster);
         when(stackDtoService.getByCrn(RESOURCE_CRN)).thenReturn(stackDto);
         Function saltPillarGenerator = mock(Function.class);
+        when(saltPillarGenerator.apply(any())).thenReturn(new HashMap<>());
         doThrow(new RuntimeException("error")).when(hostOrchestrator)
                 .saveCustomPillars(any(), any(), any());
         SecretRotationException secretRotationException = assertThrows(SecretRotationException.class,
@@ -88,6 +90,7 @@ class SaltPillarRotationExecutorTest {
         when(stackDto.getCluster()).thenReturn(cluster);
         when(stackDtoService.getByCrn(RESOURCE_CRN)).thenReturn(stackDto);
         Function saltPillarGenerator = mock(Function.class);
+        when(saltPillarGenerator.apply(any())).thenReturn(new HashMap<>());
         underTest.executeRotate(new SaltPillarRotationContext(RESOURCE_CRN, saltPillarGenerator));
         verify(hostOrchestrator, times(1)).saveCustomPillars(any(), any(), any());
         verify(saltStateParamsService, times(1)).createStateParams(eq(stackDto), isNull(), eq(true), anyInt(), anyInt());
@@ -102,6 +105,7 @@ class SaltPillarRotationExecutorTest {
         when(stackDto.getCluster()).thenReturn(cluster);
         when(stackDtoService.getByCrn(RESOURCE_CRN)).thenReturn(stackDto);
         Function saltPillarGenerator = mock(Function.class);
+        when(saltPillarGenerator.apply(any())).thenReturn(new HashMap<>());
         underTest.executeRollback(new SaltPillarRotationContext(RESOURCE_CRN, saltPillarGenerator));
         verify(hostOrchestrator, times(1)).saveCustomPillars(any(), any(), any());
         verify(saltStateParamsService, times(1)).createStateParams(eq(stackDto), isNull(), eq(true), anyInt(), anyInt());

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/rotation/CloudbreakPollerRotationExecutor.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/rotation/CloudbreakPollerRotationExecutor.java
@@ -26,23 +26,20 @@ public class CloudbreakPollerRotationExecutor implements RotationExecutor<Poller
 
     @Override
     public void rotate(PollerRotationContext rotationContext) {
-        LOGGER.info("Rotate cloudbreak secret started for {}", rotationContext.getResourceCrn());
+        LOGGER.info("Rotate cloudbreak secret: {}", rotationContext.getSecretType());
         sdxRotationService.rotateCloudbreakSecret(rotationContext.getResourceCrn(), (CloudbreakSecretType) rotationContext.getSecretType(), ROTATE);
-        LOGGER.info("Rotate cloudbreak secret finished for {}", rotationContext.getResourceCrn());
     }
 
     @Override
     public void rollback(PollerRotationContext rotationContext) {
-        LOGGER.info("Rollback cloudbreak secret started for {}", rotationContext.getResourceCrn());
+        LOGGER.info("Rollback cloudbreak secret: {}", rotationContext.getSecretType());
         sdxRotationService.rotateCloudbreakSecret(rotationContext.getResourceCrn(), (CloudbreakSecretType) rotationContext.getSecretType(), ROLLBACK);
-        LOGGER.info("Rollback cloudbreak secret finished for {}", rotationContext.getResourceCrn());
     }
 
     @Override
     public void finalize(PollerRotationContext rotationContext) {
-        LOGGER.info("Finalize cloudbreak secret started for {}", rotationContext.getResourceCrn());
+        LOGGER.info("Finalize cloudbreak secret: {}", rotationContext.getSecretType());
         sdxRotationService.rotateCloudbreakSecret(rotationContext.getResourceCrn(), (CloudbreakSecretType) rotationContext.getSecretType(), FINALIZE);
-        LOGGER.info("Finalize cloudbreak secret finished for {}", rotationContext.getResourceCrn());
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/rotation/RedbeamsPollerRotationExecutor.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/rotation/RedbeamsPollerRotationExecutor.java
@@ -26,23 +26,20 @@ public class RedbeamsPollerRotationExecutor implements RotationExecutor<PollerRo
 
     @Override
     public void rotate(PollerRotationContext rotationContext) {
-        LOGGER.info("Rotate redbeams secret started for {}", rotationContext.getResourceCrn());
+        LOGGER.info("Rotate redbeams secret: {}", rotationContext.getSecretType());
         sdxRotationService.rotateRedbeamsSecret(rotationContext.getResourceCrn(), (RedbeamsSecretType) rotationContext.getSecretType(), ROTATE);
-        LOGGER.info("Rotate redbeams secret finished for {}", rotationContext.getResourceCrn());
     }
 
     @Override
     public void rollback(PollerRotationContext rotationContext) {
-        LOGGER.info("Rollback redbeams secret started for {}", rotationContext.getResourceCrn());
+        LOGGER.info("Rollback redbeams secret: {}", rotationContext.getSecretType());
         sdxRotationService.rotateRedbeamsSecret(rotationContext.getResourceCrn(), (RedbeamsSecretType) rotationContext.getSecretType(), ROLLBACK);
-        LOGGER.info("Rollback redbeams secret finished for {}", rotationContext.getResourceCrn());
     }
 
     @Override
     public void finalize(PollerRotationContext rotationContext) {
-        LOGGER.info("Finalize redbeams secret started for {}", rotationContext.getResourceCrn());
+        LOGGER.info("Finalize redbeams secret: {}", rotationContext.getSecretType());
         sdxRotationService.rotateRedbeamsSecret(rotationContext.getResourceCrn(), (RedbeamsSecretType) rotationContext.getSecretType(), FINALIZE);
-        LOGGER.info("Finalize redbeams secret finished for {}", rotationContext.getResourceCrn());
     }
 
     @Override


### PR DESCRIPTION
- Skip throwing an exception in Redbeams during rollback when secrets are not in rotation state (it can happen when root password rotation fails before the Vault step)
- Remove unnecessary logs and resourceCrn from log messages, because MDC context should hold the related resourceCrn

See detailed description in the commit message.