### PR TITLE
CB-22077 cloud-azure module should be enhanced to fetch and populate Availability zones for cloud resources

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/VmTypeMeta.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/VmTypeMeta.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.cloud.model;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,6 +31,8 @@ public class VmTypeMeta {
     private VolumeParameterConfig st1Config;
 
     private VolumeParameterConfig localSsdConfig;
+
+    private List<String> availabilityZones = new ArrayList<>();
 
     private Map<String, Object> properties = new HashMap<>();
 
@@ -80,6 +84,14 @@ public class VmTypeMeta {
         return localSsdConfig;
     }
 
+    public List<String> getAvailabilityZones() {
+        return availabilityZones;
+    }
+
+    public void setAvailabilityZones(List<String> availabilityZones) {
+        this.availabilityZones = availabilityZones;
+    }
+
     public Map<String, Object> getProperties() {
         return properties;
     }
@@ -111,6 +123,7 @@ public class VmTypeMeta {
                 + ", ssdConfig=" + ssdConfig
                 + ", ephemeralConfig=" + ephemeralConfig
                 + ", st1Config=" + st1Config
+                + ", availabilityZones=" + availabilityZones
                 + ", properties=" + properties
                 + '}';
     }
@@ -128,6 +141,8 @@ public class VmTypeMeta {
         private VolumeParameterConfig st1Config;
 
         private VolumeParameterConfig localSsdConfig;
+
+        private List<String> availabilityZones;
 
         private final Map<String, Object> properties = new HashMap<>();
 
@@ -198,6 +213,11 @@ public class VmTypeMeta {
             return this;
         }
 
+        public VmTypeMetaBuilder withAvailabilityZones(List<String> azs) {
+            availabilityZones = azs;
+            return this;
+        }
+
         public VmTypeMetaBuilder withProperty(String name, String value) {
             properties.put(name, value);
             return this;
@@ -248,6 +268,7 @@ public class VmTypeMeta {
             vmTypeMeta.setSsdConfig(ssdConfig);
             vmTypeMeta.setSt1Config(st1Config);
             vmTypeMeta.setLocalSsdConfig(localSsdConfig);
+            vmTypeMeta.setAvailabilityZones(availabilityZones);
             vmTypeMeta.setProperties(properties);
             return vmTypeMeta;
         }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureDisk.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureDisk.java
@@ -1,0 +1,130 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import java.util.Map;
+
+import com.google.common.base.Objects;
+
+public class AzureDisk {
+    private String diskName;
+
+    private int diskSize;
+
+    private AzureDiskType diskType;
+
+    private String region;
+
+    private String resourceGroupName;
+
+    private Map<String, String> tags;
+
+    private String diskEncryptionSetId;
+
+    private String availabilityZone;
+
+    public AzureDisk(String diskName, int diskSize, AzureDiskType diskType, String region, String resourceGroupName,
+            Map<String, String> tags, String diskEncryptionSetId, String availabilityZone) {
+        this.diskName = diskName;
+        this.diskSize = diskSize;
+        this.diskType = diskType;
+        this.region = region;
+        this.resourceGroupName = resourceGroupName;
+        this.tags = tags;
+        this.diskEncryptionSetId = diskEncryptionSetId;
+        this.availabilityZone = availabilityZone;
+    }
+
+    public String getDiskName() {
+        return diskName;
+    }
+
+    public void setDiskName(String diskName) {
+        this.diskName = diskName;
+    }
+
+    public int getDiskSize() {
+        return diskSize;
+    }
+
+    public void setDiskSize(int diskSize) {
+        this.diskSize = diskSize;
+    }
+
+    public AzureDiskType getDiskType() {
+        return diskType;
+    }
+
+    public void setDiskType(AzureDiskType diskType) {
+        this.diskType = diskType;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getResourceGroupName() {
+        return resourceGroupName;
+    }
+
+    public void setResourceGroupName(String resourceGroupName) {
+        this.resourceGroupName = resourceGroupName;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags;
+    }
+
+    public String getDiskEncryptionSetId() {
+        return diskEncryptionSetId;
+    }
+
+    public void setDiskEncryptionSetId(String diskEncryptionSetId) {
+        this.diskEncryptionSetId = diskEncryptionSetId;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public void setAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+    }
+
+    @Override
+    public String toString() {
+        return "AzureDisk{" +
+                "diskName='" + diskName + '\'' +
+                ", diskSize='" + diskSize + '\'' +
+                ", diskType=" + diskType +
+                ", region='" + region + '\'' +
+                ", resourceGroupName='" + resourceGroupName + '\'' +
+                ", tags=" + tags +
+                ", diskEncryptionSetId='" + diskEncryptionSetId + '\'' +
+                ", availabilityZone='" + availabilityZone + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AzureDisk azureDisk = (AzureDisk) o;
+        return Objects.equal(diskName, azureDisk.diskName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(diskName);
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResources.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResources.java
@@ -234,6 +234,7 @@ public class AzurePlatformResources implements PlatformResources {
     public CloudVmTypes virtualMachines(ExtendedCloudCredential cloudCredential, Region region, Map<String, String> filters) {
         AzureClient client = azureClientService.getClient(cloudCredential);
         Set<VirtualMachineSize> vmTypes = client.getVmTypes(region.value());
+        Map<String, List<String>> availabilityZones = client.getAvailabilityZones(region.value());
 
         Map<String, Set<VmType>> cloudVmResponses = new HashMap<>();
         Map<String, VmType> defaultCloudVmResponses = new HashMap<>();
@@ -254,6 +255,11 @@ public class AzurePlatformResources implements PlatformResources {
             } else {
                 builder.withResourceDiskAttached(false);
             }
+
+            List<String> azs = availabilityZones.getOrDefault(virtualMachineSize.name(), new ArrayList<>());
+            LOGGER.debug("Availability Zones for VM type {} are {}", virtualMachineSize.name(), azs);
+
+            builder.withAvailabilityZones(azs);
 
             VmType vmType = VmType.vmTypeWithMeta(virtualMachineSize.name(), builder.create(), true);
             types.add(vmType);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +39,7 @@ import com.azure.resourcemanager.authorization.models.RoleAssignments;
 import com.azure.resourcemanager.compute.ComputeManager;
 import com.azure.resourcemanager.compute.fluent.models.DiskEncryptionSetInner;
 import com.azure.resourcemanager.compute.fluent.models.DiskInner;
+import com.azure.resourcemanager.compute.fluent.models.ResourceSkuInner;
 import com.azure.resourcemanager.compute.models.AvailabilitySet;
 import com.azure.resourcemanager.compute.models.CachingTypes;
 import com.azure.resourcemanager.compute.models.Disk;
@@ -48,6 +51,7 @@ import com.azure.resourcemanager.compute.models.Encryption;
 import com.azure.resourcemanager.compute.models.EncryptionSetIdentity;
 import com.azure.resourcemanager.compute.models.KeyForDiskEncryptionSet;
 import com.azure.resourcemanager.compute.models.OperatingSystemStateTypes;
+import com.azure.resourcemanager.compute.models.ResourceSkuLocationInfo;
 import com.azure.resourcemanager.compute.models.SourceVault;
 import com.azure.resourcemanager.compute.models.VirtualMachine;
 import com.azure.resourcemanager.compute.models.VirtualMachineCustomImage;
@@ -102,6 +106,7 @@ import com.azure.storage.common.StorageSharedKeyCredential;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.sequenceiq.cloudbreak.client.ProviderAuthenticationFailedException;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureDisk;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureDiskType;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureLoadBalancerFrontend;
 import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
@@ -269,18 +274,19 @@ public class AzureClient {
                 .findAny();
     }
 
-    public Disk createManagedDisk(
-            String diskName, int diskSize, AzureDiskType diskType, String region, String resourceGroupName, Map<String, String> tags,
-            String diskEncryptionSetId) {
-        LOGGER.debug("create managed disk with name={}", diskName);
-        Disk.DefinitionStages.WithCreate withCreate = azure.disks().define(diskName)
-                .withRegion(RegionUtil.findByLabelOrName(region))
-                .withExistingResourceGroup(resourceGroupName)
+    public Disk createManagedDisk(AzureDisk azureDisk) {
+        LOGGER.debug("create managed disk with name={}", azureDisk.getDiskName());
+        Disk.DefinitionStages.WithCreate withCreate = azure.disks().define(azureDisk.getDiskName())
+                .withRegion(RegionUtil.findByLabelOrName(azureDisk.getRegion()))
+                .withExistingResourceGroup(azureDisk.getResourceGroupName())
                 .withData()
-                .withSizeInGB(diskSize)
-                .withTags(tags)
-                .withSku(convertAzureDiskTypeToDiskSkuTypes(diskType));
-        setupDiskEncryptionWithDesIfNeeded(diskEncryptionSetId, withCreate);
+                .withSizeInGB(azureDisk.getDiskSize())
+                .withTags(azureDisk.getTags())
+                .withSku(convertAzureDiskTypeToDiskSkuTypes(azureDisk.getDiskType()));
+        if (StringUtils.isNotEmpty(azureDisk.getAvailabilityZone())) {
+            withCreate = withCreate.withAvailabilityZone(AvailabilityZoneId.fromString(azureDisk.getAvailabilityZone()));
+        }
+        setupDiskEncryptionWithDesIfNeeded(azureDisk.getDiskEncryptionSetId(), withCreate);
         return withCreate.create();
     }
 
@@ -998,6 +1004,34 @@ public class AzureClient {
             return matcher.group(1);
         }
         return null;
+    }
+
+    public Map<String, List<String>> getAvailabilityZones(String region) throws ProviderAuthenticationFailedException {
+        return handleException(() -> {
+            Map<String, List<String>> zoneInfo = new HashMap<>();
+            if (!StringUtils.isEmpty(region)) {
+                String criteria = "location eq '" + RegionUtil.findByLabelOrName(region).name() + "'";
+                LOGGER.debug("Fetch AZ info from Azure for region {} and criteria {}", region, criteria);
+                AzureListResult<ResourceSkuInner> azureResult = azureListResultFactory.create(azure
+                        .virtualMachines()
+                        .manager()
+                        .serviceClient()
+                        .getResourceSkus()
+                        .list(criteria, null, com.azure.core.util.Context.NONE));
+
+                azureResult.getStream().forEach(sku -> {
+                    List<ResourceSkuLocationInfo> locations = sku.locationInfo();
+                    if (locations != null) {
+                        locations.stream().forEach(loc -> {
+                            zoneInfo.put(sku.name(), loc.zones());
+                        });
+                    }
+                });
+            } else {
+                LOGGER.error("Region is not provided so not fetching the zone information");
+            }
+            return zoneInfo;
+        });
     }
 
     public void updateAdministratorLoginPassword(String resourceGroupName, String serverName, String newPassword) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilder.java
@@ -34,6 +34,7 @@ import com.azure.resourcemanager.resources.fluentcore.arm.AvailabilityZoneId;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureDisk;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureDiskType;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureResourceGroupMetadataProvider;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
@@ -136,6 +137,7 @@ public class AzureVolumeResourceBuilder extends AbstractAzureComputeBuilder {
                     .withName(resourceNameService.volumeSet(stackName, groupName, privateId, hashableString))
                     .withGroup(group.getName())
                     .withStatus(CommonStatus.REQUESTED)
+                    .withAvailabilityZone(availabilityZone)
                     .withParameters(Map.of(CloudResource.ATTRIBUTES, new VolumeSetAttributes.Builder()
                                     .withAvailabilityZone(availabilityZone)
                                     .withDeleteOnTermination(Boolean.TRUE)
@@ -204,8 +206,9 @@ public class AzureVolumeResourceBuilder extends AbstractAzureComputeBuilder {
                         Disk result = client.getDiskByName(resourceGroupName, volume.getId());
                         if (result == null) {
                             result = client.createManagedDisk(
-                                    volume.getId(), volume.getSize(), AzureDiskType.getByValue(
-                                            volume.getType()), region, resourceGroupName, cloudStack.getTags(), diskEncryptionSetId);
+                                    new AzureDisk(volume.getId(), volume.getSize(), AzureDiskType.getByValue(
+                                            volume.getType()), region, resourceGroupName, cloudStack.getTags(), diskEncryptionSetId,
+                                    resource.getAvailabilityZone()));
                         } else {
                             LOGGER.info("Managed disk for resource group: {}, name: {} already exists: {}", resourceGroupName, volume.getId(), result);
                         }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResourcesTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResourcesTest.java
@@ -6,11 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -32,6 +35,7 @@ import com.sequenceiq.cloudbreak.cloud.model.ExtendedCloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStoreMetadata;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.cloud.model.VmType;
 
 @ExtendWith(MockitoExtension.class)
 class AzurePlatformResourcesTest {
@@ -60,6 +64,7 @@ class AzurePlatformResourcesTest {
         virtualMachineSizes.add(createVirtualMachineSize("Standard_DS2_v2", 20000));
         virtualMachineSizes.add(createVirtualMachineSize("Standard_E64ds_v4", 1400000));
         when(azureClient.getVmTypes(region.value())).thenReturn(virtualMachineSizes);
+        when(azureClient.getAvailabilityZones(region.value())).thenReturn(Map.of());
 
         CloudVmTypes actual = underTest.virtualMachines(cloudCredential, region, Map.of());
 
@@ -76,6 +81,17 @@ class AzurePlatformResourcesTest {
                             .anyMatch(cloudVMResponse -> virtualMachineSize.name().equals(cloudVMResponse.value()));
                     assertTrue(virtualMachineSizeCouldBeFoundInResult);
                 });
+        virtualMachineSizes.forEach(virtualMachineSize -> {
+            List<String> availabilityZones = actual.getCloudVmResponses()
+                    .get(region.value())
+                    .stream()
+                    .filter(vmType -> virtualMachineSize.name().equals(vmType.value()))
+                    .findFirst()
+                    .map(vmType -> vmType.getMetaData().getAvailabilityZones())
+                    .orElse(null);
+            assertEquals(availabilityZones, Collections.emptyList());
+
+        });
     }
 
     @Test
@@ -89,6 +105,12 @@ class AzurePlatformResourcesTest {
         virtualMachineSizes.add(createVirtualMachineSize("Standard_E64ds_v4", 1400000));
         virtualMachineSizes.add(e64sVmTypeWithoutResourceDisk);
         when(azureClient.getVmTypes(region.value())).thenReturn(virtualMachineSizes);
+        Map<String, List<String>> zoneInfo = new HashMap<>();
+        zoneInfo.put("Standard_D2s_v4", List.of("1", "2"));
+        zoneInfo.put("Standard_E64s_v4", List.of("2", "3"));
+        zoneInfo.put("Standard_DS2_v2", List.of("1"));
+        zoneInfo.put("Standard_E64ds_v4", List.of("1", "2", "3"));
+        when(azureClient.getAvailabilityZones(region.value())).thenReturn(zoneInfo);
 
         CloudVmTypes actual = underTest.virtualMachines(cloudCredential, region, Map.of());
 
@@ -97,6 +119,18 @@ class AzurePlatformResourcesTest {
         assertFalse(actual.getCloudVmResponses().isEmpty());
         assertNotNull(actual.getCloudVmResponses().get(region.value()));
         assertEquals(virtualMachineSizes.size(), actual.getCloudVmResponses().get(region.value()).size());
+        virtualMachineSizes.forEach(virtualMachineSize -> {
+            VmType matchingVm = actual.getCloudVmResponses()
+                    .get(region.value())
+                    .stream()
+                    .filter(vmType -> virtualMachineSize.name().equals(vmType.value()))
+                    .findFirst()
+                    .orElse(null);
+            if (matchingVm == null) {
+                fail("VM from input is not present in response");
+            }
+            assertEquals(zoneInfo.get(matchingVm.value()), matchingVm.getMetaData().getAvailabilityZones());
+        });
     }
 
     @Test

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilderTest.java
@@ -6,10 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -40,6 +37,7 @@ import org.springframework.core.task.AsyncTaskExecutor;
 import com.azure.resourcemanager.compute.models.Disk;
 import com.azure.resourcemanager.compute.models.VirtualMachine;
 import com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureDisk;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureDiskType;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureResourceGroupMetadataProvider;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
@@ -356,7 +354,7 @@ public class AzureVolumeResourceBuilderTest {
     void buildTestWhenNoVolumeSet() throws Exception {
         List<CloudResource> result = underTest.build(context, cloudInstance, PRIVATE_ID, auth, group, List.of(), cloudStack);
 
-        verify(azureClient, never()).createManagedDisk(anyString(), anyInt(), any(AzureDiskType.class), anyString(), anyString(), anyMap(), anyString());
+        verify(azureClient, never()).createManagedDisk(any());
 
         assertThat(result).isNotNull();
         assertThat(result).hasSize(0);
@@ -372,7 +370,7 @@ public class AzureVolumeResourceBuilderTest {
 
         List<CloudResource> result = underTest.build(context, cloudInstance, PRIVATE_ID, auth, group, List.of(volumeSetResource), cloudStack);
 
-        verify(azureClient, never()).createManagedDisk(anyString(), anyInt(), any(AzureDiskType.class), anyString(), anyString(), anyMap(), anyString());
+        verify(azureClient, never()).createManagedDisk(any());
 
         assertThat(result).isNotNull();
         assertThat(result).hasSize(1);
@@ -394,7 +392,7 @@ public class AzureVolumeResourceBuilderTest {
 
         List<CloudResource> result = underTest.build(context, cloudInstance, PRIVATE_ID, auth, group, List.of(volumeSetResource), cloudStack);
 
-        verify(azureClient, never()).createManagedDisk(anyString(), anyInt(), any(AzureDiskType.class), anyString(), anyString(), anyMap(), anyString());
+        verify(azureClient, never()).createManagedDisk(any());
 
         assertThat(result).isNotNull();
         assertThat(result).hasSize(1);
@@ -412,7 +410,8 @@ public class AzureVolumeResourceBuilderTest {
                 .withParameters(Map.of(CloudResource.ATTRIBUTES, new VolumeSetAttributes(AVAILABILITY_ZONE, true, FSTAB, volumes, VOLUME_SIZE, VOLUME_TYPE)))
                 .withName(VOLUME_NAME).build();
 
-        when(azureClient.createManagedDisk(VOLUME_ID, VOLUME_SIZE, AzureDiskType.STANDARD_SSD_LRS, REGION, RESOURCE_GROUP, Map.of(), null)).thenReturn(disk);
+        when(azureClient.createManagedDisk(new AzureDisk(VOLUME_ID, VOLUME_SIZE, AzureDiskType.STANDARD_SSD_LRS, REGION, RESOURCE_GROUP,
+                Map.of(), null, null))).thenReturn(disk);
 
         List<CloudResource> result = underTest.build(context, cloudInstance, PRIVATE_ID, auth, group, List.of(volumeSetResource), cloudStack);
 
@@ -434,7 +433,8 @@ public class AzureVolumeResourceBuilderTest {
 
         when(instanceTemplate.getStringParameter(AzureInstanceTemplate.DISK_ENCRYPTION_SET_ID)).thenReturn(DISK_ENCRYPTION_SET_ID);
 
-        when(azureClient.createManagedDisk(VOLUME_ID, VOLUME_SIZE, AzureDiskType.STANDARD_SSD_LRS, REGION, RESOURCE_GROUP, Map.of(), null)).thenReturn(disk);
+        when(azureClient.createManagedDisk(new AzureDisk(VOLUME_ID, VOLUME_SIZE, AzureDiskType.STANDARD_SSD_LRS, REGION, RESOURCE_GROUP,
+                        Map.of(), null, null))).thenReturn(disk);
 
         List<CloudResource> result = underTest.build(context, cloudInstance, PRIVATE_ID, auth, group, List.of(volumeSetResource), cloudStack);
 
@@ -457,8 +457,8 @@ public class AzureVolumeResourceBuilderTest {
         when(instanceTemplate.getParameter(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, Object.class)).thenReturn(true);
         when(instanceTemplate.getStringParameter(AzureInstanceTemplate.DISK_ENCRYPTION_SET_ID)).thenReturn(DISK_ENCRYPTION_SET_ID);
 
-        when(azureClient.createManagedDisk(VOLUME_ID, VOLUME_SIZE, AzureDiskType.STANDARD_SSD_LRS, REGION, RESOURCE_GROUP, Map.of(), DISK_ENCRYPTION_SET_ID))
-                .thenReturn(disk);
+        when(azureClient.createManagedDisk(new AzureDisk(VOLUME_ID, VOLUME_SIZE, AzureDiskType.STANDARD_SSD_LRS, REGION, RESOURCE_GROUP, Map.of(),
+                DISK_ENCRYPTION_SET_ID, null))).thenReturn(disk);
 
         List<CloudResource> result = underTest.build(context, cloudInstance, PRIVATE_ID, auth, group, List.of(volumeSetResource), cloudStack);
 


### PR DESCRIPTION
cloud-azure module should be enhanced to fetch and populate Availability zones for cloud resources

Added AzureDisk DTO to populate information needed for creating the disk. It is needed because 7 attributes for disk were being passed as argument to the method. AZ cannot be added as another argument since maximum number of allowed arguments are 7.

Equals and hashCode has been overridden to only use diskName since diskName is unique and disk should be treated equal if diskname is same. Also, Overriding equals and hashCode is only needed for unit tests to pass since unit tests are using as part of verification.

See detailed description in the commit message.