### PR TITLE
CB-22390 Replace CCMv1 with CCMv2 in the L0 Promotion test cases

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxWithCcmResizeRecoveryTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxWithCcmResizeRecoveryTests.java
@@ -25,7 +25,7 @@ public class SdxWithCcmResizeRecoveryTests extends PreconditionSdxE2ETest {
 
     @Override
     protected void initiateEnvironmentCreation(TestContext testContext) {
-        environmentUtil.createCCMv1Environment(testContext)
+        environmentUtil.createCCMv2Environment(testContext)
                     .withFreeIpaImage(commonCloudProperties().getImageValidation().getFreeIpaImageCatalog(),
                         commonCloudProperties().getImageValidation().getFreeIpaImageUuid())
                 .when(environmentTestClient.create())
@@ -36,7 +36,7 @@ public class SdxWithCcmResizeRecoveryTests extends PreconditionSdxE2ETest {
     @Test(dataProvider = TEST_CONTEXT)
     @UseSpotInstances
     @Description(
-            given = "there is an available environment with a running SDX cluster connected via CCMv1",
+            given = "there is an available environment with a running SDX cluster connected via CCMv2 Jumpgate",
             when = "resize is performed on the SDX cluster but fails during provisioning",
             then = "recovery should be available and successful when run, the original cluster should be up and running"
     )

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxWithCcmResizeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxWithCcmResizeTests.java
@@ -25,7 +25,7 @@ public class SdxWithCcmResizeTests extends PreconditionSdxE2ETest {
 
     @Override
     protected void initiateEnvironmentCreation(TestContext testContext) {
-        environmentUtil.createCCMv1Environment(testContext)
+        environmentUtil.createCCMv2Environment(testContext)
                     .withFreeIpaImage(commonCloudProperties().getImageValidation().getFreeIpaImageCatalog(),
                         commonCloudProperties().getImageValidation().getFreeIpaImageUuid())
                 .when(environmentTestClient.create())
@@ -36,7 +36,7 @@ public class SdxWithCcmResizeTests extends PreconditionSdxE2ETest {
     @Test(dataProvider = TEST_CONTEXT)
     @UseSpotInstances
     @Description(
-            given = "there is an available environment with a running SDX cluster connected via CCMv1",
+            given = "there is an available environment with a running SDX cluster connected via CCMv2 Jumpgate",
             when = "resize is called on the SDX cluster",
             then = "SDX resize should be successful, the new cluster should be up and running"
     )

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/EnvironmentUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/EnvironmentUtil.java
@@ -77,4 +77,18 @@ public class EnvironmentUtil {
                     .withCreateFreeIpa(Boolean.TRUE)
                     .withOneFreeIpaNode();
     }
+
+    public EnvironmentTestDto createCCMv2Environment(TestContext testContext) {
+        return testContext
+                .given("telemetry", TelemetryTestDto.class)
+                    .withLogging()
+                    .withReportClusterLogs()
+                .given(EnvironmentTestDto.class)
+                    .withNetwork()
+                    .withTelemetry("telemetry")
+                    .withTunnel(Tunnel.CCMV2_JUMPGATE)
+                    .withOverrideTunnel()
+                    .withCreateFreeIpa(Boolean.TRUE)
+                    .withOneFreeIpaNode();
+    }
 }

--- a/integration-test/src/main/resources/testsuites/e2e/l0promotion/ccm-sdx-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/l0promotion/ccm-sdx-tests.yaml
@@ -2,6 +2,5 @@ name: "ccm-sdx-tests"
 tests:
   - name: "ccm_sdx_tests"
     classes:
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion.DatalakeCcmUpgradeTest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion.SdxWithCcmResizeRecoveryTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion.SdxWithCcmResizeTests

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
@@ -8,10 +8,10 @@
 {% set postgres_data_on_attached_disk = salt['pillar.get']('postgres:postgres_data_on_attached_disk', 'False') %}
 {% set command = 'systemctl show -p FragmentPath postgresql' %}
 {% set unitFile = salt['cmd.run'](command) | replace("FragmentPath=","") %}
+{% set postgres_version = salt['pillar.get']('postgres:postgres_version', '10') | int %}
 
 {% if 'None' != configure_remote_db %}
 
-{% set postgres_version = salt['pillar.get']('postgres:postgres_version', '10') | int %}
 include:
 {%- if postgres_version == 11 %}
 {%- if not salt['file.file_exists']('/usr/pgsql-11/bin/psql') %}
@@ -51,7 +51,7 @@ init-services-db-remote:
       - file: {{ postgresql.root_certs_file }}
 {%- endif %}
 
-{%- else %}
+{%- else %} {# 'None' == configure_remote_db #}
 
 {%- if postgres_data_on_attached_disk %}
 
@@ -97,9 +97,12 @@ create_embeddeddb_certificate:
 
 {%- endif %}
 
-{%- if salt['pillar.get']('postgres:postgres_version', '10') | int == 11 %}
+{%- if postgres_version == 11 %}
 include:
   - postgresql.pg11
+{%- elif postgres_version == 14 %}
+include:
+  - postgresql.pg14
 {%- endif %}
 
 ensure-postgres-stopped-before-initdb:

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/pg14.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/pg14.sls
@@ -1,0 +1,59 @@
+{%- from 'metadata/settings.sls' import metadata with context %}
+
+{% set postgres_directory = salt['pillar.get']('postgres:postgres_directory') %}
+{% set postgres_data_on_attached_disk = salt['pillar.get']('postgres:postgres_data_on_attached_disk', 'False') %}
+
+include:
+{% if not salt['file.file_exists']('/usr/pgsql-14/bin/psql') %}
+  - postgresql.pg14-install
+{% endif %}
+  - postgresql.pg14-alternatives
+
+{% for version in ['10', '11'] %}
+{% if salt['file.file_exists']('/usr/lib/systemd/system/postgresql-' +  version + '.service') %}
+remove-pg{{ version }}-alias:
+  file.replace:
+    - name: /usr/lib/systemd/system/postgresql-{{ version }}.service
+    - pattern: "Alias=postgresql.service"
+    - repl: ""
+
+disable-postgresql-{{ version }}:
+  service.dead:
+    - enable: False
+    - name: postgresql-{{ version }}
+{% endif %}
+{% endfor %}
+
+/var/lib/pgsql/data:
+  file.symlink:
+    - target: /var/lib/pgsql/14/data
+    - force: True
+    - failhard: True
+    - user: postgres
+    - group: postgres
+    - mode: 700
+    - makedirs: True
+
+change-db-location-14:
+  file.replace:
+    - name: /usr/lib/systemd/system/postgresql-14.service
+    - pattern: "Environment=PGDATA=.*"
+    - repl: Environment=PGDATA={{ postgres_directory }}/data
+    - unless: grep "Environment=PGDATA={{ postgres_directory }}/data" /usr/lib/systemd/system/postgresql-14.service
+
+postgresql-systemd-link:
+  file.replace:
+    - name: /usr/lib/systemd/system/postgresql-14.service
+    - pattern: "\\[Install\\]"
+    - repl: "[Install]\nAlias=postgresql.service"
+    - unless: cat /usr/lib/systemd/system/postgresql-14.service | grep postgresql.service
+
+{% if metadata.platform == 'YARN' %}  # systemctl reenable does not work on ycloud so we create the symlink manually
+create-postgres-service-link:
+  cmd.run:
+    - name: ln -sf /usr/lib/systemd/system/postgresql-14.service /usr/lib/systemd/system/postgresql.service && systemctl disable postgresql-14 && systemctl enable postgresql
+{% else %}
+reenable-postgres:
+  cmd.run:
+    - name: systemctl reenable postgresql-14.service
+{% endif %}


### PR DESCRIPTION
We have failing MOW-Dev L0 Promotion test cases, because of `cluster-proxy.proxy.timeout::failed because of akka.io.TcpOutgoingConnection$$anon$2: Connect timeout of Some(10 seconds) expired`.

After we've upgraded to CCMv2, the issue vanished.