### PR TITLE
CB-22422 added osType to TelemetryContext based on Components table

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryRepoConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryRepoConfiguration.java
@@ -1,49 +1,7 @@
 package com.sequenceiq.cloudbreak.telemetry;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
-@Component
-@ConfigurationProperties("telemetry.repo")
-public class TelemetryRepoConfiguration {
-
-    private String name;
-
-    private String baseUrl;
-
-    private String gpgKey;
-
-    private Integer gpgCheck;
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getBaseUrl() {
-        return baseUrl;
-    }
-
-    public void setBaseUrl(String baseUrl) {
-        this.baseUrl = baseUrl;
-    }
-
-    public String getGpgKey() {
-        return gpgKey;
-    }
-
-    public void setGpgKey(String gpgKey) {
-        this.gpgKey = gpgKey;
-    }
-
-    public Integer getGpgCheck() {
-        return gpgCheck;
-    }
-
-    public void setGpgCheck(Integer gpgCheck) {
-        this.gpgCheck = gpgCheck;
-    }
+@ConstructorBinding
+public record TelemetryRepoConfiguration(String name, String baseUrl, String gpgKey, Integer gpgCheck) {
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryRepoConfigurationHolder.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryRepoConfigurationHolder.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.cloudbreak.telemetry;
+
+import javax.validation.constraints.NotBlank;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
+
+@Component
+@ConfigurationProperties("telemetry.repos")
+public class TelemetryRepoConfigurationHolder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TelemetryRepoConfigurationHolder.class);
+
+    @NotBlank
+    private TelemetryRepoConfiguration rhel7;
+
+    @NotBlank
+    private TelemetryRepoConfiguration rhel8;
+
+    public TelemetryRepoConfiguration selectCorrectRepoConfig(TelemetryContext context) {
+        String osType = context.getOsType();
+        if ("redhat8".equals(osType)) {
+            return rhel8;
+        }
+        if ("redhat7".equals(osType)) {
+            return rhel7;
+        }
+        LOGGER.warn("Unrecognized OsType {} selected for TelemetryContext using default fallback rhel7 repository", osType);
+        return rhel7;
+    }
+
+    public TelemetryRepoConfiguration getRhel7() {
+        return rhel7;
+    }
+
+    public void setRhel7(TelemetryRepoConfiguration rhel7) {
+        this.rhel7 = rhel7;
+    }
+
+    public TelemetryRepoConfiguration getRhel8() {
+        return rhel8;
+    }
+
+    public void setRhel8(TelemetryRepoConfiguration rhel8) {
+        this.rhel8 = rhel8;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/common/TelemetryCommonConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/common/TelemetryCommonConfigService.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfigView;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryPillarConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryRepoConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryRepoConfigurationHolder;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryUpgradeConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.context.LogShipperContext;
 import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
@@ -37,16 +38,16 @@ public class TelemetryCommonConfigService implements TelemetryPillarConfigGenera
 
     private final TelemetryUpgradeConfiguration telemetryUpgradeConfiguration;
 
-    private final TelemetryRepoConfiguration telemetryRepoConfiguration;
+    private final TelemetryRepoConfigurationHolder telemetryRepoConfigurationHolder;
 
     private final AltusDatabusConnectionConfiguration altusDatabusConnectionConfiguration;
 
     public TelemetryCommonConfigService(AnonymizationRuleResolver anonymizationRuleResolver, TelemetryUpgradeConfiguration telemetryUpgradeConfiguration,
-            TelemetryRepoConfiguration telemetryRepoConfiguration, AltusDatabusConnectionConfiguration altusDatabusConnectionConfiguration) {
+            TelemetryRepoConfigurationHolder telemetryRepoConfigurationHolder, AltusDatabusConnectionConfiguration altusDatabusConnectionConfiguration) {
         this.anonymizationRuleResolver = anonymizationRuleResolver;
         this.telemetryUpgradeConfiguration = telemetryUpgradeConfiguration;
         this.altusDatabusConnectionConfiguration = altusDatabusConnectionConfiguration;
-        this.telemetryRepoConfiguration = telemetryRepoConfiguration;
+        this.telemetryRepoConfigurationHolder = telemetryRepoConfigurationHolder;
     }
 
     @Override
@@ -68,6 +69,9 @@ public class TelemetryCommonConfigService implements TelemetryPillarConfigGenera
                 builder.withDesiredCdpRequestSignerVersion(telemetryUpgradeConfiguration.getCdpRequestSigner().getDesiredVersion());
             }
         }
+
+        TelemetryRepoConfiguration telemetryRepoConfiguration = telemetryRepoConfigurationHolder.selectCorrectRepoConfig(context);
+
         return builder
                 .withClusterDetails(clusterDetails)
                 .withRules(anonymizationRuleResolver.decodeRules(telemetry.getRules()))
@@ -76,10 +80,10 @@ public class TelemetryCommonConfigService implements TelemetryPillarConfigGenera
                 .withDatabusConnectRetryTimes(altusDatabusConnectionConfiguration.getRetryTimes())
                 .withDatabusConnectRetryDelay(altusDatabusConnectionConfiguration.getRetryDelaySeconds())
                 .withDatabusConnectRetryMaxTime(altusDatabusConnectionConfiguration.getRetryMaxTimeSeconds())
-                .withRepoName(telemetryRepoConfiguration.getName())
-                .withRepoBaseUrl(telemetryRepoConfiguration.getBaseUrl())
-                .withRepoGpgKey(telemetryRepoConfiguration.getGpgKey())
-                .withRepoGpgCheck(telemetryRepoConfiguration.getGpgCheck())
+                .withRepoName(telemetryRepoConfiguration.name())
+                .withRepoBaseUrl(telemetryRepoConfiguration.baseUrl())
+                .withRepoGpgKey(telemetryRepoConfiguration.gpgKey())
+                .withRepoGpgCheck(telemetryRepoConfiguration.gpgCheck())
                 .build();
     }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/context/TelemetryContext.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/context/TelemetryContext.java
@@ -16,6 +16,8 @@ public class TelemetryContext {
 
     private FluentClusterType clusterType;
 
+    private String osType;
+
     private DatabusContext databusContext;
 
     private MonitoringContext monitoringContext;
@@ -44,6 +46,14 @@ public class TelemetryContext {
 
     public void setTelemetry(Telemetry telemetry) {
         this.telemetry = telemetry;
+    }
+
+    public String getOsType() {
+        return osType;
+    }
+
+    public void setOsType(String osType) {
+        this.osType = osType;
     }
 
     public DatabusContext getDatabusContext() {

--- a/common/src/main/resources/common-config.yml
+++ b/common/src/main/resources/common-config.yml
@@ -23,11 +23,17 @@ altus:
     endpoint:
     grpc-timeout-sec: 60
 telemetry:
-  repo:
-    name: cdp-infra-tools
-    base-url: https://archive.cloudera.com/cdp-infra-tools/latest/redhat7/yum
-    gpg-key: https://archive.cloudera.com/cdp-infra-tools/latest/redhat7/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
-    gpg-check: 1
+  repos:
+    rhel7:
+      name: cdp-infra-tools-rhel7
+      base-url: https://archive.cloudera.com/cdp-infra-tools/latest/redhat7/yum
+      gpg-key: https://archive.cloudera.com/cdp-infra-tools/latest/redhat7/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+      gpg-check: 1
+    rhel8:
+      name: cdp-infra-tools-rhel8
+      base-url: https://archive.cloudera.com/cdp-infra-tools/latest/redhat8/yum
+      gpg-key: https://archive.cloudera.com/cdp-infra-tools/latest/redhat8/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+      gpg-check: 1
   monitoring:
     remote-write-url: ""
     remote-write-internal-url: ""

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/TelemetryRepoConfigurationHolderTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/TelemetryRepoConfigurationHolderTest.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.cloudbreak.telemetry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
+
+@ExtendWith(MockitoExtension.class)
+class TelemetryRepoConfigurationHolderTest {
+
+    @InjectMocks
+    private TelemetryRepoConfigurationHolder underTest;
+
+    @Mock
+    private TelemetryRepoConfiguration rhel7;
+
+    @Mock
+    private TelemetryRepoConfiguration rhel8;
+
+    @Test
+    void selectCorrectRepoConfigWhenOsTypeRhel7() {
+        given(rhel7.name()).willReturn("cdp-infra-tools-rhel7");
+        TelemetryContext context = new TelemetryContext();
+        context.setOsType("redhat7");
+        TelemetryRepoConfiguration selected = underTest.selectCorrectRepoConfig(context);
+        assertEquals("cdp-infra-tools-rhel7", selected.name());
+    }
+
+    @Test
+    void selectCorrectRepoConfigWhenOsTypeRedhat8() {
+        given(rhel8.name()).willReturn("cdp-infra-tools-rhel8");
+        TelemetryContext context = new TelemetryContext();
+        context.setOsType("redhat8");
+        TelemetryRepoConfiguration selected = underTest.selectCorrectRepoConfig(context);
+        assertEquals("cdp-infra-tools-rhel8", selected.name());
+    }
+
+    @Test
+    void selectCorrectRepoConfigWhenOsTypeEmpty() {
+        given(rhel7.name()).willReturn("cdp-infra-tools-rhel7");
+        TelemetryContext context = new TelemetryContext();
+        TelemetryRepoConfiguration selected = underTest.selectCorrectRepoConfig(context);
+        assertEquals("cdp-infra-tools-rhel7", selected.name());
+    }
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/common/TelemetryCommonConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/common/TelemetryCommonConfigServiceTest.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.altus.AltusDatabusConnectionConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryComponentUpgradeConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryRepoConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryRepoConfigurationHolder;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryUpgradeConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.context.LogShipperContext;
 import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
@@ -45,13 +46,16 @@ public class TelemetryCommonConfigServiceTest {
     private TelemetryRepoConfiguration telemetryRepoConfiguration;
 
     @Mock
+    private TelemetryRepoConfigurationHolder telemetryRepoConfigurationHolder;
+
+    @Mock
     private AltusDatabusConnectionConfiguration altusDatabusConnectionConfiguration;
 
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
         underTest = new TelemetryCommonConfigService(anonymizationRuleResolver, telemetryUpgradeConfiguration,
-                telemetryRepoConfiguration, altusDatabusConnectionConfiguration);
+                telemetryRepoConfigurationHolder, altusDatabusConnectionConfiguration);
     }
 
     @Test
@@ -115,17 +119,50 @@ public class TelemetryCommonConfigServiceTest {
     @Test
     public void testCreateTelemetryCommonConfigs() {
         // GIVEN
+        TelemetryContext context = new TelemetryContext();
+        List<VmLog> vmLogs = generateSimpleVmLogs();
+        mockTelemetryComponentUpgradeConfig();
+        createTelemetryModel(context, vmLogs);
+
         given(telemetryUpgradeConfiguration.isEnabled()).willReturn(true);
-        TelemetryComponentUpgradeConfiguration cdpTelemetryConfig = new TelemetryComponentUpgradeConfiguration();
-        cdpTelemetryConfig.setDesiredVersion("0.0.1");
-        given(telemetryUpgradeConfiguration.getCdpTelemetry()).willReturn(cdpTelemetryConfig);
+        given(telemetryRepoConfiguration.name()).willReturn("cdp-infra-tools-rhel7");
         given(altusDatabusConnectionConfiguration.getMaxTimeSeconds()).willReturn(1);
+        given(telemetryRepoConfigurationHolder.selectCorrectRepoConfig(context)).willReturn(telemetryRepoConfiguration);
+        // WHEN
+        Map<String, Object> result = underTest.createConfigs(context).toMap();
+        // THEN
+        assertEquals("/var/log/mylog.log", vmLogs.get(0).getPath());
+        assertEquals("/grid/0/log/*", vmLogs.get(1).getPath());
+        assertEquals("/my/path/custom/log/*", vmLogs.get(2).getPath());
+        assertEquals("0.0.1", result.get("desiredCdpTelemetryVersion").toString());
+        assertEquals(1, result.get("databusConnectMaxTime"));
+        assertEquals("cdp-infra-tools-rhel7", result.get("repoName"));
+    }
+
+    private static void createTelemetryModel(TelemetryContext context, List<VmLog> vmLogs) {
         Telemetry telemetry = new Telemetry();
         Map<String, Object> fluentAttributes = new HashMap<>();
         fluentAttributes.put(SERVICE_LOG_FOLDER_PREFIX, "/var/log");
         fluentAttributes.put(SERVER_LOG_FOLDER_PREFIX, "/custom/log");
         fluentAttributes.put(AGENT_LOG_FOLDER_PREFIX, "/grid/0/log");
         telemetry.setFluentAttributes(fluentAttributes);
+        TelemetryClusterDetails telemetryClusterDetails = TelemetryClusterDetails.Builder.builder()
+                .build();
+        LogShipperContext logShipperContext = LogShipperContext.builder()
+                .withVmLogs(vmLogs)
+                .build();
+        context.setTelemetry(telemetry);
+        context.setClusterDetails(telemetryClusterDetails);
+        context.setLogShipperContext(logShipperContext);
+    }
+
+    private void mockTelemetryComponentUpgradeConfig() {
+        TelemetryComponentUpgradeConfiguration cdpTelemetryConfig = new TelemetryComponentUpgradeConfiguration();
+        cdpTelemetryConfig.setDesiredVersion("0.0.1");
+        given(telemetryUpgradeConfiguration.getCdpTelemetry()).willReturn(cdpTelemetryConfig);
+    }
+
+    private static List<VmLog> generateSimpleVmLogs() {
         List<VmLog> vmLogs = new ArrayList<>();
         VmLog log1 = new VmLog();
         log1.setPath("${serviceLogFolderPrefix}/mylog.log");
@@ -136,22 +173,6 @@ public class TelemetryCommonConfigServiceTest {
         vmLogs.add(log1);
         vmLogs.add(log2);
         vmLogs.add(log3);
-        TelemetryClusterDetails telemetryClusterDetails = TelemetryClusterDetails.Builder.builder()
-                .build();
-        LogShipperContext logShipperContext = LogShipperContext.builder()
-                .withVmLogs(vmLogs)
-                .build();
-        TelemetryContext context = new TelemetryContext();
-        context.setTelemetry(telemetry);
-        context.setClusterDetails(telemetryClusterDetails);
-        context.setLogShipperContext(logShipperContext);
-        // WHEN
-        Map<String, Object> result = underTest.createConfigs(context).toMap();
-        // THEN
-        assertEquals("/var/log/mylog.log", vmLogs.get(0).getPath());
-        assertEquals("/grid/0/log/*", vmLogs.get(1).getPath());
-        assertEquals("/my/path/custom/log/*", vmLogs.get(2).getPath());
-        assertEquals("0.0.1", result.get("desiredCdpTelemetryVersion").toString());
-        assertEquals(1, result.get("databusConnectMaxTime"));
+        return vmLogs;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
@@ -21,9 +21,11 @@ import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.auth.altus.model.CdpAccessKeyType;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.StackTags;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
 import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.altus.AltusMachineUserService;
@@ -107,6 +109,14 @@ public class TelemetryDecorator implements TelemetryContextProvider<StackDto> {
         TelemetryContext telemetryContext = new TelemetryContext();
         telemetryContext.setClusterType(mapToFluentClusterType(stack.getType()));
         telemetryContext.setTelemetry(telemetry);
+
+        try {
+            Image image = componentConfigProviderService.getImage(stack.getId());
+            telemetryContext.setOsType(image.getOsType());
+        } catch (CloudbreakImageNotFoundException e) {
+            LOGGER.warn("Not able to get Image info from Component info for stack {}", stack.getId(), e);
+        }
+
         if (telemetry != null) {
             CdpAccessKeyType cdpAccessKeyType = altusMachineUserService.getCdpAccessKeyType(stackDto);
             DatabusContext databusContext = createDatabusContext(stack, telemetry, dataBusCredential, accountId, cdpAccessKeyType);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -29,8 +30,10 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.auth.altus.model.CdpAccessKeyType;
+import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.dto.StackDto;
@@ -84,7 +87,7 @@ public class TelemetryDecoratorTest {
     private Monitoring monitoring = new Monitoring();
 
     @Before
-    public void setUp() {
+    public void setUp() throws CloudbreakImageNotFoundException {
         initMocks();
         underTest = new TelemetryDecorator(
                 altusMachineUserService,
@@ -290,16 +293,18 @@ public class TelemetryDecoratorTest {
         assertEquals(FluentClusterType.DATAHUB, result.getClusterType());
     }
 
-    private void initMocks() {
+    private void initMocks() throws CloudbreakImageNotFoundException {
         MockitoAnnotations.openMocks(this);
         AltusCredential altusCredential = new AltusCredential("myAccessKey", "mySecretKey".toCharArray());
         DataBusCredential dataBusCredential = new DataBusCredential();
+        Image image = mock(Image.class);
         dataBusCredential.setAccessKey("myAccessKey");
         dataBusCredential.setPrivateKey("mySecretKey");
         MonitoringCredential monitoringCredential = new MonitoringCredential();
         monitoringCredential.setAccessKey("myAccessKey");
         monitoringCredential.setPrivateKey("mySecretKey");
         given(componentConfigProviderService.getTelemetry(anyLong())).willReturn(telemetry);
+        given(componentConfigProviderService.getImage(anyLong())).willReturn(image);
         given(telemetry.getDatabusEndpoint()).willReturn("https://dbus-dev.com");
         given(altusMachineUserService.isAnyDataBusBasedFeatureSupported(any(Telemetry.class))).willReturn(true);
         given(altusMachineUserService.isAnyMonitoringFeatureSupported(any(Telemetry.class))).willReturn(true);


### PR DESCRIPTION
Fallback logic will use rhel7 if image osType is not set or it's a new uknown osType submitted.