### PR TITLE
CB-22268 adding other gateways as well as the primary gateway to the knox_proxyhosts ServiceConfig

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.cloudbreak.common.type.CloudConstants.AZURE;
 import static com.sequenceiq.cloudbreak.common.type.CloudConstants.GCP;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -90,6 +91,7 @@ import com.sequenceiq.cloudbreak.util.StackUtil;
 import com.sequenceiq.cloudbreak.view.ClusterView;
 import com.sequenceiq.cloudbreak.view.GatewayView;
 import com.sequenceiq.cloudbreak.view.InstanceGroupView;
+import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
 import com.sequenceiq.cloudbreak.view.StackView;
 import com.sequenceiq.common.api.backup.response.BackupResponse;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
@@ -411,6 +413,10 @@ public class StackToTemplatePreparationObjectConverter {
             Optional<String> instanceDiscoveryFQDN = generalClusterConfigs.getPrimaryGatewayInstanceDiscoveryFQDN();
             if (instanceDiscoveryFQDN.isEmpty()) {
                 generalClusterConfigs.setPrimaryGatewayInstanceDiscoveryFQDN(Optional.of(stack.getPrimaryGatewayInstance().getDiscoveryFQDN()));
+                List<InstanceMetadataView> otherInstanceMetadata = new ArrayList<>(stack.getAllAvailableGatewayInstances());
+                otherInstanceMetadata.remove(stack.getPrimaryGatewayInstance());
+                generalClusterConfigs.setOtherGatewayInstancesDiscoveryFQDN(otherInstanceMetadata.stream()
+                        .map(im -> im.getDiscoveryFQDN()).collect(Collectors.toSet()));
             }
         }
         generalClusterConfigs.setLoadBalancerGatewayFqdn(Optional.ofNullable(loadBalancerFqdnUtil.getLoadBalancerUserFacingFQDN(source.getId())));

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProvider.java
@@ -107,6 +107,7 @@ public class HueConfigProvider extends AbstractRdsRoleConfigProvider {
             Set<String> proxyHosts = new LinkedHashSet<>();
             if (generalClusterConfigs.getPrimaryGatewayInstanceDiscoveryFQDN().isPresent()) {
                 proxyHosts.add(generalClusterConfigs.getPrimaryGatewayInstanceDiscoveryFQDN().get());
+                proxyHosts.addAll(generalClusterConfigs.getOtherGatewayInstancesDiscoveryFQDN());
             }
             if (StringUtils.isNotEmpty(generalClusterConfigs.getExternalFQDN())) {
                 proxyHosts.add(generalClusterConfigs.getExternalFQDN());

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/general/GeneralClusterConfigsProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/general/GeneralClusterConfigsProvider.java
@@ -1,7 +1,10 @@
 package com.sequenceiq.cloudbreak.cmtemplate.general;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
@@ -44,6 +47,8 @@ public class GeneralClusterConfigsProvider {
         generalClusterConfigs.setCloudbreakAmbariPassword(cluster.getCloudbreakAmbariPassword());
         generalClusterConfigs.setNodeCount(stack.getFullNodeCount().intValue());
         generalClusterConfigs.setPrimaryGatewayInstanceDiscoveryFQDN(Optional.ofNullable(stack.getPrimaryGatewayInstance().getDiscoveryFQDN()));
+        generalClusterConfigs.setOtherGatewayInstancesDiscoveryFQDN(
+                getOtherGatewayInstancesFqdns(stack.getPrimaryGatewayInstance(), stack.getAllAvailableGatewayInstances()));
         generalClusterConfigs.setVariant(cluster.getVariant());
         generalClusterConfigs.setAutoTlsEnabled(cluster.getAutoTlsEnabled());
         boolean userFacingCertHasBeenGenerated = StringUtils.isNotEmpty(stack.getSecurityConfig().getUserFacingKey())
@@ -86,5 +91,11 @@ public class GeneralClusterConfigsProvider {
         generalClusterConfigs.setAutoTlsEnabled(autoTlsEnabled);
         generalClusterConfigs.setGovCloud(credential.isGovCloud());
         return generalClusterConfigs;
+    }
+
+    private Set<String> getOtherGatewayInstancesFqdns(InstanceMetadataView primaryGateway, List<InstanceMetadataView> allInstancesMetadata) {
+        List<InstanceMetadataView> otherInstanceMetadata = new ArrayList<>(allInstancesMetadata);
+        otherInstanceMetadata.remove(primaryGateway);
+        return otherInstanceMetadata.stream().map(im -> im.getDiscoveryFQDN()).collect(Collectors.toSet());
     }
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProviderTest.java
@@ -203,6 +203,7 @@ public class HueConfigProviderTest {
         generalClusterConfigs.setExternalFQDN(expectedExternalFQDN);
         generalClusterConfigs.setKnoxUserFacingCertConfigured(true);
         generalClusterConfigs.setPrimaryGatewayInstanceDiscoveryFQDN(Optional.of(expectedInternalFQDN));
+        generalClusterConfigs.setOtherGatewayInstancesDiscoveryFQDN(Set.of(expectedInternalFQDN));
 
         TemplatePreparationObject tpo = new Builder()
                 .withGeneralClusterConfigs(generalClusterConfigs)
@@ -251,10 +252,12 @@ public class HueConfigProviderTest {
 
         String expectedExternalFQDN = "myaddress.cloudera.site";
         String expectedInternalFQDN = "private-gateway.cloudera.site";
+        String expectedInternalOtherFQDN = "private-other-gateway.cloudera.site";
         GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
         generalClusterConfigs.setExternalFQDN(expectedExternalFQDN);
         generalClusterConfigs.setKnoxUserFacingCertConfigured(true);
         generalClusterConfigs.setPrimaryGatewayInstanceDiscoveryFQDN(Optional.of(expectedInternalFQDN));
+        generalClusterConfigs.setOtherGatewayInstancesDiscoveryFQDN(Set.of(expectedInternalFQDN, expectedInternalOtherFQDN));
 
         TemplatePreparationObject tpo = new Builder()
                 .withGeneralClusterConfigs(generalClusterConfigs)
@@ -271,7 +274,7 @@ public class HueConfigProviderTest {
 
         verify(safetyValve, never()).addContent(anyString());
         Map<String, String> configToValue = ConfigTestUtil.getConfigNameToValueMap(result);
-        String proxyHostsExpected = String.join(",", expectedInternalFQDN, expectedExternalFQDN);
+        String proxyHostsExpected = String.join(",", expectedInternalFQDN, expectedInternalOtherFQDN, expectedExternalFQDN);
         assertThat(configToValue).containsOnly(
                 entry("database_host", HOST),
                 entry("database_port", PORT),
@@ -307,6 +310,7 @@ public class HueConfigProviderTest {
         generalClusterConfigs.setExternalFQDN(expectedExternalFQDN);
         generalClusterConfigs.setKnoxUserFacingCertConfigured(true);
         generalClusterConfigs.setPrimaryGatewayInstanceDiscoveryFQDN(Optional.of(expectedInternalFQDN));
+        generalClusterConfigs.setOtherGatewayInstancesDiscoveryFQDN(Set.of(expectedInternalFQDN));
 
         TemplatePreparationObject tpo = new Builder()
                 .withGeneralClusterConfigs(generalClusterConfigs)

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/model/GeneralClusterConfigs.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/model/GeneralClusterConfigs.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.template.model;
 
 import java.util.Optional;
+import java.util.Set;
 
 import com.sequenceiq.cloudbreak.common.model.OrchestratorType;
 
@@ -53,6 +54,8 @@ public class GeneralClusterConfigs {
     private boolean govCloud;
 
     private String creatorWorkloadUserCrn;
+
+    private Set<String> otherGatewayInstancesDiscoveryFQDN;
 
     public OrchestratorType getOrchestratorType() {
         return orchestratorType;
@@ -244,5 +247,13 @@ public class GeneralClusterConfigs {
 
     public void setCreatorWorkloadUserCrn(String creatorWorkloadUserCrn) {
         this.creatorWorkloadUserCrn = creatorWorkloadUserCrn;
+    }
+
+    public Set<String> getOtherGatewayInstancesDiscoveryFQDN() {
+        return otherGatewayInstancesDiscoveryFQDN;
+    }
+
+    public void setOtherGatewayInstancesDiscoveryFQDN(Set<String> otherGatewayInstancesDiscoveryFQDN) {
+        this.otherGatewayInstancesDiscoveryFQDN = otherGatewayInstancesDiscoveryFQDN;
     }
 }


### PR DESCRIPTION
Currently only the primary gateway host have been put to the knox_proxyhosts, but now it will be the other available gateway hosts as well.