### PR TITLE
CDPSDX-4175 Add "/backups" to both backup & restore location on RAZ r…

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/DatalakeBackupActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/DatalakeBackupActions.java
@@ -47,7 +47,6 @@ import com.sequenceiq.datalake.service.sdx.dr.SdxBackupRestoreService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.flow.core.Flow;
 import com.sequenceiq.sdx.api.model.DatalakeDatabaseDrStatus;
-import com.sequenceiq.sdx.api.model.SdxDatabaseBackupRequest;
 import com.sequenceiq.sdx.api.model.SdxDatabaseBackupStatusResponse;
 
 @Configuration
@@ -148,16 +147,11 @@ public class DatalakeBackupActions {
 
             @Override
             protected void doExecute(SdxContext context, DatalakeDatabaseBackupStartEvent payload, Map<Object, Object> variables) {
-                SdxCluster sdxCluster = sdxService.getById(payload.getResourceId());
-                String backupLocation = sdxBackupRestoreService.modifyBackupLocation(sdxCluster, payload.getBackupRequest().getBackupLocation());
-                SdxDatabaseBackupRequest sdxDatabaseBackupRequest = payload.getBackupRequest();
-                sdxDatabaseBackupRequest.setBackupLocation(backupLocation);
                 LOGGER.info("Datalake database backup has been started for {} with backup location {}", payload.getResourceId(),
-                        sdxDatabaseBackupRequest.getBackupLocation());
+                        payload.getBackupRequest().getBackupLocation());
 
-                sdxBackupRestoreService.databaseBackup(payload.getDrStatus(),
-                        payload.getResourceId(),
-                        sdxDatabaseBackupRequest);
+                sdxBackupRestoreService.databaseBackup(payload.getDrStatus(), payload.getResourceId(),
+                        payload.getBackupRequest());
                 variables.put(DATABASE_MAX_DURATION_IN_MIN, payload.getBackupRequest().getDatabaseMaxDurationInMin());
                 sendEvent(context, DATALAKE_DATABASE_BACKUP_IN_PROGRESS_EVENT.event(), payload);
             }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/DatalakeRestoreActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/DatalakeRestoreActions.java
@@ -180,7 +180,8 @@ public class DatalakeRestoreActions {
             @Override
             protected void doExecute(SdxContext context, DatalakeDatabaseRestoreStartEvent payload, Map<Object, Object> variables) {
                 if (payload.getBackupLocation() != null) {
-                    LOGGER.info("Datalake database restore has been started for {}", payload.getResourceId());
+                    LOGGER.info("Datalake database restore has been started for {} with backup location {}", payload.getResourceId(),
+                            payload.getBackupLocation());
                     sdxBackupRestoreService.databaseRestore(payload.getDrStatus(),
                             payload.getResourceId(),
                             payload.getBackupId(),

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
@@ -812,6 +812,7 @@ public class SdxBackupRestoreService {
         if (requireNonEmptyPath && cluster.isRangerRazEnabled()) {
             backupLocation = appendBackupsIfRootLocation(backupLocation);
         }
+        LOGGER.info("Backup location after potential modification is: {}", backupLocation);
         return backupLocation;
     }
 
@@ -827,9 +828,11 @@ public class SdxBackupRestoreService {
         try {
             URI uri = new URI(backupLocation);
             if (Strings.isNullOrEmpty(uri.getPath())) {
+                LOGGER.info("Append '/backups' to backup location {}", backupLocation);
                 return backupLocation + "/backups";
             }
             if ("/".equals(uri.getPath())) {
+                LOGGER.info("Append 'backups' to backup location {}", backupLocation);
                 return backupLocation + "backups";
             }
         } catch (URISyntaxException e) {


### PR DESCRIPTION
…oot dir
JIRA:[CDPSDX-4175](https://jira.cloudera.com/browse/CDPSDX-4175)

ISSUE & SOLUTION: We fixed the upgrade/resize database backup location issue on RAZ root dir using [CB-21778](https://jira.cloudera.com/browse/CB-21778) but we didn't fix that location when resize is doing restore. This PR is fixing that (as well as change the place where we fix that issue for backup so the change is made earlier and would work for both backup and restore).

**BEFORE:** resize restore failed
![Screen Shot 2023-06-23 at 12 04 43 PM](https://github.com/hortonworks/cloudbreak/assets/39275944/71d96ece-116a-415e-b30c-72e41cdb7d96)

**AFTER:** resize backup & restore succeed. upgrade backup works still. (I hardcoded to only keep backup/restore in the flowchain)
Resize backup and restore:
![Screen Shot 2023-06-23 at 11 41 48 AM](https://github.com/hortonworks/cloudbreak/assets/39275944/036f8aae-5b59-4d2c-88dd-ef5a9759c3f9)

Upgrade backup:
![Screen Shot 2023-06-23 at 11 38 08 AM](https://github.com/hortonworks/cloudbreak/assets/39275944/45d79eeb-aa12-465e-b222-ebae86dc9aa4)

