### PR TITLE
CB-22353 Introduce Kibana Query and S3 Cluster Logs URLs to the Jenkins TestNG Reports page

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/Clue.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/Clue.java
@@ -19,14 +19,22 @@ public class Clue {
 
     private final boolean hasSpotTermination;
 
+    private final String storageUrl;
+
+    private final String searchUrl;
+
     public Clue(String name,
             String crn,
+            String storageUrl,
+            String searchUrl,
             AuditEventV4Responses auditEvents,
             List<CDPStructuredEvent> cdpStructuredEvents,
             Object response,
             boolean hasSpotTermination) {
         this.name = name;
         this.crn = crn;
+        this.storageUrl = storageUrl;
+        this.searchUrl = searchUrl;
         this.auditEvents = auditEvents;
         this.cdpStructuredEvents = cdpStructuredEvents;
         this.response = response;
@@ -39,6 +47,14 @@ public class Clue {
 
     public String getCrn() {
         return crn;
+    }
+
+    public String getStorageUrl() {
+        return storageUrl;
+    }
+
+    public String getSearchUrl() {
+        return searchUrl;
     }
 
     public AuditEventV4Responses getAuditEvents() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
@@ -1,10 +1,12 @@
 package com.sequenceiq.it.cloudbreak.context;
 
 import java.time.Duration;
+import java.util.Date;
 import java.util.Map;
 
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
+import org.testng.ITestResult;
 
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
@@ -61,6 +63,21 @@ public class MeasuredTestContext extends MockedTestContext {
     @Override
     public TestParameter getTestParameter() {
         return wrappedTestContext.getTestParameter();
+    }
+
+    @Override
+    public ITestResult getCurrentTestResult() {
+        return wrappedTestContext.getCurrentTestResult();
+    }
+
+    @Override
+    public Date getTestStartTime() {
+        return wrappedTestContext.getTestStartTime();
+    }
+
+    @Override
+    public Date getTestEndTime() {
+        return wrappedTestContext.getTestEndTime();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -55,7 +55,11 @@ import com.sequenceiq.it.cloudbreak.dto.DeletableEnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.credential.CredentialTestDto;
 import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
 import com.sequenceiq.it.cloudbreak.microservice.EnvironmentClient;
+import com.sequenceiq.it.cloudbreak.search.ClusterLogsStorageUrl;
+import com.sequenceiq.it.cloudbreak.search.KibanaSearchUrl;
+import com.sequenceiq.it.cloudbreak.search.SearchUrl;
 import com.sequenceiq.it.cloudbreak.search.Searchable;
+import com.sequenceiq.it.cloudbreak.search.StorageUrl;
 import com.sequenceiq.it.cloudbreak.util.StructuredEventUtil;
 
 @Prototype
@@ -451,6 +455,9 @@ public class EnvironmentTestDto
 
     @Override
     public Clue investigate() {
+        StorageUrl storageUrl = new ClusterLogsStorageUrl();
+        SearchUrl searchUrl = new KibanaSearchUrl();
+
         if (getResponse() == null) {
             return null;
         }
@@ -460,9 +467,13 @@ public class EnvironmentTestDto
                     getTestContext().getMicroserviceClient(EnvironmentClient.class).getDefaultClient().structuredEventsV1Endpoint();
             structuredEvents = StructuredEventUtil.getStructuredEvents(cdpStructuredEventV1Endpoint, getResponse().getCrn());
         }
+        List<Searchable> listOfSearchables = List.of(this);
+        String environmentKibanaUrl = searchUrl.getSearchUrl(listOfSearchables, getTestContext().getTestStartTime(), getTestContext().getTestEndTime());
         return new Clue(
                 getResponse().getName(),
                 getResponse().getCrn(),
+                null,
+                environmentKibanaUrl,
                 null,
                 structuredEvents,
                 getResponse(),

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
@@ -41,6 +41,7 @@ import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredEvent;
 import com.sequenceiq.cloudbreak.structuredevent.rest.endpoint.CDPStructuredEventV1Endpoint;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.cloud.v4.CloudProviderProxy;
 import com.sequenceiq.it.cloudbreak.cloud.v4.CommonCloudProperties;
 import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
 import com.sequenceiq.it.cloudbreak.context.Clue;
@@ -62,7 +63,11 @@ import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.log.Log;
 import com.sequenceiq.it.cloudbreak.microservice.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.microservice.SdxClient;
+import com.sequenceiq.it.cloudbreak.search.ClusterLogsStorageUrl;
+import com.sequenceiq.it.cloudbreak.search.KibanaSearchUrl;
+import com.sequenceiq.it.cloudbreak.search.SearchUrl;
 import com.sequenceiq.it.cloudbreak.search.Searchable;
+import com.sequenceiq.it.cloudbreak.search.StorageUrl;
 import com.sequenceiq.it.cloudbreak.util.AuditUtil;
 import com.sequenceiq.it.cloudbreak.util.InstanceUtil;
 import com.sequenceiq.it.cloudbreak.util.ResponseUtil;
@@ -582,26 +587,42 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
 
     @Override
     public Clue investigate() {
+        CloudProviderProxy cloudProvider = getTestContext().getCloudProvider();
+        StorageUrl storageUrl = new ClusterLogsStorageUrl();
+        SearchUrl searchUrl = new KibanaSearchUrl();
+        String datalakeCloudStorageUrl = null;
+
         if (getResponse() == null || getResponse().getCrn() == null) {
             return null;
         }
+
+        String resourceName = getResponse().getName();
+        String resourceCrn = getResponse().getCrn();
         AuditEventV4Responses auditEvents = AuditUtil.getAuditEvents(
                 getTestContext().getMicroserviceClient(CloudbreakClient.class),
                 CloudbreakEventService.DATALAKE_RESOURCE_TYPE,
                 null,
-                getResponse().getCrn());
+                resourceCrn);
         boolean hasSpotTermination = getResponse().getStackV4Response() != null && getResponse().getStackV4Response().getInstanceGroups().stream()
                 .flatMap(ig -> ig.getMetadata().stream())
                 .anyMatch(metadata -> InstanceStatus.DELETED_BY_PROVIDER == metadata.getInstanceStatus());
         List<CDPStructuredEvent> structuredEvents = List.of();
-        if (getResponse() != null && getResponse().getCrn() != null) {
+        if (getResponse() != null && resourceCrn != null) {
             CDPStructuredEventV1Endpoint cdpStructuredEventV1Endpoint =
                     getTestContext().getMicroserviceClient(SdxClient.class).getDefaultClient().structuredEventsV1Endpoint();
-            structuredEvents = StructuredEventUtil.getStructuredEvents(cdpStructuredEventV1Endpoint, getResponse().getCrn());
+            structuredEvents = StructuredEventUtil.getStructuredEvents(cdpStructuredEventV1Endpoint, resourceCrn);
         }
+        if (getTestContext().get(EnvironmentTestDto.class) != null || getTestContext().get(EnvironmentTestDto.class).getResponse() != null) {
+            String baseLocation = getTestContext().get(EnvironmentTestDto.class).getResponse().getTelemetry().getLogging().getStorageLocation();
+            datalakeCloudStorageUrl = storageUrl.getDatalakeStorageUrl(resourceName, resourceCrn, baseLocation, cloudProvider);
+        }
+        List<Searchable> listOfSearchables = List.of(this);
+        String datalakeKibanaUrl = searchUrl.getSearchUrl(listOfSearchables, getTestContext().getTestStartTime(), getTestContext().getTestEndTime());
         return new Clue(
-                getResponse().getName(),
-                getResponse().getCrn(),
+                resourceName,
+                resourceCrn,
+                datalakeCloudStorageUrl,
+                datalakeKibanaUrl,
                 auditEvents,
                 structuredEvents,
                 getResponse(),

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDto.java
@@ -151,6 +151,8 @@ public class StackTestDto extends StackTestDtoBase<StackTestDto> implements Purg
         return new Clue(
                 getResponse().getName(),
                 getResponse().getCrn(),
+                null,
+                null,
                 auditEvents,
                 List.of(),
                 getResponse(),

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ErrorLogMessageProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ErrorLogMessageProvider.java
@@ -95,7 +95,13 @@ public class ErrorLogMessageProvider {
             clues.forEach(clue -> {
                 appendLine(builder, "");
                 appendLine(builder, clue.getName() + " - " + clue.getCrn());
-
+                appendLine(builder, "<br>");
+                appendLine(builder, "Cluster logs: ");
+                appendLine(builder, "<a href=\"" + clue.getStorageUrl() + "\" target=\"_blank\">" + clue.getStorageUrl() + "</a>");
+                appendLine(builder, "<br>");
+                appendLine(builder, "Kibana query: ");
+                appendLine(builder, "<a href=\"" + clue.getSearchUrl() + "\" target=\"_blank\">" + clue.getSearchUrl() + "</a>");
+                appendLine(builder, "<br>");
                 if (clue.getAuditEvents() != null && CollectionUtils.isNotEmpty(clue.getAuditEvents().getResponses())) {
                     appendLine(builder, "Audit events:");
                     appendLine(builder, formatAuditEvents(clue.getAuditEvents().getResponses()));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/action/S3ClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/action/S3ClientActions.java
@@ -168,7 +168,12 @@ public class S3ClientActions extends S3Client {
         if (StringUtils.containsIgnoreCase(getAwsProperties().getRegion(), "us-gov")) {
             deploymentS3Console = "https://console.amazonaws-us-gov.com/s3/buckets/";
         }
-        return format("%s%s?region=%s&prefix=%s%s/&showversions=false",
-                deploymentS3Console, bucketName, getAwsProperties().getRegion(), getKeyPrefix(baseLocation), clusterLogPath);
+        if (StringUtils.contains(getKeyPrefix(baseLocation), clusterLogPath)) {
+            return format("%s%s?region=%s&prefix=%s/&showversions=false",
+                    deploymentS3Console, bucketName, getAwsProperties().getRegion(), getKeyPrefix(baseLocation));
+        } else {
+            return format("%s%s?region=%s&prefix=%s%s/&showversions=false",
+                    deploymentS3Console, bucketName, getAwsProperties().getRegion(), getKeyPrefix(baseLocation), clusterLogPath);
+        }
     }
 }


### PR DESCRIPTION
Lookup of logs should not involve any manual digging just a simple click on the test page.
