### PR TITLE
CB-22380: Modified Salt script for getting DL storage sizes so that it can't return empty values in response.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/datalake_metrics/get_database_sizes/scripts/get_database_sizes.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/datalake_metrics/get_database_sizes/scripts/get_database_sizes.sh
@@ -61,8 +61,12 @@ getDataSizesForDatabases() {
     TRIMMED_DB=$(echo "$DB" | tr -d '"')
     if doesDatabaseExist "$TRIMMED_DB" ; then
       CUR_DB_SIZE=$(runPSQLCommand "select sum(pg_table_size(quote_ident(tablename)::regclass)) from pg_tables where schemaname not in ('pg_catalog','information_schema');" "$TRIMMED_DB")
-      RESULT="${RESULT}${DB}:${CUR_DB_SIZE},"
-      doLog "Size of database ${DB} is ${CUR_DB_SIZE} bytes."
+      if [ -z "$CUR_DB_SIZE" ]; then
+        doLog "Unable to get size of database ${DB} even though it seems to exist..."
+      else
+        RESULT="${RESULT}${DB}:${CUR_DB_SIZE},"
+        doLog "Size of database ${DB} is ${CUR_DB_SIZE} bytes."
+      fi
     fi
   done
 


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-22380

We encountered occasional issues with getting the DL storage sizes which I have determined to be due to a unique issue where a DB is found to exist but its size cannot be obtained. This approach will make it so we just ignore these DB sizes and move forward with the collection.

This may potentially have issues if the DBs are not actually empty, I will look into this but for now this should be adequate.