### PR TITLE
CB-22264: Introduce allowMajorOsUpgrade parameter for FreeIpa upgrade to enable the upgrade for different OS

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/upgrade/FreeIpaUpgradeV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/upgrade/FreeIpaUpgradeV1Endpoint.java
@@ -42,5 +42,6 @@ public interface FreeIpaUpgradeV1Endpoint {
             nickname = "getFreeIpaUpgradeOptionsV1")
     FreeIpaUpgradeOptions getFreeIpaUpgradeOptions(
             @QueryParam("environmentCrn") @ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @NotEmpty String environmentCrn,
-            @QueryParam("catalog") String catalog);
+            @QueryParam("catalog") String catalog,
+            @QueryParam("allowMajorOsUpgrade") Boolean allowMajorOsUpgrade);
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/upgrade/model/FreeIpaUpgradeRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/upgrade/model/FreeIpaUpgradeRequest.java
@@ -24,6 +24,8 @@ public class FreeIpaUpgradeRequest {
 
     private ImageSettingsRequest image;
 
+    private Boolean allowMajorOsUpgrade;
+
     public String getEnvironmentCrn() {
         return environmentCrn;
     }
@@ -40,11 +42,20 @@ public class FreeIpaUpgradeRequest {
         this.image = image;
     }
 
+    public Boolean getAllowMajorOsUpgrade() {
+        return allowMajorOsUpgrade;
+    }
+
+    public void setAllowMajorOsUpgrade(Boolean allowMajorOsUpgrade) {
+        this.allowMajorOsUpgrade = allowMajorOsUpgrade;
+    }
+
     @Override
     public String toString() {
         return "FreeIpaUpgradeRequest{" +
                 "environmentCrn='" + environmentCrn + '\'' +
                 ", image=" + image +
+                ", allowMajorOsUpgrade=" + allowMajorOsUpgrade +
                 '}';
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaUpgradeV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaUpgradeV1Controller.java
@@ -36,8 +36,8 @@ public class FreeIpaUpgradeV1Controller implements FreeIpaUpgradeV1Endpoint {
 
     @Override
     @CheckPermissionByResourceCrn(action = UPGRADE_FREEIPA)
-    public FreeIpaUpgradeOptions getFreeIpaUpgradeOptions(@ResourceCrn String environmentCrn, String catalog) {
+    public FreeIpaUpgradeOptions getFreeIpaUpgradeOptions(@ResourceCrn String environmentCrn, String catalog, Boolean allowMajorOsUpgrade) {
         String accountId = crnService.getCurrentAccountId();
-        return upgradeService.collectUpgradeOptions(accountId, environmentCrn, catalog);
+        return upgradeService.collectUpgradeOptions(accountId, environmentCrn, catalog, allowMajorOsUpgrade);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/dto/ImageWrapper.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/dto/ImageWrapper.java
@@ -4,11 +4,11 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image;
 
 public class ImageWrapper {
 
-    private Image image;
+    private final Image image;
 
-    private String catalogUrl;
+    private final String catalogUrl;
 
-    private String catalogName;
+    private final String catalogName;
 
     public ImageWrapper(Image image, String catalogUrl, String catalogName) {
         this.image = image;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmService.java
@@ -100,7 +100,7 @@ public class UpgradeCcmService {
         Stack stack = stackService.getStackById(stackId);
         ImageEntity stackImage = imageService.getByStackId(stackId);
         FreeIpaUpgradeOptions freeIpaUpgradeOptions = upgradeService.collectUpgradeOptions(stack.getAccountId(), stack.getEnvironmentCrn(),
-                Objects.requireNonNullElse(stackImage.getImageCatalogName(), stackImage.getImageCatalogUrl()));
+                Objects.requireNonNullElse(stackImage.getImageCatalogName(), stackImage.getImageCatalogUrl()), false);
         if (!freeIpaUpgradeOptions.getImages().isEmpty()) {
             throw new CloudbreakServiceException("FreeIPA is not on the latest available image. Please upgrade that first. CCM upgrade is not possible yet.");
         }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/FreeIpaImageFilter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/FreeIpaImageFilter.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.freeipa.service.image;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image;
+
+@Component
+public class FreeIpaImageFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaImageFilter.class);
+
+    private static final String DEFAULT_REGION = "default";
+
+    private static final String MAJOR_OS_UPGRADE_TARGET = "redhat8";
+
+    @Inject
+    private ProviderSpecificImageFilter providerSpecificImageFilter;
+
+    List<Image> filterImages(List<Image> candidateImages, FreeIpaImageFilterSettings imageFilterSettings) {
+        LOGGER.debug("Filtering images with the following parameters: {}", imageFilterSettings);
+        String platform = imageFilterSettings.platform();
+        List<Image> filteredImages = candidateImages.stream().filter(filterImagesPredicate(imageFilterSettings)).toList();
+        if (!filteredImages.isEmpty()) {
+            List<Image> notApplicableImages = new ArrayList<>(candidateImages);
+            notApplicableImages.removeAll(filteredImages);
+            LOGGER.debug("Used filter for: | {} | Images filtered: {}", imageFilterSettings.os(),
+                    notApplicableImages.stream().map(Image::toString).collect(Collectors.joining(", ")));
+            return providerSpecificImageFilter.filterImages(platform, filteredImages);
+        } else {
+            LOGGER.warn("No FreeIPA image found with OS {}, falling back to the latest available one if such exists!", imageFilterSettings.os());
+            return candidateImages;
+        }
+    }
+
+    private Predicate<Image> filterImagesPredicate(FreeIpaImageFilterSettings imageFilterSettings) {
+        return image -> {
+            String targetOs = image.getOs();
+            return (majorOsUpgradeAllowed(imageFilterSettings, targetOs) || targetOs.equalsIgnoreCase(imageFilterSettings.os())) &&
+                    image.getImageSetsByProvider().containsKey(imageFilterSettings.platform()) &&
+                    filterRegion(imageFilterSettings, image);
+        };
+    }
+
+    private boolean majorOsUpgradeAllowed(FreeIpaImageFilterSettings imageFilterSettings, String targetOs) {
+        return imageFilterSettings.allowMajorOsUpgrade() && MAJOR_OS_UPGRADE_TARGET.equals(targetOs);
+    }
+
+    boolean filterRegion(FreeIpaImageFilterSettings imageFilterSettings, Image img) {
+        Set<String> regionSet = img.getImageSetsByProvider().get(imageFilterSettings.platform()).keySet();
+        return CollectionUtils.containsAny(regionSet, imageFilterSettings.region(), DEFAULT_REGION);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/FreeIpaImageFilterSettings.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/FreeIpaImageFilterSettings.java
@@ -1,0 +1,4 @@
+package com.sequenceiq.freeipa.service.image;
+
+public record FreeIpaImageFilterSettings(String currentImageId, String catalog, String os, String region, String platform, boolean allowMajorOsUpgrade) {
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageProvider.java
@@ -3,12 +3,11 @@ package com.sequenceiq.freeipa.service.image;
 import java.util.List;
 import java.util.Optional;
 
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsRequest;
 import com.sequenceiq.freeipa.dto.ImageWrapper;
 
 public interface ImageProvider {
 
-    Optional<ImageWrapper> getImage(ImageSettingsRequest imageSettings, String region, String platformString);
+    Optional<ImageWrapper> getImage(FreeIpaImageFilterSettings imageFilterParams);
 
-    List<ImageWrapper> getImages(ImageSettingsRequest imageSettings, String region, String platformString);
+    List<ImageWrapper> getImages(FreeIpaImageFilterSettings imageFilterParams);
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmServiceTest.java
@@ -158,7 +158,7 @@ class UpgradeCcmServiceTest {
         when(imageService.getByStackId(STACK_ID)).thenReturn(imageEntity);
         FreeIpaUpgradeOptions upgradeOptions = new FreeIpaUpgradeOptions();
         upgradeOptions.setImages(new ArrayList<>());
-        when(upgradeService.collectUpgradeOptions(ACCOUNT_ID, ENV_CRN, "catalog")).thenReturn(upgradeOptions);
+        when(upgradeService.collectUpgradeOptions(ACCOUNT_ID, ENV_CRN, "catalog", false)).thenReturn(upgradeOptions);
     }
 
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/CoreImageProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/CoreImageProviderTest.java
@@ -22,7 +22,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.ImageCatalogV4Endp
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImagesV4Response;
 import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image;
 import com.sequenceiq.freeipa.dto.ImageWrapper;
 
@@ -64,7 +63,7 @@ public class CoreImageProviderTest {
     public void shouldReturnEmptyInCaseOfException() throws Exception {
         when(imageCatalogV4Endpoint.getSingleImageByCatalogNameAndImageId(WORKSPACE_ID_DEFAULT, CATALOG_NAME, IMAGE_ID)).thenThrow(new RuntimeException());
 
-        Optional<ImageWrapper> actual = victim.getImage(anImageSettings(), REGION, PLATFORM);
+        Optional<ImageWrapper> actual = victim.getImage(createImageFilterSettings());
 
         assertTrue(actual.isEmpty());
     }
@@ -73,7 +72,7 @@ public class CoreImageProviderTest {
     public void shouldReturnEmptyInCaseOfNullResponse() throws Exception {
         when(imageCatalogV4Endpoint.getSingleImageByCatalogNameAndImageId(WORKSPACE_ID_DEFAULT, CATALOG_NAME, IMAGE_ID)).thenReturn(null);
 
-        Optional<ImageWrapper> actual = victim.getImage(anImageSettings(), REGION, PLATFORM);
+        Optional<ImageWrapper> actual = victim.getImage(createImageFilterSettings());
 
         assertTrue(actual.isEmpty());
     }
@@ -82,7 +81,7 @@ public class CoreImageProviderTest {
     public void shouldReturnResult() throws Exception {
         when(imageCatalogV4Endpoint.getSingleImageByCatalogNameAndImageId(WORKSPACE_ID_DEFAULT, CATALOG_NAME, IMAGE_ID)).thenReturn(anImageResponse());
 
-        Optional<ImageWrapper> actual = victim.getImage(anImageSettings(), REGION, PLATFORM);
+        Optional<ImageWrapper> actual = victim.getImage(createImageFilterSettings());
         Image image = actual.get().getImage();
 
         assertEquals(DATE, image.getDate());
@@ -97,9 +96,7 @@ public class CoreImageProviderTest {
         when(imageCatalogV4Endpoint.getImagesByName(WORKSPACE_ID_DEFAULT, CATALOG_NAME, null, PLATFORM, null, null, false))
                 .thenReturn(new ImagesV4Response());
 
-        ImageSettingsRequest imageSettings = new ImageSettingsRequest();
-        imageSettings.setCatalog(CATALOG_NAME);
-        List<ImageWrapper> result = victim.getImages(imageSettings, "", PLATFORM);
+        List<ImageWrapper> result = victim.getImages(createImageFilterSettings());
 
         assertTrue(result.isEmpty());
     }
@@ -109,9 +106,7 @@ public class CoreImageProviderTest {
         when(imageCatalogV4Endpoint.getImagesByName(WORKSPACE_ID_DEFAULT, CATALOG_NAME, null, PLATFORM, null, null, false))
                 .thenThrow(new WebApplicationException());
 
-        ImageSettingsRequest imageSettings = new ImageSettingsRequest();
-        imageSettings.setCatalog(CATALOG_NAME);
-        List<ImageWrapper> result = victim.getImages(imageSettings, "", PLATFORM);
+        List<ImageWrapper> result = victim.getImages(createImageFilterSettings());
 
         assertTrue(result.isEmpty());
     }
@@ -121,9 +116,7 @@ public class CoreImageProviderTest {
         when(imageCatalogV4Endpoint.getImagesByName(WORKSPACE_ID_DEFAULT, CATALOG_NAME, null, PLATFORM, null, null, false))
                 .thenThrow(new Exception());
 
-        ImageSettingsRequest imageSettings = new ImageSettingsRequest();
-        imageSettings.setCatalog(CATALOG_NAME);
-        List<ImageWrapper> result = victim.getImages(imageSettings, "", PLATFORM);
+        List<ImageWrapper> result = victim.getImages(createImageFilterSettings());
 
         assertTrue(result.isEmpty());
     }
@@ -135,9 +128,7 @@ public class CoreImageProviderTest {
         when(imageCatalogV4Endpoint.getImagesByName(WORKSPACE_ID_DEFAULT, CATALOG_NAME, null, PLATFORM, null, null, false))
                 .thenReturn(imagesV4Response);
 
-        ImageSettingsRequest imageSettings = new ImageSettingsRequest();
-        imageSettings.setCatalog(CATALOG_NAME);
-        List<ImageWrapper> result = victim.getImages(imageSettings, "", PLATFORM);
+        List<ImageWrapper> result = victim.getImages(createImageFilterSettings());
 
         assertEquals(1, result.size());
         ImageWrapper imageWrapper = result.get(0);
@@ -151,12 +142,8 @@ public class CoreImageProviderTest {
         assertEquals(VM_IMAGE_REFERENCE, image.getImageSetsByProvider().get(PLATFORM).get(REGION));
     }
 
-    private ImageSettingsRequest anImageSettings() {
-        ImageSettingsRequest imageSettings = new ImageSettingsRequest();
-        imageSettings.setCatalog(CATALOG_NAME);
-        imageSettings.setId(IMAGE_ID);
-
-        return imageSettings;
+    private FreeIpaImageFilterSettings createImageFilterSettings() {
+        return new FreeIpaImageFilterSettings(IMAGE_ID, CATALOG_NAME, null, REGION, PLATFORM, false);
     }
 
     private ImageV4Response anImageResponse() {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/FreeIpaImageFilterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/FreeIpaImageFilterTest.java
@@ -1,0 +1,139 @@
+package com.sequenceiq.freeipa.service.image;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image;
+
+@ExtendWith(MockitoExtension.class)
+class FreeIpaImageFilterTest {
+
+    private static final String REDHAT_8 = "redhat8";
+
+    private static final String CENTOS_7 = "centos7";
+
+    private static final String REGION_1 = "eu-central-1";
+
+    private static final String AWS = "AWS";
+
+    @InjectMocks
+    private FreeIpaImageFilter underTest;
+
+    @Mock
+    private ProviderSpecificImageFilter providerSpecificImageFilter;
+
+    @Test
+    void setUnderTestFilterImagesShouldReturnAllImageWhenMajorOsUpgradeIsEnabled() {
+        List<Image> candidateImages = List.of(
+                createImage("image-1", REDHAT_8, AWS, REGION_1),
+                createImage("image-2", CENTOS_7, AWS, REGION_1)
+        );
+        FreeIpaImageFilterSettings imageFilterSettings = createImageFilterSettings(CENTOS_7, REGION_1, AWS, true);
+
+        when(providerSpecificImageFilter.filterImages(any(), any())).thenAnswer(invocation -> invocation.getArgument(1));
+
+        List<Image> actual = underTest.filterImages(candidateImages, imageFilterSettings);
+
+        assertTrue(actual.containsAll(candidateImages));
+        verify(providerSpecificImageFilter).filterImages(any(), any());
+    }
+
+    @Test
+    void setUnderTestFilterImagesShouldReturnImageWithTheProperOsWhenMajorOsUpgradeIsNotEnabled() {
+        Image image1 = createImage("image-1", REDHAT_8, AWS, REGION_1);
+        Image image2 = createImage("image-2", CENTOS_7, AWS, REGION_1);
+        List<Image> candidateImages = List.of(image1, image2);
+        FreeIpaImageFilterSettings imageFilterSettings = createImageFilterSettings(CENTOS_7, REGION_1, AWS, false);
+
+        when(providerSpecificImageFilter.filterImages(any(), any())).thenAnswer(invocation -> invocation.getArgument(1));
+
+        List<Image> actual = underTest.filterImages(candidateImages, imageFilterSettings);
+
+        assertTrue(actual.contains(image2));
+        assertFalse(actual.contains(image1));
+        verify(providerSpecificImageFilter).filterImages(any(), any());
+    }
+
+    @Test
+    void setUnderTestFilterImagesShouldReturnImageWithTheProperOsWhenMajorOsUpgradeIsEnabled() {
+        Image image1 = createImage("image-1", "amazonlinux", AWS, REGION_1);
+        Image image2 = createImage("image-2", CENTOS_7, AWS, REGION_1);
+        List<Image> candidateImages = List.of(image1, image2);
+        FreeIpaImageFilterSettings imageFilterSettings = createImageFilterSettings(CENTOS_7, REGION_1, AWS, true);
+
+        when(providerSpecificImageFilter.filterImages(any(), any())).thenAnswer(invocation -> invocation.getArgument(1));
+
+        List<Image> actual = underTest.filterImages(candidateImages, imageFilterSettings);
+
+        assertTrue(actual.contains(image2));
+        assertFalse(actual.contains(image1));
+        verify(providerSpecificImageFilter).filterImages(any(), any());
+    }
+
+    @Test
+    void setUnderTestFilterImagesShouldReturnImageWithTheProperPlatform() {
+        Image image1 = createImage("image-1", CENTOS_7, "azure", REGION_1);
+        Image image2 = createImage("image-2", CENTOS_7, AWS, REGION_1);
+        List<Image> candidateImages = List.of(image1, image2);
+        FreeIpaImageFilterSettings imageFilterSettings = createImageFilterSettings(CENTOS_7, REGION_1, AWS, false);
+
+        when(providerSpecificImageFilter.filterImages(any(), any())).thenAnswer(invocation -> invocation.getArgument(1));
+
+        List<Image> actual = underTest.filterImages(candidateImages, imageFilterSettings);
+
+        assertTrue(actual.contains(image2));
+        assertFalse(actual.contains(image1));
+        verify(providerSpecificImageFilter).filterImages(any(), any());
+    }
+
+    @Test
+    void setUnderTestFilterImagesShouldReturnImageWithTheProperRegion() {
+        Image image1 = createImage("image-1", CENTOS_7, AWS, "other-region");
+        Image image2 = createImage("image-2", CENTOS_7, AWS, REGION_1);
+        List<Image> candidateImages = List.of(image1, image2);
+        FreeIpaImageFilterSettings imageFilterSettings = createImageFilterSettings(CENTOS_7, REGION_1, AWS, false);
+
+        when(providerSpecificImageFilter.filterImages(any(), any())).thenAnswer(invocation -> invocation.getArgument(1));
+
+        List<Image> actual = underTest.filterImages(candidateImages, imageFilterSettings);
+
+        assertTrue(actual.contains(image2));
+        assertFalse(actual.contains(image1));
+        verify(providerSpecificImageFilter).filterImages(any(), any());
+    }
+
+    @Test
+    void setUnderTestFilterImagesShouldReturnCandidateImagesWhenNoProperImageFound() {
+        Image image1 = createImage("image-1", CENTOS_7, AWS, REGION_1);
+        Image image2 = createImage("image-2", CENTOS_7, AWS, REGION_1);
+        List<Image> candidateImages = List.of(image1, image2);
+        FreeIpaImageFilterSettings imageFilterSettings = createImageFilterSettings(REDHAT_8, "other-region", "azure", false);
+
+        List<Image> actual = underTest.filterImages(candidateImages, imageFilterSettings);
+
+        assertTrue(actual.containsAll(candidateImages));
+        verifyNoInteractions(providerSpecificImageFilter);
+    }
+
+    private FreeIpaImageFilterSettings createImageFilterSettings(String os, String region, String platform, boolean allowMajorOsUpgrade) {
+        return new FreeIpaImageFilterSettings(null, null, os, region, platform, allowMajorOsUpgrade);
+    }
+
+    private Image createImage(String imageId, String os, String platform, String region) {
+        return new Image(null, null, null, os, imageId, Map.of(platform, Map.of(region, "imageName")), null, null, true);
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/ImageCatalogProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/ImageCatalogProviderTest.java
@@ -45,7 +45,7 @@ public class ImageCatalogProviderTest {
 
     private static final String IMAGE_CATALOG_FILTER_ALL_OS_JSON = "freeipa-catalog-filter-all-os.json";
 
-    private static final List<String> IMAGE_CATALOG_OS_TYPES = Lists.newArrayList("redhat7", "centos7");
+    private static final List<String> IMAGE_CATALOG_OS_TYPES = Lists.newArrayList("redhat7", "centos7", "redhat8");
 
     private static final List<String> CB_CENTOS_7_FILTER = Lists.newArrayList("centos7");
 
@@ -74,11 +74,11 @@ public class ImageCatalogProviderTest {
 
         ImageCatalog catalog = underTest.getImageCatalog(IMAGE_CATALOG_JSON);
         List<com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image> images = catalog.getImages().getFreeipaImages();
-        assertEquals(4, images.size());
+        assertEquals(5, images.size());
         assertEquals("61851893-8340-411d-afb7-e1b55107fb10", images.get(0).getUuid());
 
         FreeIpaVersions freeIpaVersions = catalog.getVersions().getFreeIpaVersions().get(0);
-        assertEquals(2, freeIpaVersions.getImageIds().size());
+        assertEquals(3, freeIpaVersions.getImageIds().size());
         assertEquals("61851893-8340-411d-afb7-e1b55107fb10", freeIpaVersions.getImageIds().get(0));
         assertEquals(1, freeIpaVersions.getDefaults().size());
         assertEquals(List.of("71851893-8340-411d-afb7-e1b55107fb10"), freeIpaVersions.getDefaults());
@@ -146,9 +146,9 @@ public class ImageCatalogProviderTest {
         assertEquals(IMAGE_CATALOG_OS_TYPES, actualOsTypes);
 
         List<String> expectedIds = List.of("61851893-8340-411d-afb7-e1b55107fb10", "71851893-8340-411d-afb7-e1b55107fb10",
-                "81851893-8340-411d-afb7-e1b55107fb10", "91851893-8340-411d-afb7-e1b55107fb10");
+                "81851893-8340-411d-afb7-e1b55107fb10", "91851893-8340-411d-afb7-e1b55107fb10", "b465c893-fe04-44b1-ae8e-0452bbb39c99");
         assertEquals(expectedIds, mapToUuid(actualCatalog.getImages().getFreeipaImages()));
-        assertEquals(List.of("61851893-8340-411d-afb7-e1b55107fb10", "71851893-8340-411d-afb7-e1b55107fb10"),
+        assertEquals(List.of("61851893-8340-411d-afb7-e1b55107fb10", "71851893-8340-411d-afb7-e1b55107fb10", "b465c893-fe04-44b1-ae8e-0452bbb39c99"),
                 actualCatalog.getVersions().getFreeIpaVersions().get(0).getImageIds());
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/upgrade/UpgradeImageServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/upgrade/UpgradeImageServiceTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.freeipa.service.upgrade;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -17,17 +18,22 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image;
 import com.sequenceiq.freeipa.api.v1.freeipa.upgrade.model.ImageInfoResponse;
 import com.sequenceiq.freeipa.dto.ImageWrapper;
 import com.sequenceiq.freeipa.entity.ImageEntity;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.image.FreeIpaImageFilterSettings;
 import com.sequenceiq.freeipa.service.image.ImageNotFoundException;
 import com.sequenceiq.freeipa.service.image.ImageService;
 
 @ExtendWith(MockitoExtension.class)
 class UpgradeImageServiceTest {
+
+    private static final String CATALOG_URL = "catalogURL";
+
+    @Mock
+    private FreeIpaImageFilterSettings imageFilterSettings;
 
     @Mock
     private ImageService imageService;
@@ -37,13 +43,11 @@ class UpgradeImageServiceTest {
 
     @Test
     public void testSelectImage() {
-        Stack stack = new Stack();
-        ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
         Image image = createImage("now");
-        ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
-        when(imageService.fetchImageWrapperAndName(stack, imageSettingsRequest)).thenReturn(Pair.of(imageWrapper, "imageName"));
+        ImageWrapper imageWrapper = new ImageWrapper(image, CATALOG_URL, "catalogName");
+        when(imageService.fetchImageWrapperAndName(imageFilterSettings)).thenReturn(Pair.of(imageWrapper, "imageName"));
 
-        ImageInfoResponse imageInfoResponse = underTest.selectImage(stack, imageSettingsRequest);
+        ImageInfoResponse imageInfoResponse = underTest.selectImage(imageFilterSettings);
 
         assertEquals(imageWrapper.getCatalogName(), imageInfoResponse.getCatalogName());
         assertEquals(imageWrapper.getCatalogUrl(), imageInfoResponse.getCatalog());
@@ -76,16 +80,15 @@ class UpgradeImageServiceTest {
     @Test
     public void testFindTargetImages() {
         Stack stack = new Stack();
-        ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
         Image image = createImage("2021-09-01");
-        ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
-        when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
+        ImageWrapper imageWrapper = new ImageWrapper(image, CATALOG_URL, "catalogName");
+        when(imageService.fetchImagesWrapperAndName(eq(stack), any(), any(), eq(true))).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
 
         ImageInfoResponse currentImage = new ImageInfoResponse();
         currentImage.setDate("2021-08-21");
         currentImage.setId("111-222");
 
-        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, imageSettingsRequest, currentImage);
+        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, CATALOG_URL, currentImage, true);
 
         assertEquals(1, targetImages.size());
         ImageInfoResponse imageInfoResponse = targetImages.get(0);
@@ -99,16 +102,15 @@ class UpgradeImageServiceTest {
     @Test
     public void testFindTargetImagesNoNewerImage() {
         Stack stack = new Stack();
-        ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
         Image image = createImage("2021-07-01");
-        ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
-        when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
+        ImageWrapper imageWrapper = new ImageWrapper(image, CATALOG_URL, "catalogName");
+        when(imageService.fetchImagesWrapperAndName(eq(stack), any(), any(), eq(true))).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
 
         ImageInfoResponse currentImage = new ImageInfoResponse();
         currentImage.setDate("2021-08-21");
         currentImage.setId("111-222");
 
-        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, imageSettingsRequest, currentImage);
+        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, CATALOG_URL, currentImage, true);
 
         assertTrue(targetImages.isEmpty());
     }
@@ -116,16 +118,15 @@ class UpgradeImageServiceTest {
     @Test
     public void testFindTargetImagesImageWithSameId() {
         Stack stack = new Stack();
-        ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
         Image image = createImage("2021-09-01");
-        ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
-        when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
+        ImageWrapper imageWrapper = new ImageWrapper(image, CATALOG_URL, "catalogName");
+        when(imageService.fetchImagesWrapperAndName(eq(stack), any(), any(), eq(true))).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
 
         ImageInfoResponse currentImage = new ImageInfoResponse();
         currentImage.setDate("2021-08-21");
         currentImage.setId("1234-456");
 
-        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, imageSettingsRequest, currentImage);
+        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, CATALOG_URL, currentImage, true);
 
         assertTrue(targetImages.isEmpty());
     }
@@ -135,15 +136,13 @@ class UpgradeImageServiceTest {
         Stack stack = new Stack();
         stack.setCloudPlatform("AWS");
         stack.setRegion("reg");
-        ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
         Image image = createImage("2021-09-01");
-        ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
-        when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
-        ArgumentCaptor<ImageSettingsRequest> captor = ArgumentCaptor.forClass(ImageSettingsRequest.class);
+        ImageWrapper imageWrapper = new ImageWrapper(image, CATALOG_URL, "catalogName");
+        when(imageService.fetchImagesWrapperAndName(eq(stack), any(), any(), eq(true))).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
+        ArgumentCaptor<FreeIpaImageFilterSettings> captor = ArgumentCaptor.forClass(FreeIpaImageFilterSettings.class);
         Image currentImageFromCatalog = createImage("2021-08-01");
         ImageWrapper currentImageWrapperFromCatalog = new ImageWrapper(currentImageFromCatalog, "asdf", "Asdf");
-        when(imageService.getImage(captor.capture(), eq(stack.getRegion()), eq(stack.getCloudPlatform().toLowerCase())))
-                .thenReturn(currentImageWrapperFromCatalog);
+        when(imageService.getImage(captor.capture())).thenReturn(currentImageWrapperFromCatalog);
 
         ImageInfoResponse currentImage = new ImageInfoResponse();
         currentImage.setId("222-333");
@@ -151,7 +150,7 @@ class UpgradeImageServiceTest {
         currentImage.setCatalogName("catName");
         currentImage.setOs("zOs");
 
-        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, imageSettingsRequest, currentImage);
+        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, CATALOG_URL, currentImage, true);
 
         assertEquals(1, targetImages.size());
         ImageInfoResponse imageInfoResponse = targetImages.get(0);
@@ -160,10 +159,12 @@ class UpgradeImageServiceTest {
         assertEquals(image.getDate(), imageInfoResponse.getDate());
         assertEquals(image.getUuid(), imageInfoResponse.getId());
         assertEquals(image.getOs(), imageInfoResponse.getOs());
-        ImageSettingsRequest settingsRequest = captor.getValue();
-        assertEquals(currentImage.getCatalog(), settingsRequest.getCatalog());
-        assertEquals(currentImage.getId(), settingsRequest.getId());
-        assertEquals(currentImage.getOs(), settingsRequest.getOs());
+        FreeIpaImageFilterSettings settingsRequest = captor.getValue();
+        assertEquals(currentImage.getCatalog(), settingsRequest.catalog());
+        assertEquals(currentImage.getId(), settingsRequest.currentImageId());
+        assertEquals(currentImage.getOs(), settingsRequest.os());
+        assertEquals(stack.getRegion(), settingsRequest.region());
+        assertEquals(stack.getCloudPlatform().toLowerCase(), settingsRequest.platform());
     }
 
     @Test
@@ -171,28 +172,28 @@ class UpgradeImageServiceTest {
         Stack stack = new Stack();
         stack.setCloudPlatform("AWS");
         stack.setRegion("reg");
-        ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
         Image image = createImage("2021-09-01");
-        ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
-        when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
-        ArgumentCaptor<ImageSettingsRequest> captor = ArgumentCaptor.forClass(ImageSettingsRequest.class);
+        ImageWrapper imageWrapper = new ImageWrapper(image, CATALOG_URL, "catalogName");
+        when(imageService.fetchImagesWrapperAndName(eq(stack), any(), any(), eq(true))).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
+        ArgumentCaptor<FreeIpaImageFilterSettings> captor = ArgumentCaptor.forClass(FreeIpaImageFilterSettings.class);
         Image currentImageFromCatalog = createImage(null);
         ImageWrapper currentImageWrapperFromCatalog = new ImageWrapper(currentImageFromCatalog, "asdf", "Asdf");
-        when(imageService.getImage(captor.capture(), eq(stack.getRegion()), eq(stack.getCloudPlatform().toLowerCase())))
-                .thenReturn(currentImageWrapperFromCatalog);
+        when(imageService.getImage(captor.capture())).thenReturn(currentImageWrapperFromCatalog);
 
         ImageInfoResponse currentImage = new ImageInfoResponse();
         currentImage.setId("222-333");
         currentImage.setCatalogName("cat");
         currentImage.setOs("zOs");
 
-        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, imageSettingsRequest, currentImage);
+        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, CATALOG_URL, currentImage, true);
 
         assertTrue(targetImages.isEmpty());
-        ImageSettingsRequest settingsRequest = captor.getValue();
-        assertEquals(currentImage.getCatalogName(), settingsRequest.getCatalog());
-        assertEquals(currentImage.getId(), settingsRequest.getId());
-        assertEquals(currentImage.getOs(), settingsRequest.getOs());
+        FreeIpaImageFilterSettings settingsRequest = captor.getValue();
+        assertEquals(currentImage.getCatalogName(), settingsRequest.catalog());
+        assertEquals(currentImage.getId(), settingsRequest.currentImageId());
+        assertEquals(currentImage.getOs(), settingsRequest.os());
+        assertEquals(stack.getRegion(), settingsRequest.region());
+        assertEquals(stack.getCloudPlatform().toLowerCase(), settingsRequest.platform());
     }
 
     @Test
@@ -200,44 +201,43 @@ class UpgradeImageServiceTest {
         Stack stack = new Stack();
         stack.setCloudPlatform("AWS");
         stack.setRegion("reg");
-        ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
         Image image = createImage("2021-09-01");
-        ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
-        when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
-        ArgumentCaptor<ImageSettingsRequest> captor = ArgumentCaptor.forClass(ImageSettingsRequest.class);
-        when(imageService.getImage(captor.capture(), eq(stack.getRegion()), eq(stack.getCloudPlatform().toLowerCase())))
-                .thenThrow(new ImageNotFoundException("Image not found"));
+        ImageWrapper imageWrapper = new ImageWrapper(image, CATALOG_URL, "catalogName");
+        when(imageService.fetchImagesWrapperAndName(eq(stack), any(), any(), eq(true))).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
+        ArgumentCaptor<FreeIpaImageFilterSettings> captor = ArgumentCaptor.forClass(FreeIpaImageFilterSettings.class);
+        when(imageService.getImage(captor.capture())).thenThrow(new ImageNotFoundException("Image not found"));
 
         ImageInfoResponse currentImage = new ImageInfoResponse();
         currentImage.setId("222-333");
         currentImage.setCatalogName("cat");
         currentImage.setOs("zOs");
 
-        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, imageSettingsRequest, currentImage);
+        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, CATALOG_URL, currentImage, true);
 
         assertTrue(targetImages.isEmpty());
-        ImageSettingsRequest settingsRequest = captor.getValue();
-        assertEquals(currentImage.getCatalogName(), settingsRequest.getCatalog());
-        assertEquals(currentImage.getId(), settingsRequest.getId());
-        assertEquals(currentImage.getOs(), settingsRequest.getOs());
+        FreeIpaImageFilterSettings settingsRequest = captor.getValue();
+        assertEquals(currentImage.getCatalogName(), settingsRequest.catalog());
+        assertEquals(currentImage.getId(), settingsRequest.currentImageId());
+        assertEquals(currentImage.getOs(), settingsRequest.os());
+        assertEquals(stack.getRegion(), settingsRequest.region());
+        assertEquals(stack.getCloudPlatform().toLowerCase(), settingsRequest.platform());
     }
 
     @Test
     public void testFindTargetImagesImageWithWrongDateFormatIgnored() {
         Stack stack = new Stack();
-        ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
         Image image = createImage("2021-09-01");
-        ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
+        ImageWrapper imageWrapper = new ImageWrapper(image, CATALOG_URL, "catalogName");
         Image image2 = createImage("20210901");
-        ImageWrapper imageWrapper2 = new ImageWrapper(image2, "catalogURL", "catalogName");
-        when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest))
+        ImageWrapper imageWrapper2 = new ImageWrapper(image2, CATALOG_URL, "catalogName");
+        when(imageService.fetchImagesWrapperAndName(eq(stack), any(), any(), eq(true)))
                 .thenReturn(List.of(Pair.of(imageWrapper, "imageName"), Pair.of(imageWrapper2, "imageName2")));
 
         ImageInfoResponse currentImage = new ImageInfoResponse();
         currentImage.setDate("2021-08-21");
         currentImage.setId("111-222");
 
-        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, imageSettingsRequest, currentImage);
+        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, CATALOG_URL, currentImage, true);
 
         assertEquals(1, targetImages.size());
         ImageInfoResponse imageInfoResponse = targetImages.get(0);

--- a/freeipa/src/test/resources/com/sequenceiq/freeipa/service/image/freeipa-catalog-1.json
+++ b/freeipa/src/test/resources/com/sequenceiq/freeipa/service/image/freeipa-catalog-1.json
@@ -108,6 +108,64 @@
         "os": "centos7",
         "os_type": "redhat7",
         "uuid": "91851893-8340-411d-afb7-e1b55107fb10"
+      },
+      {
+        "created": 1687868435,
+        "published": 1687870712,
+        "date": "2023-06-27",
+        "description": "Official Cloudbreak image",
+        "images": {
+          "aws": {
+            "af-south-1": "ami-04d2bcd85d94d94c1",
+            "ap-east-1": "ami-04cbe95ed40152f0a",
+            "ap-northeast-1": "ami-0fb16474bb4e5b32b",
+            "ap-northeast-2": "ami-0963996c6a5cd5444",
+            "ap-south-1": "ami-0c7c5934da0ed33fd",
+            "ap-southeast-1": "ami-062aecaf76b8b3d43",
+            "ap-southeast-2": "ami-0620d99af88ef2d9c",
+            "ap-southeast-3": "ami-025558987dc3c03f9",
+            "ca-central-1": "ami-006d5461c1dcb02e0",
+            "eu-central-1": "ami-05ecf3428d75b30d1",
+            "eu-central-2": "ami-0ae457ff2be2b8a5b",
+            "eu-north-1": "ami-0857f83ab4bde001e",
+            "eu-south-1": "ami-04130130b1e9383d1",
+            "eu-south-2": "ami-05b76725953fb453d",
+            "eu-west-1": "ami-06df140d001a07419",
+            "eu-west-2": "ami-01363e868ff604ecf",
+            "eu-west-3": "ami-0be56dfafc43fe6c6",
+            "me-central-1": "ami-058883bc86a720a4d",
+            "me-south-1": "ami-0667a2b30876c10d7",
+            "sa-east-1": "ami-0315ea333c5a0e3d0",
+            "us-east-1": "ami-0be49ddbc18a9ac0b",
+            "us-east-2": "ami-023560f1b4912d32e",
+            "us-west-1": "ami-0bc6119986f38318b",
+            "us-west-2": "ami-04c4232549a04967a"
+          }
+        },
+        "os": "redhat8",
+        "os_type": "redhat8",
+        "uuid": "b465c893-fe04-44b1-ae8e-0452bbb39c99",
+        "package-versions": {
+          "blackbox-exporter": "0.19.0",
+          "cdp-logging-agent": "0.3.6",
+          "cdp-minifi-agent": "1.22.07",
+          "cdp-prometheus": "2.36.2",
+          "cdp-request-signer": "0.2.4",
+          "cdp-telemetry": "0.4.31",
+          "cloudbreak_images": "b6af9d842e92697d6ee3b80d6801af6480aa3ceb",
+          "freeipa-health-agent": "0.1-20230524185955gitcd308d4",
+          "freeipa-ldap-agent": "1.0.0-b10391",
+          "freeipa-plugin": "1.0-20230613035802git1c2c21d.el8",
+          "inverting-proxy-agent": "3.0.7-b1",
+          "inverting-proxy-agent_gbn": "41924420",
+          "node-exporter": "1.3.1",
+          "python36": "3.6.8-38.module+el8.5.0+12207+5c5719bc",
+          "salt": "3001.8",
+          "salt-bootstrap": "0.13.6-2022-05-20T08:57:17"
+        },
+        "tags": {
+          "fips-mode": "disabled"
+        }
       }
     ]
   },
@@ -116,7 +174,8 @@
       {
         "images": [
           "61851893-8340-411d-afb7-e1b55107fb10",
-          "71851893-8340-411d-afb7-e1b55107fb10"
+          "71851893-8340-411d-afb7-e1b55107fb10",
+          "b465c893-fe04-44b1-ae8e-0452bbb39c99"
         ],
         "defaults": [
           "71851893-8340-411d-afb7-e1b55107fb10"


### PR DESCRIPTION
This commit contains the following changes:
- Introduce FreeIpaImageFilterSettings class to encapsulate all the upgrade required parameters
- Added allowMajorOsUpgrade parameter to FreeIpaUpgradeRequest
- Added allowMajorOsUpgrade request parameter to FreeIpaUpgradeV1Endpoint.getFreeIpaUpgradeOptions