### PR TITLE
CB-21512 improve exit criteria for salt related rotations

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/rotation/ExitCriteriaProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/rotation/ExitCriteriaProvider.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.cloudbreak.rotation;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
+import com.sequenceiq.cloudbreak.converter.scheduler.StatusToPollGroupConverter;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
+
+@Component
+public class ExitCriteriaProvider {
+
+    @Inject
+    private StatusToPollGroupConverter statusToPollGroupConverter;
+
+    public ExitCriteriaModel get(StackDto stack) {
+        InMemoryStateStore.putStack(stack.getId(), statusToPollGroupConverter.convert(stack.getStatus()));
+        InMemoryStateStore.putCluster(stack.getCluster().getId(), statusToPollGroupConverter.convert(stack.getStatus()));
+        return ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel(stack.getId(), stack.getCluster().getId());
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/rotation/context/provider/CMDBPasswordRotationContextProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/rotation/context/provider/CMDBPasswordRotationContextProviderTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -21,12 +22,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.container.postgres.PostgresConfigService;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.rotation.CloudbreakSecretType;
+import com.sequenceiq.cloudbreak.rotation.ExitCriteriaProvider;
 import com.sequenceiq.cloudbreak.rotation.secret.RotationContext;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
@@ -54,6 +57,9 @@ public class CMDBPasswordRotationContextProviderTest {
     @Mock
     private ClusterHostServiceRunner clusterHostServiceRunner;
 
+    @Mock
+    private ExitCriteriaProvider exitCriteriaProvider;
+
     @InjectMocks
     private CMDBPasswordRotationContextProvider underTest;
 
@@ -64,6 +70,7 @@ public class CMDBPasswordRotationContextProviderTest {
         ClusterView cluster = mock(ClusterView.class);
         when(stackDto.getCluster()).thenReturn(cluster);
         when(cluster.getId()).thenReturn(1L);
+        lenient().when(exitCriteriaProvider.get(any())).thenReturn(ClusterDeletionBasedExitCriteriaModel.nonCancellableModel());
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/rotation/context/provider/CMServiceDBPasswordRotationContextProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/rotation/context/provider/CMServiceDBPasswordRotationContextProviderTest.java
@@ -20,11 +20,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRdsRoleConfigProvider;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.container.postgres.PostgresConfigService;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.rotation.ExitCriteriaProvider;
 import com.sequenceiq.cloudbreak.rotation.context.CMServiceConfigRotationContext;
 import com.sequenceiq.cloudbreak.rotation.secret.RotationContext;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
@@ -56,11 +58,15 @@ public class CMServiceDBPasswordRotationContextProviderTest {
     @Mock
     private AbstractRdsConfigProvider rdsConfigProvider;
 
+    @Mock
+    private ExitCriteriaProvider exitCriteriaProvider;
+
     @InjectMocks
     private CMServiceDBPasswordRotationContextProvider underTest;
 
     @Test
     public void testGetContext() throws IllegalAccessException {
+        when(exitCriteriaProvider.get(any())).thenReturn(ClusterDeletionBasedExitCriteriaModel.nonCancellableModel());
         FieldUtils.writeDeclaredField(underTest, "rdsRoleConfigProviders", List.of(rdsRoleConfigProvider), true);
         FieldUtils.writeDeclaredField(underTest, "rdsConfigProviders", List.of(rdsConfigProvider), true);
         Cluster cluster = mockCluster();

--- a/core/src/test/java/com/sequenceiq/cloudbreak/rotation/context/provider/UserKeyPairSaltStateRunRotationContextGeneratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/rotation/context/provider/UserKeyPairSaltStateRunRotationContextGeneratorTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.rotation.context.provider;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
@@ -15,8 +16,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
 import com.sequenceiq.cloudbreak.converter.spi.CredentialToCloudCredentialConverter;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
 import com.sequenceiq.cloudbreak.domain.StackAuthentication;
 import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.rotation.ExitCriteriaProvider;
 import com.sequenceiq.cloudbreak.rotation.context.SaltRunOrchestratorStateRotationContext;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.environment.credential.CredentialConverter;
@@ -59,8 +62,12 @@ class UserKeyPairSaltStateRunRotationContextGeneratorTest {
     @Mock
     private EnvironmentAuthenticationResponse environmentAuthenticationResponse;
 
+    @Mock
+    private ExitCriteriaProvider exitCriteriaProvider;
+
     @Test
     void testGenerateContext() {
+        when(exitCriteriaProvider.get(any())).thenReturn(ClusterDeletionBasedExitCriteriaModel.nonCancellableModel());
         when(stackDto.getStackAuthentication()).thenReturn(stackAuthentication);
         when(detailedEnvironmentResponse.getAuthentication()).thenReturn(environmentAuthenticationResponse);
         when(stackAuthentication.getPublicKeyId()).thenReturn("pk1");

--- a/core/src/test/java/com/sequenceiq/cloudbreak/rotation/executor/SaltPillarRotationExecutorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/rotation/executor/SaltPillarRotationExecutorTest.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -26,11 +27,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateParams;
+import com.sequenceiq.cloudbreak.rotation.ExitCriteriaProvider;
 import com.sequenceiq.cloudbreak.rotation.context.SaltPillarRotationContext;
 import com.sequenceiq.cloudbreak.rotation.secret.SecretRotationException;
 import com.sequenceiq.cloudbreak.service.salt.SaltStateParamsService;
@@ -52,8 +55,16 @@ class SaltPillarRotationExecutorTest {
     @Mock
     private SaltStateParamsService saltStateParamsService;
 
+    @Mock
+    private ExitCriteriaProvider exitCriteriaProvider;
+
     @InjectMocks
     private SaltPillarRotationExecutor underTest;
+
+    @BeforeEach
+    void setup() {
+        lenient().when(exitCriteriaProvider.get(any())).thenReturn(ClusterDeletionBasedExitCriteriaModel.nonCancellableModel());
+    }
 
     @Test
     void validationShouldSucceed() throws CloudbreakOrchestratorFailedException {


### PR DESCRIPTION
- after pod restart we need to update memory state again regarding polling group in order to be able to properly poll salt related operations

See detailed description in the commit message.