### PR TITLE
CB-22332 Return Hosts which have returned to good health state.

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/ExtendedPollingResult.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/ExtendedPollingResult.java
@@ -10,10 +10,13 @@ public class ExtendedPollingResult {
 
     private Set<Long> failedInstanceIds;
 
-    private ExtendedPollingResult(PollingResult pollingResult, Exception exception, Set<Long> payload) {
+    private Set<String> failedHostNames;
+
+    private ExtendedPollingResult(PollingResult pollingResult, Exception exception, Set<Long> payload, Set<String> failedHostNames) {
         this.pollingResult = pollingResult;
         this.exception = exception;
         this.failedInstanceIds = payload;
+        this.failedHostNames = failedHostNames;
     }
 
     public boolean isSuccess() {
@@ -44,8 +47,14 @@ public class ExtendedPollingResult {
         return failedInstanceIds;
     }
 
+    public Set<String> getFailedHostNames() {
+        return failedHostNames;
+    }
+
     public static class ExtendedPollingResultBuilder {
         private Set<Long> failedInstaceIds;
+
+        private Set<String> failedHostNames;
 
         private Exception exception;
 
@@ -53,6 +62,11 @@ public class ExtendedPollingResult {
 
         public ExtendedPollingResultBuilder withPayload(Set<Long> failedInstanceIds) {
             this.failedInstaceIds = failedInstanceIds;
+            return this;
+        }
+
+        public ExtendedPollingResultBuilder withPayloadWithHostNames(Set<String> failedHostNames) {
+            this.failedHostNames = failedHostNames;
             return this;
         }
 
@@ -87,7 +101,7 @@ public class ExtendedPollingResult {
         }
 
         public ExtendedPollingResult build() {
-            return new ExtendedPollingResult(pollingResult, exception, failedInstaceIds);
+            return new ExtendedPollingResult(pollingResult, exception, failedInstaceIds, failedHostNames);
         }
     }
 

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/PollingService.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/PollingService.java
@@ -86,6 +86,7 @@ public class PollingService<T> {
                     .timeout()
                     .withException(actual)
                     .withPayload(statusCheckerTask.getFailedInstanceIds())
+                    .withPayloadWithHostNames(statusCheckerTask.getFailedHostNames())
                     .build();
         }
         LOGGER.debug("Poller exiting.");

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/StatusCheckerTask.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/StatusCheckerTask.java
@@ -20,6 +20,10 @@ public interface StatusCheckerTask<T> {
         return Collections.emptySet();
     }
 
+    default Set<String> getFailedHostNames() {
+        return Collections.emptySet();
+    }
+
     default boolean initialExitCheck(T t) {
         return true;
     }

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterSetupService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterSetupService.java
@@ -56,7 +56,7 @@ public interface ClusterSetupService {
 
     ExtendedPollingResult waitForHosts(Set<InstanceMetadataView> hostsInCluster) throws ClusterClientInitException;
 
-    void waitForHostsHealthy(Set<InstanceMetadataView> hostsInCluster) throws ClusterClientInitException;
+    List<InstanceMetadataView> waitForHostsHealthy(Set<InstanceMetadataView> hostsInCluster) throws ClusterClientInitException;
 
     String getSdxContext();
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupService.java
@@ -394,7 +394,7 @@ public class ClouderaManagerSetupService implements ClusterSetupService {
     }
 
     @Override
-    public void waitForHostsHealthy(Set<InstanceMetadataView> hostsInCluster) throws ClusterClientInitException {
+    public List<InstanceMetadataView> waitForHostsHealthy(Set<InstanceMetadataView> hostsInCluster) throws ClusterClientInitException {
         ClusterView cluster = stack.getCluster();
         String user = cluster.getCloudbreakAmbariUser();
         String password = cluster.getCloudbreakAmbariPassword();
@@ -404,8 +404,14 @@ public class ClouderaManagerSetupService implements ClusterSetupService {
         } catch (ClouderaManagerClientInitException e) {
             throw new ClusterClientInitException(e);
         }
-        clouderaManagerPollingServiceProvider.startPollingCmHostStatusHealthy(
-                stack, client, hostsInCluster.stream().map(x -> x.getDiscoveryFQDN()).collect(Collectors.toUnmodifiableSet()));
+        ExtendedPollingResult extendedPollingResult = clouderaManagerPollingServiceProvider.startPollingCmHostStatusHealthy(
+                stack, client, hostsInCluster.stream().map(InstanceMetadataView::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet()));
+        if (!extendedPollingResult.isSuccess()) {
+            return hostsInCluster.stream().filter(instanceMetadataView ->
+                    !extendedPollingResult.getFailedHostNames().contains(instanceMetadataView.getDiscoveryFQDN())).collect(Collectors.toList());
+        } else {
+            return hostsInCluster.stream().toList();
+        }
     }
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerHostHealthyStatusChecker.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerHostHealthyStatusChecker.java
@@ -17,7 +17,6 @@ import com.cloudera.api.swagger.model.ApiHost;
 import com.cloudera.api.swagger.model.ApiHostList;
 import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterEventService;
-import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
 
@@ -50,6 +49,11 @@ public class ClouderaManagerHostHealthyStatusChecker extends AbstractClouderaMan
         this.hostnamesToCheckFor = new HashSet<>(hostnamesToCheckFor);
         initialNodeCount = hostnamesToCheckFor.size();
         LOGGER.info("Initialized ClouderaManagerHostHealthyStatusChecker with start={}, hostNamesToCheckFor.size()={}", start, hostnamesToCheckFor.size());
+    }
+
+    @Override
+    public Set<String> getFailedHostNames() {
+        return hostnamesToCheckFor;
     }
 
     @Override
@@ -108,9 +112,8 @@ public class ClouderaManagerHostHealthyStatusChecker extends AbstractClouderaMan
 
     @Override
     public void handleTimeout(ClouderaManagerPollerObject pollerObject) {
-        throw new ClouderaManagerOperationFailedException(
-                String.format("Operation timed out. Failed while waiting for %d nodes to move into health state. MissingNodeCount=%d, MissingNodes=[%s]",
-                        initialNodeCount, hostnamesToCheckFor.size(), hostnamesToCheckFor));
+        LOGGER.debug("Operation timed out. Failed while waiting for {} nodes to move into health state. MissingNodeCount={}, MissingNodes={}",
+                initialNodeCount, hostnamesToCheckFor.size(), hostnamesToCheckFor);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartUpscaleCommissionViaCMHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartUpscaleCommissionViaCMHandler.java
@@ -96,7 +96,7 @@ public class StopStartUpscaleCommissionViaCMHandler extends ExceptionCatcherEven
                     String.valueOf(allInstancesToCommission.size()));
 
             ClusterSetupService clusterSetupService = clusterApiConnectors.getConnector(stack).clusterSetupService();
-            clusterSetupService.waitForHostsHealthy(new HashSet<>(allInstancesToCommission));
+            allInstancesToCommission = clusterSetupService.waitForHostsHealthy(new HashSet<>(allInstancesToCommission));
 
             flowMessageService.fireEventAndLog(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_SCALING_STOPSTART_UPSCALE_CMHOSTSSTARTED,
                     String.valueOf(allInstancesToCommission.size()));


### PR DESCRIPTION
-Things Done 
Now, after this change we will be able to upscale the nodes which reported there heart beat in 5 mins and the other nodes won't be considered. 
First, it was all or nothing situation where we can commission all nodes or none of them will move forward and we will throw a timeout exception even if a single node fails to sent a heart beat in given time.

-Things Left
If after the filtering 0 nodes are left than it will be considered a failure. 
UT coverage for this change.

See detailed description in the commit message.