### PR TITLE
CB-21882 Send secret rotation events to EDH

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/rotation/secret/usage/SecretRotationUsageProcessor.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/rotation/secret/usage/SecretRotationUsageProcessor.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.cloudbreak.rotation.secret.usage;
+
+import com.sequenceiq.cloudbreak.rotation.secret.RotationFlowExecutionType;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretType;
+
+public interface SecretRotationUsageProcessor {
+
+    void rotationStarted(SecretType secretType, String resourceCrn, RotationFlowExecutionType executionType);
+
+    void rotationFinished(SecretType secretType, String resourceCrn, RotationFlowExecutionType executionType);
+
+    void rotationFailed(SecretType secretType, String resourceCrn, String reason, RotationFlowExecutionType executionType);
+
+    void rollbackStarted(SecretType secretType, String resourceCrn, RotationFlowExecutionType executionType);
+
+    void rollbackFinished(SecretType secretType, String resourceCrn, RotationFlowExecutionType executionType);
+
+    void rollbackFailed(SecretType secretType, String resourceCrn, String reason, RotationFlowExecutionType executionType);
+}

--- a/flow/src/main/java/com/sequenceiq/flow/rotation/handler/RollbackRotationHandler.java
+++ b/flow/src/main/java/com/sequenceiq/flow/rotation/handler/RollbackRotationHandler.java
@@ -1,12 +1,17 @@
 package com.sequenceiq.flow.rotation.handler;
 
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.eventbus.Event;
+import com.sequenceiq.cloudbreak.rotation.secret.RotationFlowExecutionType;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretType;
 import com.sequenceiq.cloudbreak.rotation.secret.step.SecretRotationStep;
+import com.sequenceiq.cloudbreak.rotation.secret.usage.SecretRotationUsageProcessor;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
@@ -21,6 +26,9 @@ public class RollbackRotationHandler extends ExceptionCatcherEventHandler<Rollba
     @Inject
     private SecretRotationService secretRotationService;
 
+    @Inject
+    private Optional<SecretRotationUsageProcessor> secretRotationUsageProcessor;
+
     @Override
     public String selector() {
         return EventSelectorUtil.selector(RollbackRotationTriggerEvent.class);
@@ -33,10 +41,20 @@ public class RollbackRotationHandler extends ExceptionCatcherEventHandler<Rollba
 
     @Override
     protected Selectable doAccept(HandlerEvent<RollbackRotationTriggerEvent> event) {
-        Exception exception = event.getData().getException();
-        SecretRotationStep failedStep = event.getData().getFailedStep();
-        secretRotationService.rollbackRotation(event.getData().getSecretType(), event.getData().getResourceCrn(),
-                event.getData().getExecutionType(), failedStep);
-        return RotationFailedEvent.fromPayload(SecretRotationEvent.ROTATION_FAILED_EVENT.event(), event.getData(), exception, failedStep);
+        RollbackRotationTriggerEvent rollbackEvent = event.getData();
+        String resourceCrn = rollbackEvent.getResourceCrn();
+        RotationFlowExecutionType executionType = rollbackEvent.getExecutionType();
+        SecretType secretType = rollbackEvent.getSecretType();
+        Exception exception = rollbackEvent.getException();
+        SecretRotationStep failedStep = rollbackEvent.getFailedStep();
+        secretRotationUsageProcessor.ifPresent(processor -> processor.rollbackStarted(secretType, resourceCrn, executionType));
+        try {
+            secretRotationService.rollbackRotation(secretType, resourceCrn, executionType, failedStep);
+            secretRotationUsageProcessor.ifPresent(processor -> processor.rollbackFinished(secretType, resourceCrn, executionType));
+            return RotationFailedEvent.fromPayload(SecretRotationEvent.ROTATION_FAILED_EVENT.event(), rollbackEvent, exception, failedStep);
+        } catch (Exception e) {
+            secretRotationUsageProcessor.ifPresent(processor -> processor.rollbackFailed(secretType, resourceCrn, e.getMessage(), executionType));
+            throw e;
+        }
     }
 }

--- a/flow/src/test/java/com/sequenceiq/flow/rotation/handler/ExecuteRotationHandlerTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/rotation/handler/ExecuteRotationHandlerTest.java
@@ -6,6 +6,10 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +23,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.eventbus.Event;
 import com.sequenceiq.cloudbreak.eventbus.EventBus;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretType;
+import com.sequenceiq.cloudbreak.rotation.secret.usage.SecretRotationUsageProcessor;
 import com.sequenceiq.flow.rotation.event.ExecuteRotationFailedEvent;
 import com.sequenceiq.flow.rotation.event.ExecuteRotationFinishedEvent;
 import com.sequenceiq.flow.rotation.event.ExecuteRotationTriggerEvent;
@@ -27,10 +33,15 @@ import com.sequenceiq.flow.rotation.service.SecretRotationService;
 @ExtendWith(MockitoExtension.class)
 public class ExecuteRotationHandlerTest {
 
+    private static final SecretType SECRET_TYPE = mock(SecretType.class);
+
     private ArgumentCaptor<Event> argumentCaptor;
 
     @Mock
     private SecretRotationService secretRotationService;
+
+    @Mock
+    private SecretRotationUsageProcessor secretRotationUsageProcessor;
 
     @InjectMocks
     private ExecuteRotationHandler underTest;
@@ -41,6 +52,7 @@ public class ExecuteRotationHandlerTest {
         EventBus eventBus = mock(EventBus.class);
         doNothing().when(eventBus).notify(anyString(), argumentCaptor.capture());
         FieldUtils.writeField(underTest, "eventBus", eventBus, true);
+        FieldUtils.writeField(underTest, "secretRotationUsageProcessor", Optional.of(secretRotationUsageProcessor), true);
     }
 
     @Test
@@ -50,6 +62,7 @@ public class ExecuteRotationHandlerTest {
         underTest.accept(Event.wrap(getTriggerEvent()));
 
         assertEquals(ExecuteRotationFinishedEvent.class, argumentCaptor.getValue().getData().getClass());
+        verify(secretRotationUsageProcessor, times(1)).rotationStarted(any(), any(), any());
     }
 
     @Test
@@ -59,10 +72,11 @@ public class ExecuteRotationHandlerTest {
         underTest.accept(Event.wrap(getTriggerEvent()));
 
         assertEquals(ExecuteRotationFailedEvent.class, argumentCaptor.getValue().getData().getClass());
+        verify(secretRotationUsageProcessor, times(1)).rotationStarted(any(), any(), any());
     }
 
     private static ExecuteRotationTriggerEvent getTriggerEvent() {
-        return new ExecuteRotationTriggerEvent(null, null, null, null, null);
+        return new ExecuteRotationTriggerEvent(null, null, null, SECRET_TYPE, null);
     }
 
 }

--- a/flow/src/test/java/com/sequenceiq/flow/rotation/handler/FinalizeRotationHandlerTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/rotation/handler/FinalizeRotationHandlerTest.java
@@ -6,6 +6,11 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +24,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.eventbus.Event;
 import com.sequenceiq.cloudbreak.eventbus.EventBus;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretType;
+import com.sequenceiq.cloudbreak.rotation.secret.usage.SecretRotationUsageProcessor;
 import com.sequenceiq.flow.rotation.event.FinalizeRotationSuccessEvent;
 import com.sequenceiq.flow.rotation.event.FinalizeRotationTriggerEvent;
 import com.sequenceiq.flow.rotation.event.RotationFailedEvent;
@@ -27,10 +34,15 @@ import com.sequenceiq.flow.rotation.service.SecretRotationService;
 @ExtendWith(MockitoExtension.class)
 public class FinalizeRotationHandlerTest {
 
+    private static final SecretType SECRET_TYPE = mock(SecretType.class);
+
     private ArgumentCaptor<Event> argumentCaptor;
 
     @Mock
     private SecretRotationService secretRotationService;
+
+    @Mock
+    private SecretRotationUsageProcessor secretRotationUsageProcessor;
 
     @InjectMocks
     private FinalizeRotationHandler underTest;
@@ -41,6 +53,7 @@ public class FinalizeRotationHandlerTest {
         EventBus eventBus = mock(EventBus.class);
         doNothing().when(eventBus).notify(anyString(), argumentCaptor.capture());
         FieldUtils.writeField(underTest, "eventBus", eventBus, true);
+        FieldUtils.writeField(underTest, "secretRotationUsageProcessor", Optional.of(secretRotationUsageProcessor), true);
     }
 
     @Test
@@ -50,6 +63,7 @@ public class FinalizeRotationHandlerTest {
         underTest.accept(Event.wrap(getTriggerEvent()));
 
         assertEquals(FinalizeRotationSuccessEvent.class, argumentCaptor.getValue().getData().getClass());
+        verify(secretRotationUsageProcessor, times(1)).rotationFinished(any(), any(), any());
     }
 
     @Test
@@ -59,10 +73,11 @@ public class FinalizeRotationHandlerTest {
         underTest.accept(Event.wrap(getTriggerEvent()));
 
         assertEquals(RotationFailedEvent.class, argumentCaptor.getValue().getData().getClass());
+        verify(secretRotationUsageProcessor, never()).rotationFinished(any(), any(), any());
     }
 
     private static FinalizeRotationTriggerEvent getTriggerEvent() {
-        return new FinalizeRotationTriggerEvent(null, null, null, null, null);
+        return new FinalizeRotationTriggerEvent(null, null, null, SECRET_TYPE, null);
     }
 
 }

--- a/usage-collection/src/main/java/com/sequenceiq/cloudbreak/usage/UsageReportProcessor.java
+++ b/usage-collection/src/main/java/com/sequenceiq/cloudbreak/usage/UsageReportProcessor.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.cloudera.thunderhead.service.common.usage.UsageProto;
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPSecretRotationEvent;
 import com.sequenceiq.cloudbreak.usage.model.UsageContext;
 import com.sequenceiq.cloudbreak.usage.strategy.CompositeUsageProcessingStrategy;
 import com.sequenceiq.cloudbreak.usage.strategy.UsageProcessingStrategy;
@@ -302,6 +303,14 @@ public class UsageReportProcessor implements UsageReporter {
         checkNotNull(details);
         usageProcessingStrategy.processUsage(eventBuilder()
                 .setCdpEnvironmentProxyConfigEditEvent(details)
+                .build(), null);
+    }
+
+    @Override
+    public void cdpSecretRotationEvent(CDPSecretRotationEvent details) {
+        checkNotNull(details);
+        usageProcessingStrategy.processUsage(eventBuilder()
+                .setCdpSecretRotationEvent(details)
                 .build(), null);
     }
 

--- a/usage-collection/src/main/java/com/sequenceiq/cloudbreak/usage/UsageReporter.java
+++ b/usage-collection/src/main/java/com/sequenceiq/cloudbreak/usage/UsageReporter.java
@@ -185,4 +185,11 @@ public interface UsageReporter {
      */
     void cdpEnvironmentProxyConfigEditEvent(
             UsageProto.CDPEnvironmentProxyConfigEditEvent details);
+
+    /**
+     * Reports a secret rotation event
+     * @param details the event details
+     */
+    void cdpSecretRotationEvent(
+            UsageProto.CDPSecretRotationEvent details);
 }

--- a/usage-collection/src/main/java/com/sequenceiq/cloudbreak/usage/service/SecretRotationUsageService.java
+++ b/usage-collection/src/main/java/com/sequenceiq/cloudbreak/usage/service/SecretRotationUsageService.java
@@ -1,0 +1,82 @@
+package com.sequenceiq.cloudbreak.usage.service;
+
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPSecretRotationEvent;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPSecretRotationStatus;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.rotation.secret.RotationFlowExecutionType;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretType;
+import com.sequenceiq.cloudbreak.rotation.secret.usage.SecretRotationUsageProcessor;
+import com.sequenceiq.cloudbreak.usage.UsageReporter;
+
+@Service
+public class SecretRotationUsageService implements SecretRotationUsageProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SecretRotationUsageService.class);
+
+    @Inject
+    private UsageReporter usageReporter;
+
+    @Override
+    public void rotationStarted(SecretType secretType, String resourceCrn, RotationFlowExecutionType executionType) {
+        if (executionType == null) {
+            sendUsageReport(secretType, resourceCrn, null, CDPSecretRotationStatus.Value.STARTED);
+        }
+    }
+
+    @Override
+    public void rotationFinished(SecretType secretType, String resourceCrn, RotationFlowExecutionType executionType) {
+        if (executionType == null) {
+            sendUsageReport(secretType, resourceCrn, null, CDPSecretRotationStatus.Value.FINISHED);
+        }
+    }
+
+    @Override
+    public void rotationFailed(SecretType secretType, String resourceCrn, String reason, RotationFlowExecutionType executionType) {
+        if (executionType == null) {
+            sendUsageReport(secretType, resourceCrn, reason, CDPSecretRotationStatus.Value.FAILED);
+        }
+    }
+
+    @Override
+    public void rollbackStarted(SecretType secretType, String resourceCrn, RotationFlowExecutionType executionType) {
+        if (executionType == null) {
+            sendUsageReport(secretType, resourceCrn, null, CDPSecretRotationStatus.Value.ROLLBACK_STARTED);
+        }
+    }
+
+    @Override
+    public void rollbackFinished(SecretType secretType, String resourceCrn, RotationFlowExecutionType executionType) {
+        if (executionType == null) {
+            sendUsageReport(secretType, resourceCrn, null, CDPSecretRotationStatus.Value.ROLLBACK_FINISHED);
+        }
+    }
+
+    @Override
+    public void rollbackFailed(SecretType secretType, String resourceCrn, String reason, RotationFlowExecutionType executionType) {
+        if (executionType == null) {
+            sendUsageReport(secretType, resourceCrn, reason, CDPSecretRotationStatus.Value.ROLLBACK_FAILED);
+        }
+    }
+
+    private void sendUsageReport(SecretType secretType, String resourceCrn, String reason, CDPSecretRotationStatus.Value status) {
+        try {
+            LOGGER.debug("Send secret rotation usage report for secretType: {}, status: {}, reason: {}", secretType, status, reason);
+            usageReporter.cdpSecretRotationEvent(CDPSecretRotationEvent.newBuilder()
+                    .setAccountId(ThreadBasedUserCrnProvider.getAccountId())
+                    .setSecretType(secretType.toString())
+                    .setResourceCrn(resourceCrn)
+                    .setReason(reason == null ? "" : reason)
+                    .setStatus(status)
+                    .build());
+        } catch (Exception e) {
+            LOGGER.error("Couldn't send usage report about secret rotation with secret type: {}, status: {}", secretType, status, e);
+        }
+    }
+}

--- a/usage-collection/src/main/proto/usage.proto
+++ b/usage-collection/src/main/proto/usage.proto
@@ -278,6 +278,14 @@ message Event {
     ApplicationMetricsReportEvent ApplicationMetricsReportEvent = 132;
     // A CDP CML model V2 upload event.
     ModelV2UploadedEvent modelV2UploadedEvent = 133;
+    // A Replication Manager usage statistics was reported
+    RMUsageStatistics rmUsageStatistics = 136;
+    // A CDP CDE usage event that reports heartbeats of active services
+    CDPCDEActiveServicesHeartbeat cdpCDEActiveServicesHeartbeat  = 137;
+    // A CDP CDE usage event that reports heartbeats of active virtual clusters
+    CDPCDEActiveVCHeartbeat cdpCDEActiveVCHeartbeat  = 138;
+    // A secret rotation started/finished/failed.
+    CDPSecretRotationEvent cdpSecretRotationEvent = 139;
   }
 }
 
@@ -294,6 +302,8 @@ message AltusIamAccountType {
     MANAGED_SKYNET_CDPONE_TRIAL = 3;
     // A managed Skynet CDP trial account.
     MANAGED_SKYNET_CDP_TRIAL = 4;
+    // DEPRECATED: C1C accounts. C1C accounts are created by users using an email.
+    C1C = 5;
   }
 }
 
@@ -928,6 +938,9 @@ message CDPCMLWorkspaceStatus {
     VALIDATE_MIGRATION_FINISHED = 64;
     // The status when the validate CDSW migration has failed.
     VALIDATE_MIGRATION_FAILED = 65;
+
+    // The status when the healthpoller is not able to reach the KubeAPI server of a workspace.
+    CONNECTION_FAILED = 66;
   }
 }
 
@@ -1152,6 +1165,8 @@ message CDPCMLWorkspaceNodeStatesHeartbeat {
   string workspaceVersion = 8;
   // The status of the CML workspace
   string workspaceStatus = 9;
+  // The information regarding metering pods
+  string meteringInfo = 10;
 }
 
 message CDPCMLWorkspaceNodeState {
@@ -1491,6 +1506,10 @@ message CDPLiftieClusterNodesSummary {
   int32 numNodesNonmeteredUnhealthy = 6;
   // The names of any unhealthy nodes
   repeated string unhealthyNodes = 7;
+  // The number of CDE Tier1 (CORE) nodes
+  int32 numNodesTier1 = 8;
+  // The number of CDE Tier2 (ALLP) nodes
+  int32 numNodesTier2 = 9;
 }
 
 message CDPLiftieClusterMeteringPodsSummary {
@@ -1541,6 +1560,8 @@ message CDPLiftieClusterPodStatesHeartbeatSummary {
   string clusterId = 2;
   // Total number of pods
   int32 totalNumPods = 3;
+  // total number of unhealthy pods
+  int32 totalUnhealthyPods = 12;
   // Summary Info of Metering Pods
   CDPLiftieClusterPodSummmary meteringPods = 4;
   // Summary Info of Fluentd Pods
@@ -1555,6 +1576,8 @@ message CDPLiftieClusterPodStatesHeartbeatSummary {
   repeated string unhealthyPodList = 9;
   // The workload region
   string workloadRegion = 10;
+  // The CDP environment CRN.
+  string environmentCrn = 11;
 }
 
 message CDPLiftieClusterPodSummmary {
@@ -1845,6 +1868,13 @@ message CDPClusterStatus {
     DELETE_EBS_VOLUMES_FINISHED = 62;
     // The status when a delete volume operation on a cluster has failed.
     DELETE_EBS_VOLUMES_FAILED = 63;
+
+    // The status when a CM sync operation is started.
+    CM_SYNC_STARTED = 64;
+    // The status when a CM sync operation is finished.
+    CM_SYNC_FINISHED = 65;
+    // The status when a CM sync operation is failed.
+    CM_SYNC_FAILED = 66;
   }
 }
 
@@ -2522,6 +2552,12 @@ message CDPDFServiceRequested {
   bool privateCluster = 14;
   // Is validation skipped for enable and update requests
   bool runValidations = 15;
+  // Is User Defined Routing(UDR) mode enabled?
+  bool userDefinedRouting = 16;
+  // Is a custom Pod CIDR range defined for assigning IPs to pods in the kubernetes cluster
+  bool customPodCidr = 17;
+  // Is a custom Service CIDR range defined for assigning IPs to services in the kubernetes cluster
+  bool customServiceCidr = 18;
 }
 
 message CDPDFServiceStatusChanged {
@@ -3543,6 +3579,55 @@ message CDPCDEServiceUpgradeRequested {
   string targetKubernetesVersion = 8;
 }
 
+// Heartbeat that reports all the active CDE services.
+message CDPCDEActiveServicesHeartbeat {
+  repeated CDPCDEActiveServiceDetails cdpCDEActiveServiceDetails = 1;
+}
+
+// Details of a CDE service to be reported in a heartbeat.
+message CDPCDEActiveServiceDetails {
+  // The ID of the CDE service.
+  string id = 1;
+  // The CDP account ID.
+  string accountId = 2;
+  // The CRN of the CDE cluster's environment.
+  string environmentCrn = 3;
+  // The cluster CRN.
+  string clusterCrn = 4;
+  // The environment type. Indicates the platform being used, mainly AWS or Azure.
+  CDPEnvironmentsEnvironmentType.Value environmentType = 5;
+  // The CDE version.
+  string cdeVersion = 6;
+  // Status of the CDP CDE service.
+  string status = 7;
+  // Kubernetes version of CDE service.
+  string kubernetesVersion = 8;
+  // Number of active virtual clusters in the service.
+  int32 numActiveVirtualClusters = 9;
+}
+
+// Heartbeat that reports all the active Virtual clusters.
+message CDPCDEActiveVCHeartbeat {
+  repeated CDPCDEActiveVCDetails cdpCDEActiveVCDetails = 1;
+}
+
+// Details of a virtual cluster to be reported in the heartbeat.
+message CDPCDEActiveVCDetails{
+  // The ID of the CDP CDE virtual cluster.
+  string id = 1;
+  // The ID of the CDP CDE service for which the virtual cluster creation was requested.
+  string clusterId = 2;
+  // The CRN of the CDP CDE service for which the virtual cluster creation was requested.
+  string clusterCrn = 3;
+  // The CDP account ID.
+  string accountId = 4;
+  // Spark version of the virtual cluster.
+  string sparkVersion = 5;
+  // Status of the CDP CDE virtual cluster.
+  string status = 6;
+  // Tier of the virtual cluster.
+  string appTier = 7;
+}
 
 // Generated when a CDP CDE job run is initiated or its status changes.
 message CDPCDEJobRunStatusChanged {
@@ -4168,8 +4253,9 @@ message CDPTrialEnvironment {
 
 // The pattern and status for CDP Trial workloads.
 message CDPTrialWorkload {
-  // Pattern used by the trial workload. Currently supported CDP trial workload patterns are CDP_OPEN_DATA_LAKEHOUSE.
+  // Pattern used by the trial workload. Currently supported CDP trial workload patterns are CDP_OPEN_DATA_LAKEHOUSE and CDP_DATA_DISTRIBUTION_AND_STREAM_ANALYTICS.
   // CDP_OPEN_DATA_LAKEHOUSE - Indicates open data lakehouse pattern for CDP.
+  // CDP_DATA_DISTRIBUTION_AND_STREAM_ANALYTICS - Indicates data flow pattern for CDP.
   string pattern = 1;
   // Status of the workload deployment for the trial.
   CDPTrialWorkloadStatus.Value status = 2;
@@ -4528,9 +4614,11 @@ message ExperimentRunEvent {
   string status = 5;
   string action= 6;
   uint32 tags = 7;
-  uint32 metrics = 8;
   uint32 params = 9;
   uint32 artifacts = 10;
+  string history = 11;
+  string version = 12;
+  string engineId = 13;
 }
 
 message ModelDeployedEvent {
@@ -4680,4 +4768,58 @@ message ModelV2UploadedEvent {
   string runId = 5;
   uint32 userId = 6;
   uint32 projectId = 7;
+}
+
+// A Replication manager policy statistics details
+message RMPolicyStatistics {
+  // Amount of replication policies of certain type managed by Replication Manager
+  int32 amount = 1;
+}
+
+// A Replication manager statistics details
+message RMUsageStatistics {
+  // Amount of clusters managed by Replication Manager
+  int32 amountOfClusters = 1;
+  // Amount of replication policies managed by Replication Manager
+  int32 amountOfPolicies = 2;
+  // Details of HDFS Policies managed by Replication manager
+  RMPolicyStatistics hdfsPolicies = 3;
+  // Details of HIVE Policies managed by Replication manager
+  RMPolicyStatistics hivePolicies = 4;
+  // Details of HBase Policies managed by Replication manager
+  RMPolicyStatistics hbasePolicies = 5;
+}
+
+// Status of secret rotation event
+message CDPSecretRotationStatus {
+  enum Value {
+    // Indicates that status cannot be recognized
+    UNKNOWN = 0;
+    // Indicates that it is a secret rotation started event
+    STARTED = 1;
+    // Indicates that it is a secret rotation finished event
+    FINISHED = 2;
+    // Indicates that it is a secret rotation failed event
+    FAILED = 3;
+    // Indicates that it is a secret rotation rollback started event
+    ROLLBACK_STARTED = 4;
+    // Indicates that it is a secret rotation rollback finished event
+    ROLLBACK_FINISHED = 5;
+    // Indicates that it is a secret rotation rollback failed event
+    ROLLBACK_FAILED = 6;
+  }
+}
+
+// Event about secret rotation
+message CDPSecretRotationEvent {
+  // Status of secret rotation
+  CDPSecretRotationStatus.Value status = 1;
+  // CRN of resource
+  string resourceCrn = 2;
+  // Secret type
+  string secretType = 3;
+  // Status reason
+  string reason = 4;
+  // corresponding account id
+  string accountId = 5;
 }

--- a/usage-collection/src/test/java/com/sequenceiq/cloudbreak/usage/service/SecretRotationUsageServiceTest.java
+++ b/usage-collection/src/test/java/com/sequenceiq/cloudbreak/usage/service/SecretRotationUsageServiceTest.java
@@ -1,0 +1,195 @@
+package com.sequenceiq.cloudbreak.usage.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.thunderhead.service.common.usage.UsageProto;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.rotation.secret.RotationFlowExecutionType;
+import com.sequenceiq.cloudbreak.rotation.secret.SecretType;
+import com.sequenceiq.cloudbreak.usage.UsageReporter;
+
+@ExtendWith(MockitoExtension.class)
+public class SecretRotationUsageServiceTest {
+
+    private static final SecretType SECRET_TYPE = mock(SecretType.class);
+
+    private static final String RESOURCE_CRN = "resourceCrn";
+
+    private static final String REASON = "reason";
+
+    private static final String USER_CRN = "crn:cdp:iam:us-west-1:1234:user:5678";
+
+    @Mock
+    private UsageReporter usageReporter;
+
+    @InjectMocks
+    private SecretRotationUsageService underTest;
+
+    @Test
+    public void testRotationStartedWhenErrorOccurs() {
+        underTest.rotationStarted(null, null, null);
+        verifyNoInteractions(usageReporter);
+    }
+
+    @Test
+    public void testRotationFinishedWhenErrorOccurs() {
+        underTest.rotationFinished(null, null, null);
+        verifyNoInteractions(usageReporter);
+    }
+
+    @Test
+    public void testRotationFailedWhenErrorOccurs() {
+        underTest.rotationFailed(null, null, null, null);
+        verifyNoInteractions(usageReporter);
+    }
+
+    @Test
+    public void testRollbackStartedWhenErrorOccurs() {
+        underTest.rollbackStarted(null, null, null);
+        verifyNoInteractions(usageReporter);
+    }
+
+    @Test
+    public void testRollbackFinishedWhenErrorOccurs() {
+        underTest.rollbackFinished(null, null, null);
+        verifyNoInteractions(usageReporter);
+    }
+
+    @Test
+    public void testRollbackFailedWhenErrorOccurs() {
+        underTest.rollbackFailed(null, null, null, null);
+        verifyNoInteractions(usageReporter);
+    }
+
+    @Test
+    public void testRotationStartedWhenExecutionTypeIsNotNull() {
+        underTest.rotationStarted(SECRET_TYPE, RESOURCE_CRN, RotationFlowExecutionType.ROTATE);
+        verifyNoInteractions(usageReporter);
+    }
+
+    @Test
+    public void testRotationFinishedWhenExecutionTypeIsNotNull() {
+        underTest.rotationFinished(SECRET_TYPE, RESOURCE_CRN, RotationFlowExecutionType.ROTATE);
+        verifyNoInteractions(usageReporter);
+    }
+
+    @Test
+    public void testRotationFailedWhenExecutionTypeIsNotNull() {
+        underTest.rotationFailed(SECRET_TYPE, RESOURCE_CRN, null, RotationFlowExecutionType.ROTATE);
+        verifyNoInteractions(usageReporter);
+    }
+
+    @Test
+    public void testRollbackStartedWhenExecutionTypeIsNotNull() {
+        underTest.rollbackStarted(SECRET_TYPE, RESOURCE_CRN, RotationFlowExecutionType.ROTATE);
+        verifyNoInteractions(usageReporter);
+    }
+
+    @Test
+    public void testRollbackFinishedWhenExecutionTypeIsNotNull() {
+        underTest.rollbackFinished(SECRET_TYPE, RESOURCE_CRN, RotationFlowExecutionType.ROTATE);
+        verifyNoInteractions(usageReporter);
+    }
+
+    @Test
+    public void testRollbackFailedWhenExecutionTypeIsNotNull() {
+        underTest.rollbackFailed(SECRET_TYPE, RESOURCE_CRN, null, RotationFlowExecutionType.ROTATE);
+        verifyNoInteractions(usageReporter);
+    }
+
+    @Test
+    public void testRotationStarted() {
+        doNothing().when(usageReporter).cdpSecretRotationEvent(any());
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.rotationStarted(SECRET_TYPE, RESOURCE_CRN, null));
+
+        ArgumentCaptor<UsageProto.CDPSecretRotationEvent> eventCaptor = ArgumentCaptor.forClass(UsageProto.CDPSecretRotationEvent.class);
+        verify(usageReporter).cdpSecretRotationEvent(eventCaptor.capture());
+        UsageProto.CDPSecretRotationEvent event = eventCaptor.getValue();
+        assertEquals(RESOURCE_CRN, event.getResourceCrn());
+        assertEquals(SECRET_TYPE.toString(), event.getSecretType());
+        assertEquals("", event.getReason());
+        assertEquals(UsageProto.CDPSecretRotationStatus.Value.STARTED, event.getStatus());
+    }
+
+    @Test
+    public void testRotationFinished() {
+        doNothing().when(usageReporter).cdpSecretRotationEvent(any());
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.rotationFinished(SECRET_TYPE, RESOURCE_CRN, null));
+
+        ArgumentCaptor<UsageProto.CDPSecretRotationEvent> eventCaptor = ArgumentCaptor.forClass(UsageProto.CDPSecretRotationEvent.class);
+        verify(usageReporter).cdpSecretRotationEvent(eventCaptor.capture());
+        UsageProto.CDPSecretRotationEvent event = eventCaptor.getValue();
+        assertEquals(RESOURCE_CRN, event.getResourceCrn());
+        assertEquals(SECRET_TYPE.toString(), event.getSecretType());
+        assertEquals("", event.getReason());
+        assertEquals(UsageProto.CDPSecretRotationStatus.Value.FINISHED, event.getStatus());
+    }
+
+    @Test
+    public void testRotationFailed() {
+        doNothing().when(usageReporter).cdpSecretRotationEvent(any());
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.rotationFailed(SECRET_TYPE, RESOURCE_CRN, REASON, null));
+
+        ArgumentCaptor<UsageProto.CDPSecretRotationEvent> eventCaptor = ArgumentCaptor.forClass(UsageProto.CDPSecretRotationEvent.class);
+        verify(usageReporter).cdpSecretRotationEvent(eventCaptor.capture());
+        UsageProto.CDPSecretRotationEvent event = eventCaptor.getValue();
+        assertEquals(RESOURCE_CRN, event.getResourceCrn());
+        assertEquals(SECRET_TYPE.toString(), event.getSecretType());
+        assertEquals(REASON, event.getReason());
+        assertEquals(UsageProto.CDPSecretRotationStatus.Value.FAILED, event.getStatus());
+    }
+
+    @Test
+    public void testRollbackStarted() {
+        doNothing().when(usageReporter).cdpSecretRotationEvent(any());
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.rollbackStarted(SECRET_TYPE, RESOURCE_CRN, null));
+
+        ArgumentCaptor<UsageProto.CDPSecretRotationEvent> eventCaptor = ArgumentCaptor.forClass(UsageProto.CDPSecretRotationEvent.class);
+        verify(usageReporter).cdpSecretRotationEvent(eventCaptor.capture());
+        UsageProto.CDPSecretRotationEvent event = eventCaptor.getValue();
+        assertEquals(RESOURCE_CRN, event.getResourceCrn());
+        assertEquals(SECRET_TYPE.toString(), event.getSecretType());
+        assertEquals("", event.getReason());
+        assertEquals(UsageProto.CDPSecretRotationStatus.Value.ROLLBACK_STARTED, event.getStatus());
+    }
+
+    @Test
+    public void testRollbackFinished() {
+        doNothing().when(usageReporter).cdpSecretRotationEvent(any());
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.rollbackFinished(SECRET_TYPE, RESOURCE_CRN, null));
+
+        ArgumentCaptor<UsageProto.CDPSecretRotationEvent> eventCaptor = ArgumentCaptor.forClass(UsageProto.CDPSecretRotationEvent.class);
+        verify(usageReporter).cdpSecretRotationEvent(eventCaptor.capture());
+        UsageProto.CDPSecretRotationEvent event = eventCaptor.getValue();
+        assertEquals(RESOURCE_CRN, event.getResourceCrn());
+        assertEquals(SECRET_TYPE.toString(), event.getSecretType());
+        assertEquals("", event.getReason());
+        assertEquals(UsageProto.CDPSecretRotationStatus.Value.ROLLBACK_FINISHED, event.getStatus());
+    }
+
+    @Test
+    public void testRollbackFailed() {
+        doNothing().when(usageReporter).cdpSecretRotationEvent(any());
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.rollbackFailed(SECRET_TYPE, RESOURCE_CRN, REASON, null));
+
+        ArgumentCaptor<UsageProto.CDPSecretRotationEvent> eventCaptor = ArgumentCaptor.forClass(UsageProto.CDPSecretRotationEvent.class);
+        verify(usageReporter).cdpSecretRotationEvent(eventCaptor.capture());
+        UsageProto.CDPSecretRotationEvent event = eventCaptor.getValue();
+        assertEquals(RESOURCE_CRN, event.getResourceCrn());
+        assertEquals(SECRET_TYPE.toString(), event.getSecretType());
+        assertEquals(REASON, event.getReason());
+        assertEquals(UsageProto.CDPSecretRotationStatus.Value.ROLLBACK_FAILED, event.getStatus());
+    }
+}


### PR DESCRIPTION
Only first-level secretTypes will be sent to EDH, where the execution type is null (secret types from polling are not included). SecretRotationUsageProcessor is injected as an optional service, to avoid using usage-collection as a flow module depencency.

See detailed description in the commit message.