### PR TITLE
CB-20506 Add image info to FMS instancemetadata

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Image.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Image.java
@@ -5,6 +5,7 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -61,9 +62,8 @@ public class Image {
         return userdata;
     }
 
+    @Deprecated
     public void setUserdata(Map<InstanceGroupType, String> userdata) {
-        // This is a deprecated field because of FedRAMP we moved this value into vault. Old clusters still
-        // using this value but the new clusters using stack.coreUserData and stack.gatewayUserData
         this.userdata = userdata;
     }
 
@@ -89,6 +89,31 @@ public class Image {
 
     public Map<String, String> getPackageVersions() {
         return packageVersions == null ? new HashMap<>() : packageVersions;
+    }
+
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        } else {
+            Image image = (Image) o;
+            return Objects.equals(imageName, image.imageName)
+                    && Objects.equals(userdata, image.userdata)
+                    && Objects.equals(os, image.os)
+                    && Objects.equals(osType, image.osType)
+                    && Objects.equals(imageCatalogUrl, image.imageCatalogUrl)
+                    && Objects.equals(imageId, image.imageId)
+                    && Objects.equals(imageCatalogName, image.imageCatalogName)
+                    && Objects.equals(packageVersions, image.packageVersions);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(imageName, userdata, os, osType, imageCatalogUrl, imageId, imageCatalogName, packageVersions);
     }
 
     @Override

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/instance/InstanceMetaDataResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/instance/InstanceMetaDataResponse.java
@@ -1,15 +1,18 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaModelDescriptions.HostMetadataModelDescription;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaModelDescriptions.InstanceGroupModelDescription;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaModelDescriptions.InstanceMetaDataModelDescription;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsResponse;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel("InstanceMetaDataV1Response")
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_NULL)
 public class InstanceMetaDataResponse {
 
@@ -48,6 +51,8 @@ public class InstanceMetaDataResponse {
 
     @ApiModelProperty(InstanceGroupModelDescription.AVAILABILITY_ZONE)
     private String availabilityZone;
+
+    private ImageSettingsResponse image;
 
     public String getInstanceGroup() {
         return instanceGroup;
@@ -145,6 +150,14 @@ public class InstanceMetaDataResponse {
         this.availabilityZone = availabilityZone;
     }
 
+    public ImageSettingsResponse getImage() {
+        return image;
+    }
+
+    public void setImage(ImageSettingsResponse image) {
+        this.image = image;
+    }
+
     @Override
     public String toString() {
         return "InstanceMetaDataResponse{" +
@@ -160,6 +173,7 @@ public class InstanceMetaDataResponse {
                 ", lifeCycle=" + lifeCycle +
                 ", subnetId='" + subnetId + '\'' +
                 ", availabilityZone='" + availabilityZone + '\'' +
+                ", image=" + image +
                 '}';
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/image/ImageToImageEntityConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/image/ImageToImageEntityConverter.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.freeipa.converter.image;
 
+import java.util.Map;
+
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image;
@@ -7,6 +9,8 @@ import com.sequenceiq.freeipa.entity.ImageEntity;
 
 @Component
 public class ImageToImageEntityConverter {
+
+    private static final String FREEIPA_LDAP_AGENT = "freeipa-ldap-agent";
 
     public ImageEntity convert(String accountId, Image source) {
         ImageEntity imageEntity = new ImageEntity();
@@ -20,6 +24,14 @@ public class ImageToImageEntityConverter {
     }
 
     public String extractLdapAgentVersion(Image image) {
-        return image.getPackageVersions() == null ? null : image.getPackageVersions().get("freeipa-ldap-agent");
+        return extractLdapAgentVersion(image.getPackageVersions());
+    }
+
+    public String extractLdapAgentVersion(com.sequenceiq.cloudbreak.cloud.model.Image image) {
+        return extractLdapAgentVersion(image.getPackageVersions());
+    }
+
+    private String extractLdapAgentVersion(Map<String, String> packageVersions) {
+        return packageVersions == null ? null : packageVersions.get(FREEIPA_LDAP_AGENT);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/image/ImageToImageSettingsResponseConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/image/ImageToImageSettingsResponseConverter.java
@@ -1,5 +1,10 @@
 package com.sequenceiq.freeipa.converter.image;
 
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
@@ -9,6 +14,11 @@ import com.sequenceiq.freeipa.entity.ImageEntity;
 @Component
 public class ImageToImageSettingsResponseConverter implements Converter<ImageEntity, ImageSettingsResponse> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImageToImageSettingsResponseConverter.class);
+
+    @Inject
+    private ImageToImageEntityConverter imageEntityConverter;
+
     public ImageSettingsResponse convert(ImageEntity source) {
         ImageSettingsResponse response = new ImageSettingsResponse();
         response.setCatalog(source.getImageCatalogUrl());
@@ -16,5 +26,19 @@ public class ImageToImageSettingsResponseConverter implements Converter<ImageEnt
         response.setOs(source.getOs());
         response.setLdapAgentVersion(source.getLdapAgentVersion());
         return response;
+    }
+
+    public ImageSettingsResponse convert(com.sequenceiq.cloudbreak.cloud.model.Image source) {
+        if (source != null) {
+            ImageSettingsResponse response = new ImageSettingsResponse();
+            response.setId(source.getImageId());
+            response.setOs(source.getOs());
+            response.setCatalog(StringUtils.isNotEmpty(source.getImageCatalogUrl()) ? source.getImageCatalogUrl() : source.getImageCatalogName());
+            response.setLdapAgentVersion(imageEntityConverter.extractLdapAgentVersion(source));
+            return response;
+        } else {
+            LOGGER.debug("Source image is null");
+            return null;
+        }
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverter.java
@@ -52,13 +52,8 @@ public class InstanceGroupRequestToInstanceGroupConverter {
     @Inject
     private DefaultInstanceGroupProvider defaultInstanceGroupProvider;
 
-    public InstanceGroup convert(InstanceGroupRequest source,
-        NetworkRequest networkRequest,
-        String accountId,
-        Stack stack,
-        FreeIpaServerRequest ipaServerRequest,
-        DetailedEnvironmentResponse environment,
-        EnumMap<CloudArgsForIgConverter, String> cloudArgsForIgConverter) {
+    public InstanceGroup convert(InstanceGroupRequest source, NetworkRequest networkRequest, String accountId, Stack stack,
+            FreeIpaServerRequest ipaServerRequest, DetailedEnvironmentResponse environment, EnumMap<CloudArgsForIgConverter, String> cloudArgsForIgConverter) {
         InstanceGroup instanceGroup = new InstanceGroup();
         CloudPlatform cloudPlatform = CloudPlatform.valueOf(stack.getCloudPlatform());
         instanceGroup.setTemplate(source.getInstanceTemplate() == null

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/InstanceMetaDataToInstanceMetaDataResponseConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/InstanceMetaDataToInstanceMetaDataResponseConverter.java
@@ -4,16 +4,23 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import javax.inject.Inject;
+
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetaDataResponse;
+import com.sequenceiq.freeipa.converter.image.ImageToImageSettingsResponseConverter;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 
 @Component
 public class InstanceMetaDataToInstanceMetaDataResponseConverter implements Converter<InstanceMetaData, InstanceMetaDataResponse> {
 
     private static final String NOT_AVAILABLE = "N/A";
+
+    @Inject
+    private ImageToImageSettingsResponseConverter imageConverter;
 
     @Override
     public InstanceMetaDataResponse convert(InstanceMetaData source) {
@@ -33,6 +40,10 @@ public class InstanceMetaDataToInstanceMetaDataResponseConverter implements Conv
         metaDataJson.setLifeCycle(source.getLifeCycle());
         metaDataJson.setAvailabilityZone(source.getAvailabilityZone());
         metaDataJson.setSubnetId(source.getSubnetId());
+        if (source.getImage() != null) {
+            Image image = source.getImage().getSilent(Image.class);
+            metaDataJson.setImage(imageConverter.convert(image));
+        }
         return metaDataJson;
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceMetaData.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceMetaData.java
@@ -10,6 +10,8 @@ import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.json.JsonToString;
 import com.sequenceiq.cloudbreak.common.orchestration.Node;
 import com.sequenceiq.cloudbreak.common.orchestration.OrchestrationNode;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceLifeCycle;
@@ -67,6 +69,10 @@ public class InstanceMetaData implements OrchestrationNode {
     private InstanceLifeCycle lifeCycle;
 
     private String variant;
+
+    @Convert(converter = JsonToString.class)
+    @Column(columnDefinition = "TEXT")
+    private Json image;
 
     public String getPrivateIp() {
         return privateIp;
@@ -251,6 +257,14 @@ public class InstanceMetaData implements OrchestrationNode {
 
     public void setVariant(String variant) {
         this.variant = variant;
+    }
+
+    public Json getImage() {
+        return image;
+    }
+
+    public void setImage(Json image) {
+        this.image = image;
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upgrade/UpgradeEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upgrade/UpgradeEvent.java
@@ -29,6 +29,9 @@ public class UpgradeEvent extends StackEvent {
 
     private final VerticalScaleRequest verticalScaleRequest;
 
+    @SuppressWarnings("IllegalType")
+    private final HashSet<String> instancesOnOldImage;
+
     @JsonCreator
     public UpgradeEvent(
             @JsonProperty("selector") String selector,
@@ -40,7 +43,8 @@ public class UpgradeEvent extends StackEvent {
             @JsonProperty("backupSet") boolean backupSet,
             @JsonProperty("needMigration") boolean needMigration,
             @JsonProperty("triggeredVariant") String triggeredVariant,
-            @JsonProperty("verticalScaleRequest") VerticalScaleRequest verticalScaleRequest) {
+            @JsonProperty("verticalScaleRequest") VerticalScaleRequest verticalScaleRequest,
+            @JsonProperty("instancesOnOldImage") HashSet<String> instancesOnOldImage) {
         super(selector, stackId);
         this.instanceIds = instanceIds;
         this.primareGwInstanceId = primareGwInstanceId;
@@ -50,6 +54,7 @@ public class UpgradeEvent extends StackEvent {
         this.needMigration = needMigration;
         this.triggeredVariant = triggeredVariant;
         this.verticalScaleRequest = verticalScaleRequest;
+        this.instancesOnOldImage = instancesOnOldImage;
     }
 
     public Set<String> getInstanceIds() {
@@ -84,6 +89,10 @@ public class UpgradeEvent extends StackEvent {
         return verticalScaleRequest;
     }
 
+    public Set<String> getInstancesOnOldImage() {
+        return instancesOnOldImage;
+    }
+
     @Override
     public boolean equalsEvent(StackEvent other) {
         return isClassAndEqualsEvent(UpgradeEvent.class, other,
@@ -94,7 +103,8 @@ public class UpgradeEvent extends StackEvent {
                         && Objects.equals(triggeredVariant, event.triggeredVariant)
                         && backupSet == event.backupSet
                         && needMigration == event.needMigration
-                        && Objects.equals(verticalScaleRequest, event.verticalScaleRequest));
+                        && Objects.equals(verticalScaleRequest, event.verticalScaleRequest)
+                        && Objects.equals(instancesOnOldImage, event.instancesOnOldImage));
     }
 
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/FreeipaPlatformStringTransformer.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/FreeipaPlatformStringTransformer.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.freeipa.service.image;
+
+import static com.sequenceiq.cloudbreak.common.gov.CommonGovService.GOV;
+
+import org.springframework.stereotype.Component;
+
+import com.google.common.base.Strings;
+import com.sequenceiq.freeipa.entity.Stack;
+
+@Component
+public class FreeipaPlatformStringTransformer {
+
+    public String getPlatformString(Stack stack) {
+        String platformVariant = stack.getPlatformvariant();
+        String platform = stack.getCloudPlatform().toLowerCase();
+        if (Strings.isNullOrEmpty(platformVariant)) {
+            return platform;
+        } else if (platformVariant.toLowerCase().endsWith(GOV)) {
+            return platform.concat(GOV).toLowerCase();
+        } else {
+            return platform;
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/upgrade/UpgradeValidationService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/upgrade/UpgradeValidationService.java
@@ -5,6 +5,7 @@ import static java.util.function.Predicate.not;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -49,8 +50,8 @@ public class UpgradeValidationService {
         throw new BadRequestException("Some of the instances is not available. Please fix them first! Instances: " + notAvailableInstances);
     }
 
-    public void validateSelectedImageDifferentFromCurrent(ImageInfoResponse currentImage, ImageInfoResponse selectedImage) {
-        if (currentImage.getId().equals(selectedImage.getId())) {
+    public void validateSelectedImageDifferentFromCurrent(ImageInfoResponse currentImage, ImageInfoResponse selectedImage, Set<String> instancesOnOldImage) {
+        if (currentImage.getId().equals(selectedImage.getId()) && CollectionUtils.isEmpty(instancesOnOldImage)) {
             LOGGER.warn("Selected {} and current {} image are the same", selectedImage, currentImage);
             throw new BadRequestException("Selected and current image are the same with id: " + currentImage.getId());
         }

--- a/freeipa/src/main/resources/schema/app/20230531134016_CB-20506_alter_instancemetadata_table_add_image_column.sql
+++ b/freeipa/src/main/resources/schema/app/20230531134016_CB-20506_alter_instancemetadata_table_add_image_column.sql
@@ -1,0 +1,10 @@
+-- // CB-20506 alter instancemetadata table add image column
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE instancemetadata ADD COLUMN IF NOT EXISTS image TEXT;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+
+ALTER TABLE instancemetadata DROP COLUMN IF EXISTS image;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/image/ImageToImageEntityConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/image/ImageToImageEntityConverterTest.java
@@ -34,4 +34,14 @@ class ImageToImageEntityConverterTest {
 
         assertEquals("1.2.3", result);
     }
+
+    @Test
+    void testExtractLdapAgentVersionCloudImage() {
+        com.sequenceiq.cloudbreak.cloud.model.Image source =
+                new com.sequenceiq.cloudbreak.cloud.model.Image("asd", Map.of(), "osss", "type", "url", "name", "imid", Map.of("freeipa-ldap-agent", "1.2.3"));
+
+        String result = underTest.extractLdapAgentVersion(source);
+
+        assertEquals("1.2.3", result);
+    }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/image/ImageToImageSettingsResponseConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/image/ImageToImageSettingsResponseConverterTest.java
@@ -1,15 +1,29 @@
 package com.sequenceiq.freeipa.converter.image;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsResponse;
 import com.sequenceiq.freeipa.entity.ImageEntity;
 
+@ExtendWith(MockitoExtension.class)
 class ImageToImageSettingsResponseConverterTest {
 
-    private ImageToImageSettingsResponseConverter underTest = new ImageToImageSettingsResponseConverter();
+    @Mock
+    private ImageToImageEntityConverter imageEntityConverter;
+
+    @InjectMocks
+    private ImageToImageSettingsResponseConverter underTest;
 
     @Test
     void testConversion() {
@@ -25,5 +39,28 @@ class ImageToImageSettingsResponseConverterTest {
         assertEquals(source.getImageCatalogUrl(), result.getCatalog());
         assertEquals(source.getOs(), result.getOs());
         assertEquals(source.getLdapAgentVersion(), result.getLdapAgentVersion());
+    }
+
+    @Test
+    void testCloudImageConversion() {
+        com.sequenceiq.cloudbreak.cloud.model.Image source =
+                new Image("imgname", Map.of(), "alma", "rocky", "url", "name", "imgid", Map.of("freeipa-ldap-agent", "1.2.3"));
+        when(imageEntityConverter.extractLdapAgentVersion(source)).thenReturn("1.2.3");
+
+        ImageSettingsResponse result = underTest.convert(source);
+
+        assertEquals(source.getImageId(), result.getId());
+        assertEquals(source.getImageCatalogUrl(), result.getCatalog());
+        assertEquals(source.getOs(), result.getOs());
+        assertEquals("1.2.3", result.getLdapAgentVersion());
+    }
+
+    @Test
+    void testCloudImageConversionWhenSourceNull() {
+        com.sequenceiq.cloudbreak.cloud.model.Image source = null;
+
+        ImageSettingsResponse result = underTest.convert(source);
+
+        assertNull(result);
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/FreeipaPlatformStringTransformerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/FreeipaPlatformStringTransformerTest.java
@@ -1,14 +1,12 @@
 package com.sequenceiq.freeipa.service.image;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.stream.Stream;
 
-import org.junit.Assert;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.InjectMocks;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsConstants;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureConstants;
@@ -16,11 +14,9 @@ import com.sequenceiq.cloudbreak.cloud.gcp.GcpConstants;
 import com.sequenceiq.cloudbreak.common.type.CloudConstants;
 import com.sequenceiq.freeipa.entity.Stack;
 
-@ExtendWith(MockitoExtension.class)
-class PlatformStringTransformerTest {
+class FreeipaPlatformStringTransformerTest {
 
-    @InjectMocks
-    private ImageService imageService;
+    private FreeipaPlatformStringTransformer underTest = new FreeipaPlatformStringTransformer();
 
     private static Stream<Arguments> variantFlags() {
         return Stream.of(
@@ -52,7 +48,7 @@ class PlatformStringTransformerTest {
         Stack stack = new Stack();
         stack.setCloudPlatform(platform);
         stack.setPlatformvariant(variant);
-        Assert.assertEquals(expected.toLowerCase(), imageService.getPlatformString(stack).toLowerCase());
+        assertEquals(expected.toLowerCase(), underTest.getPlatformString(stack).toLowerCase());
     }
 
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/ImageServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/ImageServiceTest.java
@@ -92,6 +92,9 @@ public class ImageServiceTest {
     @Mock
     private EntitlementService entitlementService;
 
+    @Mock
+    private FreeipaPlatformStringTransformer platformStringTransformer;
+
     @Captor
     private ArgumentCaptor<ImageSettingsRequest> imageSettingsRequestCaptor;
 
@@ -176,6 +179,7 @@ public class ImageServiceTest {
         when(image.getUuid()).thenReturn(IMAGE_UUID);
         when(imageRepository.save(any(ImageEntity.class))).thenAnswer(invocation -> invocation.getArgument(0, ImageEntity.class));
         when(imageConverter.extractLdapAgentVersion(image)).thenReturn("1.2.3");
+        when(platformStringTransformer.getPlatformString(stack)).thenReturn("aws");
 
         ImageEntity imageEntity = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.changeImage(stack, imageRequest));
 
@@ -198,6 +202,7 @@ public class ImageServiceTest {
         when(image.getImageSetsByProvider()).thenReturn(Collections.singletonMap(DEFAULT_PLATFORM, Collections.singletonMap(DEFAULT_REGION, EXISTING_ID)));
         when(imageRepository.save(any(ImageEntity.class))).thenAnswer(invocation -> invocation.getArgument(0, ImageEntity.class));
         when(imageConverter.convert(any(), any())).thenReturn(new ImageEntity());
+        when(platformStringTransformer.getPlatformString(stack)).thenReturn("aws");
 
         ImageEntity imageEntity = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.create(stack, imageRequest));
 
@@ -247,6 +252,7 @@ public class ImageServiceTest {
         Image image = new Image(123L, "now", "desc", DEFAULT_OS, IMAGE_UUID, Map.of(), "os", Map.of(), true);
         ImageWrapper imageWrapper = new ImageWrapper(image, IMAGE_CATALOG_URL, IMAGE_CATALOG);
         when(imageProvider.getImage(any(), any(), any())).thenReturn(Optional.of(imageWrapper));
+        when(platformStringTransformer.getPlatformString(stack)).thenReturn("aws");
 
         ImageCatalog result = underTest.generateImageCatalogForStack(stack);
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/InstanceMetadataServiceComponentTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/InstanceMetadataServiceComponentTest.java
@@ -43,6 +43,7 @@ import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.repository.InstanceMetaDataRepository;
 import com.sequenceiq.freeipa.service.client.CachedEnvironmentClientService;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
+import com.sequenceiq.freeipa.service.image.ImageService;
 import com.sequenceiq.freeipa.service.stack.instance.InstanceMetaDataService;
 
 @SpringBootTest(classes = InstanceMetadataServiceComponentTest.TestConfig.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
@@ -209,5 +210,8 @@ public class InstanceMetadataServiceComponentTest {
 
         @MockBean
         private FreeIpaService freeIpaService;
+
+        @MockBean
+        private ImageService imageService;
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/upgrade/UpgradeValidationServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/upgrade/UpgradeValidationServiceTest.java
@@ -95,7 +95,17 @@ class UpgradeValidationServiceTest {
         ImageInfoResponse selectedImage = new ImageInfoResponse();
         selectedImage.setId("111-222");
 
-        assertThrows(BadRequestException.class, () -> underTest.validateSelectedImageDifferentFromCurrent(currentImage, selectedImage));
+        assertThrows(BadRequestException.class, () -> underTest.validateSelectedImageDifferentFromCurrent(currentImage, selectedImage, Set.of()));
+    }
+
+    @Test
+    public void testCurrentAndSelectedImageAreTheSameThereAreInstancesOnOldImage() {
+        ImageInfoResponse currentImage = new ImageInfoResponse();
+        currentImage.setId("111-222");
+        ImageInfoResponse selectedImage = new ImageInfoResponse();
+        selectedImage.setId("111-222");
+
+        underTest.validateSelectedImageDifferentFromCurrent(currentImage, selectedImage, Set.of("a"));
     }
 
     @Test
@@ -105,6 +115,6 @@ class UpgradeValidationServiceTest {
         ImageInfoResponse selectedImage = new ImageInfoResponse();
         selectedImage.setId("111-333");
 
-        underTest.validateSelectedImageDifferentFromCurrent(currentImage, selectedImage);
+        underTest.validateSelectedImageDifferentFromCurrent(currentImage, selectedImage, Set.of());
     }
 }


### PR DESCRIPTION
- save image info with instancemetadata when created
- publish image info on the API
- alter upgrade logic, so it's possible to upgrade when there is instance with old image
- alter upgrade logic, that instances with current image are not upgraded

See detailed description in the commit message.