### PR TITLE
CB-22390 Replace CCMv1 with CCMv2 in the L0 Promotion test cases

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxWithCcmResizeRecoveryTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxWithCcmResizeRecoveryTests.java
@@ -25,7 +25,7 @@ public class SdxWithCcmResizeRecoveryTests extends PreconditionSdxE2ETest {
 
     @Override
     protected void initiateEnvironmentCreation(TestContext testContext) {
-        environmentUtil.createCCMv1Environment(testContext)
+        environmentUtil.createCCMv2Environment(testContext)
                     .withFreeIpaImage(commonCloudProperties().getImageValidation().getFreeIpaImageCatalog(),
                         commonCloudProperties().getImageValidation().getFreeIpaImageUuid())
                 .when(environmentTestClient.create())
@@ -36,7 +36,7 @@ public class SdxWithCcmResizeRecoveryTests extends PreconditionSdxE2ETest {
     @Test(dataProvider = TEST_CONTEXT)
     @UseSpotInstances
     @Description(
-            given = "there is an available environment with a running SDX cluster connected via CCMv1",
+            given = "there is an available environment with a running SDX cluster connected via CCMv2 Jumpgate",
             when = "resize is performed on the SDX cluster but fails during provisioning",
             then = "recovery should be available and successful when run, the original cluster should be up and running"
     )

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxWithCcmResizeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxWithCcmResizeTests.java
@@ -25,7 +25,7 @@ public class SdxWithCcmResizeTests extends PreconditionSdxE2ETest {
 
     @Override
     protected void initiateEnvironmentCreation(TestContext testContext) {
-        environmentUtil.createCCMv1Environment(testContext)
+        environmentUtil.createCCMv2Environment(testContext)
                     .withFreeIpaImage(commonCloudProperties().getImageValidation().getFreeIpaImageCatalog(),
                         commonCloudProperties().getImageValidation().getFreeIpaImageUuid())
                 .when(environmentTestClient.create())
@@ -36,7 +36,7 @@ public class SdxWithCcmResizeTests extends PreconditionSdxE2ETest {
     @Test(dataProvider = TEST_CONTEXT)
     @UseSpotInstances
     @Description(
-            given = "there is an available environment with a running SDX cluster connected via CCMv1",
+            given = "there is an available environment with a running SDX cluster connected via CCMv2 Jumpgate",
             when = "resize is called on the SDX cluster",
             then = "SDX resize should be successful, the new cluster should be up and running"
     )

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/EnvironmentUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/EnvironmentUtil.java
@@ -77,4 +77,18 @@ public class EnvironmentUtil {
                     .withCreateFreeIpa(Boolean.TRUE)
                     .withOneFreeIpaNode();
     }
+
+    public EnvironmentTestDto createCCMv2Environment(TestContext testContext) {
+        return testContext
+                .given("telemetry", TelemetryTestDto.class)
+                    .withLogging()
+                    .withReportClusterLogs()
+                .given(EnvironmentTestDto.class)
+                    .withNetwork()
+                    .withTelemetry("telemetry")
+                    .withTunnel(Tunnel.CCMV2_JUMPGATE)
+                    .withOverrideTunnel()
+                    .withCreateFreeIpa(Boolean.TRUE)
+                    .withOneFreeIpaNode();
+    }
 }

--- a/integration-test/src/main/resources/testsuites/e2e/l0promotion/ccm-sdx-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/l0promotion/ccm-sdx-tests.yaml
@@ -2,6 +2,5 @@ name: "ccm-sdx-tests"
 tests:
   - name: "ccm_sdx_tests"
     classes:
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion.DatalakeCcmUpgradeTest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion.SdxWithCcmResizeRecoveryTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion.SdxWithCcmResizeTests


### PR DESCRIPTION
We have failing MOW-Dev L0 Promotion test cases, because of `cluster-proxy.proxy.timeout::failed because of akka.io.TcpOutgoingConnection$$anon$2: Connect timeout of Some(10 seconds) expired`.

After we've upgraded to CCMv2, the issue vanished.