### PR TITLE
CB-22392 Improve AZURE and GCP get Cluster Logs URL methods

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/action/AzureCloudBlobClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/action/AzureCloudBlobClientActions.java
@@ -197,6 +197,11 @@ public class AzureCloudBlobClientActions extends AzureCloudBlobClient {
         Log.log(LOGGER, format(" Azure Blob Log Path: %s", keyPrefix));
         Log.log(LOGGER, format(" Azure Blob Cluster Logs: %s", clusterLogPath));
 
+        if (StringUtils.contains(keyPrefix, clusterLogPath)) {
+            LOGGER.info("Azure Adls Gen 2 Blob is present at '{}' container in storage directory with path: [{}]", containerName, keyPrefix);
+            return format("https://autotestingapi.blob.core.windows.net/%s/%s",
+                    containerName, keyPrefix);
+        }
         try {
             DataLakeDirectoryClient storageDirectory = cloudBlobContainer.getDirectoryClient(keyPrefix);
             DataLakeDirectoryClient logsDirectory = storageDirectory.getSubdirectoryClient(clusterLogPath);
@@ -209,6 +214,8 @@ public class AzureCloudBlobClientActions extends AzureCloudBlobClient {
                 throw new TestFailException(format("Azure Adls Gen 2 Blob is NOT present at '%s' container in '%s' storage directory with path: [%s]",
                         containerName, keyPrefix, clusterLogPath));
             }
+        } catch (TestFailException testFail) {
+            throw testFail;
         } catch (Exception e) {
             LOGGER.error("Azure Adls Gen 2 Blob couldn't process the call. So returning with error!", e);
             throw new TestFailException("Azure Adls Gen 2 Blob couldn't process the call.", e);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/action/GcpClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/action/GcpClientActions.java
@@ -400,7 +400,12 @@ public class GcpClientActions extends GcpClient {
         Log.log(LOGGER, format(" Google GCS Log Path: %s", logPath));
         Log.log(LOGGER, format(" Google GCS Cluster Logs: %s", clusterLogPath));
 
-        return format("https://console.cloud.google.com/storage/browser/%s/%s%s?project=gcp-dev-cloudbreak",
-                bucketName, getKeyPrefix(baseLocation), clusterLogPath);
+        if (StringUtils.contains(getKeyPrefix(baseLocation), clusterLogPath)) {
+            return format("https://console.cloud.google.com/storage/browser/%s/%s?project=gcp-dev-cloudbreak",
+                    bucketName, getKeyPrefix(baseLocation));
+        } else {
+            return format("https://console.cloud.google.com/storage/browser/%s/%s%s?project=gcp-dev-cloudbreak",
+                    bucketName, getKeyPrefix(baseLocation), clusterLogPath);
+        }
     }
 }


### PR DESCRIPTION
In case of separate resource's TestDTO path generation base location fallback should be introduced to the getLoggingUrl method.