### PR TITLE
CB-22309 - Embedded PG14 support

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
@@ -8,10 +8,10 @@
 {% set postgres_data_on_attached_disk = salt['pillar.get']('postgres:postgres_data_on_attached_disk', 'False') %}
 {% set command = 'systemctl show -p FragmentPath postgresql' %}
 {% set unitFile = salt['cmd.run'](command) | replace("FragmentPath=","") %}
+{% set postgres_version = salt['pillar.get']('postgres:postgres_version', '10') | int %}
 
 {% if 'None' != configure_remote_db %}
 
-{% set postgres_version = salt['pillar.get']('postgres:postgres_version', '10') | int %}
 include:
 {%- if postgres_version == 11 %}
 {%- if not salt['file.file_exists']('/usr/pgsql-11/bin/psql') %}
@@ -51,7 +51,7 @@ init-services-db-remote:
       - file: {{ postgresql.root_certs_file }}
 {%- endif %}
 
-{%- else %}
+{%- else %} {# 'None' == configure_remote_db #}
 
 {%- if postgres_data_on_attached_disk %}
 
@@ -97,9 +97,12 @@ create_embeddeddb_certificate:
 
 {%- endif %}
 
-{%- if salt['pillar.get']('postgres:postgres_version', '10') | int == 11 %}
+{%- if postgres_version == 11 %}
 include:
   - postgresql.pg11
+{%- elif postgres_version == 14 %}
+include:
+  - postgresql.pg14
 {%- endif %}
 
 ensure-postgres-stopped-before-initdb:

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/pg14.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/pg14.sls
@@ -1,0 +1,59 @@
+{%- from 'metadata/settings.sls' import metadata with context %}
+
+{% set postgres_directory = salt['pillar.get']('postgres:postgres_directory') %}
+{% set postgres_data_on_attached_disk = salt['pillar.get']('postgres:postgres_data_on_attached_disk', 'False') %}
+
+include:
+{% if not salt['file.file_exists']('/usr/pgsql-14/bin/psql') %}
+  - postgresql.pg14-install
+{% endif %}
+  - postgresql.pg14-alternatives
+
+{% for version in ['10', '11'] %}
+{% if salt['file.file_exists']('/usr/lib/systemd/system/postgresql-' +  version + '.service') %}
+remove-pg{{ version }}-alias:
+  file.replace:
+    - name: /usr/lib/systemd/system/postgresql-{{ version }}.service
+    - pattern: "Alias=postgresql.service"
+    - repl: ""
+
+disable-postgresql-{{ version }}:
+  service.dead:
+    - enable: False
+    - name: postgresql-{{ version }}
+{% endif %}
+{% endfor %}
+
+/var/lib/pgsql/data:
+  file.symlink:
+    - target: /var/lib/pgsql/14/data
+    - force: True
+    - failhard: True
+    - user: postgres
+    - group: postgres
+    - mode: 700
+    - makedirs: True
+
+change-db-location-14:
+  file.replace:
+    - name: /usr/lib/systemd/system/postgresql-14.service
+    - pattern: "Environment=PGDATA=.*"
+    - repl: Environment=PGDATA={{ postgres_directory }}/data
+    - unless: grep "Environment=PGDATA={{ postgres_directory }}/data" /usr/lib/systemd/system/postgresql-14.service
+
+postgresql-systemd-link:
+  file.replace:
+    - name: /usr/lib/systemd/system/postgresql-14.service
+    - pattern: "\\[Install\\]"
+    - repl: "[Install]\nAlias=postgresql.service"
+    - unless: cat /usr/lib/systemd/system/postgresql-14.service | grep postgresql.service
+
+{% if metadata.platform == 'YARN' %}  # systemctl reenable does not work on ycloud so we create the symlink manually
+create-postgres-service-link:
+  cmd.run:
+    - name: ln -sf /usr/lib/systemd/system/postgresql-14.service /usr/lib/systemd/system/postgresql.service && systemctl disable postgresql-14 && systemctl enable postgresql
+{% else %}
+reenable-postgres:
+  cmd.run:
+    - name: systemctl reenable postgresql-14.service
+{% endif %}


### PR DESCRIPTION
### This commit is already on master, backporting it to 2.73.0 to unblock the QE.


This commit includes the support for embedded Postgres 14

- turning off PG10 and PG11 services
- configuring the `PGDATA` and `Alias=postgresql.service`
- configuring the alternatives
- installing PG14 if it does not exist yet

See detailed description in the commit message.