### PR TITLE
CB-21875 Does not set FINISHED status if the actual status is FAILED …

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/StackSecretRotationStatusService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/StackSecretRotationStatusService.java
@@ -6,6 +6,8 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
+import com.sequenceiq.cloudbreak.view.StackView;
 import com.sequenceiq.flow.rotation.status.service.SecretRotationStatusService;
 
 @Primary
@@ -15,6 +17,9 @@ public class StackSecretRotationStatusService implements SecretRotationStatusSer
     @Inject
     private StackUpdater stackUpdater;
 
+    @Inject
+    private StackDtoService stackDtoService;
+
     @Override
     public void rotationStarted(String resourceCrn) {
         stackUpdater.updateStackStatus(resourceCrn, DetailedStackStatus.SECRET_ROTATION_STARTED, null);
@@ -22,7 +27,10 @@ public class StackSecretRotationStatusService implements SecretRotationStatusSer
 
     @Override
     public void rotationFinished(String resourceCrn) {
-        stackUpdater.updateStackStatus(resourceCrn, DetailedStackStatus.SECRET_ROTATION_FINISHED, null);
+        StackView stack = stackDtoService.getStackViewByCrn(resourceCrn);
+        if (stack.getStackStatus().getDetailedStackStatus() != DetailedStackStatus.SECRET_ROTATION_FAILED) {
+            stackUpdater.updateStackStatus(resourceCrn, DetailedStackStatus.SECRET_ROTATION_FINISHED, null);
+        }
     }
 
     @Override

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/StackSecretRotationStatusServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/StackSecretRotationStatusServiceTest.java
@@ -1,16 +1,25 @@
 package com.sequenceiq.cloudbreak.service;
 
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.SECRET_ROTATION_FAILED;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.SECRET_ROTATION_FINISHED;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.SECRET_ROTATION_STARTED;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 
 @ExtendWith(MockitoExtension.class)
 class StackSecretRotationStatusServiceTest {
@@ -22,25 +31,41 @@ class StackSecretRotationStatusServiceTest {
     @Mock
     private StackUpdater stackUpdater;
 
+    @Mock
+    private StackDtoService stackDtoService;
+
     @InjectMocks
     private StackSecretRotationStatusService underTest;
 
     @Test
     void testRotationStarted() {
         underTest.rotationStarted(RESOURCE_CRN);
-        Mockito.verify(stackUpdater, Mockito.times(1)).updateStackStatus(eq(RESOURCE_CRN), eq(DetailedStackStatus.SECRET_ROTATION_STARTED), isNull());
+        verify(stackUpdater, times(1)).updateStackStatus(eq(RESOURCE_CRN), eq(SECRET_ROTATION_STARTED), isNull());
     }
 
     @Test
     void testRotationFinished() {
+        when(stackDtoService.getStackViewByCrn(eq(RESOURCE_CRN))).thenReturn(stack(SECRET_ROTATION_STARTED));
         underTest.rotationFinished(RESOURCE_CRN);
-        Mockito.verify(stackUpdater, Mockito.times(1)).updateStackStatus(eq(RESOURCE_CRN), eq(DetailedStackStatus.SECRET_ROTATION_FINISHED), isNull());
+        verify(stackUpdater, times(1)).updateStackStatus(eq(RESOURCE_CRN), eq(SECRET_ROTATION_FINISHED), isNull());
+    }
+
+    @Test
+    void testRotationFinishedShouldSkipStatusUpdateWhenStatusIsAlreadySecretRotationFailed() {
+        when(stackDtoService.getStackViewByCrn(eq(RESOURCE_CRN))).thenReturn(stack(SECRET_ROTATION_FAILED));
+        underTest.rotationFinished(RESOURCE_CRN);
+        verify(stackUpdater, never()).updateStackStatus(eq(RESOURCE_CRN), eq(SECRET_ROTATION_FINISHED), isNull());
     }
 
     @Test
     void testRotationFailed() {
         underTest.rotationFailed(RESOURCE_CRN, STATUS_REASON);
-        Mockito.verify(stackUpdater, Mockito.times(1)).updateStackStatus(eq(RESOURCE_CRN), eq(DetailedStackStatus.SECRET_ROTATION_FAILED), eq(STATUS_REASON));
+        verify(stackUpdater, times(1)).updateStackStatus(eq(RESOURCE_CRN), eq(SECRET_ROTATION_FAILED), eq(STATUS_REASON));
     }
 
+    private Stack stack(DetailedStackStatus detailedStackStatus) {
+        Stack stack = new Stack();
+        stack.setStackStatus(new StackStatus(stack, detailedStackStatus));
+        return stack;
+    }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/entity/DatalakeStatusEnum.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/entity/DatalakeStatusEnum.java
@@ -130,6 +130,8 @@ public enum DatalakeStatusEnum {
                 return DATALAKE_UPGRADE_CCM_FAILED;
             case SALT_PASSWORD_ROTATION_IN_PROGRESS:
                 return SALT_PASSWORD_ROTATION_FAILED;
+            case DATALAKE_SECRET_ROTATION_IN_PROGRESS:
+                return DATALAKE_SECRET_ROTATION_FAILED;
             default:
                 return this;
         }

--- a/datalake/src/test/java/com/sequenceiq/datalake/entity/DatalakeStatusEnumTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/entity/DatalakeStatusEnumTest.java
@@ -4,6 +4,8 @@ import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.CERT_ROTATION_FA
 import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.CERT_ROTATION_IN_PROGRESS;
 import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.CHANGE_IMAGE_IN_PROGRESS;
 import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.DATALAKE_ROLLING_UPGRADE_IN_PROGRESS;
+import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.DATALAKE_SECRET_ROTATION_FAILED;
+import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.DATALAKE_SECRET_ROTATION_IN_PROGRESS;
 import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.DATALAKE_UPGRADE_CCM_FAILED;
 import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.DATALAKE_UPGRADE_CCM_IN_PROGRESS;
 import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.DATALAKE_UPGRADE_FAILED;
@@ -56,7 +58,8 @@ class DatalakeStatusEnumTest {
                     entry(DATALAKE_ROLLING_UPGRADE_IN_PROGRESS, DATALAKE_UPGRADE_FAILED),
                     entry(DATALAKE_UPGRADE_IN_PROGRESS, DATALAKE_UPGRADE_FAILED), entry(CERT_ROTATION_IN_PROGRESS, CERT_ROTATION_FAILED),
                     entry(RECOVERY_IN_PROGRESS, RECOVERY_FAILED), entry(DATALAKE_UPGRADE_CCM_IN_PROGRESS, DATALAKE_UPGRADE_CCM_FAILED),
-                    entry(SALT_PASSWORD_ROTATION_IN_PROGRESS, SALT_PASSWORD_ROTATION_FAILED))
+                    entry(SALT_PASSWORD_ROTATION_IN_PROGRESS, SALT_PASSWORD_ROTATION_FAILED),
+                    entry(DATALAKE_SECRET_ROTATION_IN_PROGRESS, DATALAKE_SECRET_ROTATION_FAILED))
     );
 
     private static final Set<DatalakeStatusEnum> STOP_STATE_SET = EnumSet.of(STOPPED, STOP_IN_PROGRESS);

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/status/SdxSecretRotationStatusServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/status/SdxSecretRotationStatusServiceTest.java
@@ -1,9 +1,15 @@
 package com.sequenceiq.datalake.service.sdx.status;
 
+import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.DATALAKE_SECRET_ROTATION_FAILED;
+import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.DATALAKE_SECRET_ROTATION_FINISHED;
+import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.DATALAKE_SECRET_ROTATION_IN_PROGRESS;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +18,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.entity.SdxStatusEntity;
+import com.sequenceiq.datalake.service.sdx.SdxService;
 
 @ExtendWith(MockitoExtension.class)
 class SdxSecretRotationStatusServiceTest {
@@ -23,27 +32,43 @@ class SdxSecretRotationStatusServiceTest {
     @Mock
     private SdxStatusService sdxStatusService;
 
+    @Mock
+    private SdxService sdxService;
+
     @InjectMocks
     private SdxSecretRotationStatusService underTest;
 
     @Test
     void testRotationStarted() {
         underTest.rotationStarted(RESOURCE_CRN);
-        verify(sdxStatusService, times(1))
-                .setStatusForDatalakeAndNotify(eq(DatalakeStatusEnum.DATALAKE_SECRET_ROTATION_IN_PROGRESS), isNull(), eq(RESOURCE_CRN));
+        verify(sdxStatusService, times(1)).setStatusForDatalakeAndNotify(eq(DATALAKE_SECRET_ROTATION_IN_PROGRESS), isNull(), eq(RESOURCE_CRN));
     }
 
     @Test
     void testRotationFinished() {
+        when(sdxService.getByCrn(eq(RESOURCE_CRN))).thenReturn(new SdxCluster());
+        when(sdxStatusService.getActualStatusForSdx(any(SdxCluster.class))).thenReturn(sdxStatusEntity(DATALAKE_SECRET_ROTATION_IN_PROGRESS));
         underTest.rotationFinished(RESOURCE_CRN);
-        verify(sdxStatusService, times(1))
-                .setStatusForDatalakeAndNotify(eq(DatalakeStatusEnum.DATALAKE_SECRET_ROTATION_FINISHED), isNull(), eq(RESOURCE_CRN));
+        verify(sdxStatusService, times(1)).setStatusForDatalakeAndNotify(eq(DATALAKE_SECRET_ROTATION_FINISHED), isNull(), eq(RESOURCE_CRN));
+    }
+
+    @Test
+    void testRotationFinishedShouldSkipStatusUpdateWhenStatusIsAlreadySecretRotationFailed() {
+        when(sdxService.getByCrn(eq(RESOURCE_CRN))).thenReturn(new SdxCluster());
+        when(sdxStatusService.getActualStatusForSdx(any(SdxCluster.class))).thenReturn(sdxStatusEntity(DATALAKE_SECRET_ROTATION_FAILED));
+        underTest.rotationFinished(RESOURCE_CRN);
+        verify(sdxStatusService, never()).setStatusForDatalakeAndNotify(eq(DATALAKE_SECRET_ROTATION_FINISHED), isNull(), eq(RESOURCE_CRN));
     }
 
     @Test
     void testRotationFailed() {
         underTest.rotationFailed(RESOURCE_CRN, STATUS_REASON);
-        verify(sdxStatusService, times(1))
-                .setStatusForDatalakeAndNotify(eq(DatalakeStatusEnum.DATALAKE_SECRET_ROTATION_FAILED), eq(STATUS_REASON), eq(RESOURCE_CRN));
+        verify(sdxStatusService, times(1)).setStatusForDatalakeAndNotify(eq(DATALAKE_SECRET_ROTATION_FAILED), eq(STATUS_REASON), eq(RESOURCE_CRN));
+    }
+
+    private SdxStatusEntity sdxStatusEntity(DatalakeStatusEnum datalakeStatusEnum) {
+        SdxStatusEntity sdxStatusEntity = new SdxStatusEntity();
+        sdxStatusEntity.setStatus(datalakeStatusEnum);
+        return sdxStatusEntity;
     }
 }


### PR DESCRIPTION
…during secret rotation. This may occur if the rotation is done in multiple services, because we intentionally prevent the sub-flow from failing, thus the status change at the end of the sub-flowchain would try to set the FINISHED status.

See detailed description in the commit message.