### PR TITLE
CB-22402 Temporarly lock runtime version for the Marketplace e2e test to 7.2.15

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
@@ -284,7 +284,8 @@ public abstract class AbstractCloudProvider implements CloudProvider {
     protected abstract DistroXClusterTestDto withCluster(DistroXClusterTestDto cluster);
 
     @Override
-    public String getLatestMarketplacePreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient) {
+    public String getLatestMarketplacePreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient,
+            String runtimeVersion) {
         throw new TestFailException("Marketplace images are not supported on this platform");
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
@@ -64,7 +64,8 @@ public interface CloudProvider {
 
     String getLatestPreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient);
 
-    String getLatestMarketplacePreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient);
+    String getLatestMarketplacePreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient,
+            String runtimeVersion);
 
     String getLatestBaseImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient);
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
@@ -119,8 +119,9 @@ public class CloudProviderProxy implements CloudProvider {
     }
 
     @Override
-    public String getLatestMarketplacePreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient) {
-        return getDelegate(imageCatalogTestDto).getLatestMarketplacePreWarmedImageID(testContext, imageCatalogTestDto, cloudbreakClient);
+    public String getLatestMarketplacePreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient,
+            String runtimeVersion) {
+        return getDelegate(imageCatalogTestDto).getLatestMarketplacePreWarmedImageID(testContext, imageCatalogTestDto, cloudbreakClient, runtimeVersion);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -429,7 +429,8 @@ public class AzureCloudProvider extends AbstractCloudProvider {
     }
 
     @Override
-    public String getLatestMarketplacePreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient) {
+    public String getLatestMarketplacePreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient,
+            String runtimeVersion) {
         try {
             Optional<ImageV4Response> prewarmedImagesForRuntime = cloudbreakClient
                     .getDefaultClient()
@@ -441,13 +442,13 @@ public class AzureCloudProvider extends AbstractCloudProvider {
                             .stream()
                             .anyMatch(i -> i.getValue().containsKey(MARKETPLACE_REGION)))
                     .filter(image -> StringUtils.equalsIgnoreCase(image.getStackDetails().getVersion(),
-                            commonClusterManagerProperties().getRuntimeVersion()))
+                            runtimeVersion))
                     .max(Comparator.comparing(ImageV4Response::getPublished));
 
             ImageV4Response latestPrewarmedImage = prewarmedImagesForRuntime
                     .orElseThrow(() ->
                             new IllegalStateException(format("Cannot find pre-warmed Azure Marketplace images at Azure provider for '%s' runtime version!",
-                            commonClusterManagerProperties().getRuntimeVersion())));
+                                    runtimeVersion)));
             Log.log(LOGGER, format(" Image Catalog Name: %s ", imageCatalogTestDto.getRequest().getName()));
             Log.log(LOGGER, format(" Image Catalog URL: %s ", imageCatalogTestDto.getRequest().getUrl()));
             Log.log(LOGGER, format(" Selected Pre-warmed Image Date: %s | ID: %s | Description: %s ", latestPrewarmedImage.getDate(),

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXMarketplaceImageTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXMarketplaceImageTests.java
@@ -42,6 +42,8 @@ public class DistroXMarketplaceImageTests extends PreconditionSdxE2ETest {
 
     private static final int MARKETPLACE_IMAGE_PARTS_COUNT = 4;
 
+    private static final String RUNTIME_VERSION = "7.2.15";
+
     @Inject
     private SdxTestClient sdxTestClient;
 
@@ -120,6 +122,7 @@ public class DistroXMarketplaceImageTests extends PreconditionSdxE2ETest {
                     .withCloudStorage(getCloudStorageRequest(testContext))
                     .withStackRequest(key(cluster), key(stack))
                     .withTelemetry(telemetry)
+                    .withRuntimeVersion(RUNTIME_VERSION)
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
                 .await(SdxClusterStatusResponse.RUNNING)
                 .awaitForHealthyInstances()
@@ -171,7 +174,7 @@ public class DistroXMarketplaceImageTests extends PreconditionSdxE2ETest {
         testContext
                 .given(imgCatalogKey, ImageCatalogTestDto.class)
                 .when((tc, dto, client) -> {
-                    selectedImageID.set(tc.getCloudProvider().getLatestMarketplacePreWarmedImageID(tc, dto, client));
+                    selectedImageID.set(tc.getCloudProvider().getLatestMarketplacePreWarmedImageID(tc, dto, client, RUNTIME_VERSION));
                     return dto;
                 });
         return selectedImageID.get();


### PR DESCRIPTION
The runtime version for e2e tests was raised to 7.2.17. However there is no marketplace image in the production image catalog as of now. Hard coding in 7.2.15 for the marketplace e2e test for the meanwhile.