### PR TITLE
CB-22416 Setup native memory tracking

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     exclude group: 'org.glassfish.jersey.core'
   }
   implementation group: 'io.micrometer',                    name: 'micrometer-registry-prometheus', version: micrometerVersion
+  implementation group: 'io.github.mweirauch',              name: 'micrometer-jvm-extras',          version: microMeterJvmExtrasVersion
   api group: 'commons-io',                                  name: 'commons-io',                     version: apacheCommonsIoVersion
   api group: 'commons-net',                                 name: 'commons-net',                    version: '3.9.0'
   api group: 'org.apache.commons',                          name: 'commons-collections4',           version: commonsCollections4Version

--- a/common/src/main/java/com/sequenceiq/cloudbreak/jvm/DiagnosticCommandRunner.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/jvm/DiagnosticCommandRunner.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.cloudbreak.jvm;
+
+import java.lang.management.ManagementFactory;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class DiagnosticCommandRunner {
+
+    public String vmFlags() throws ReflectionException, MalformedObjectNameException, InstanceNotFoundException, MBeanException {
+        return run("vmFlags", "-all");
+    }
+
+    public String vmNativeMemory() throws ReflectionException, MalformedObjectNameException, InstanceNotFoundException, MBeanException {
+        return run("vmNativeMemory", "summary");
+    }
+
+    private String run(String operationName, String param) throws MalformedObjectNameException, ReflectionException, InstanceNotFoundException, MBeanException {
+        return (String) ManagementFactory.getPlatformMBeanServer().invoke(new ObjectName("com.sun.management:type=DiagnosticCommand"),
+                operationName,
+                new Object[] { new String[] { param } },
+                new String[] { String[].class.getName() });
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/jvm/JvmInfoProvider.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/jvm/JvmInfoProvider.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.cloudbreak.jvm;
+
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JvmInfoProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JvmInfoProvider.class);
+
+    @Value("${vm.info.vmflags.enabled:true}")
+    private boolean vmFlagsEnabled;
+
+    @Inject
+    private VmFlagsParser vmFlagsParser;
+
+    @Inject
+    private DiagnosticCommandRunner diagnosticCommandRunner;
+
+    @PostConstruct
+    public void init() {
+        if (vmFlagsEnabled) {
+            printVmFlags();
+        }
+    }
+
+    private void printVmFlags() {
+        try {
+            String vmFlags = diagnosticCommandRunner.vmFlags();
+            List<String> vmFlagList = vmFlagsParser.parseVmFlags(vmFlags);
+            LOGGER.debug("VM flags: {}", vmFlagList);
+        } catch (Exception e) {
+            LOGGER.error("Cannot print VM flags", e);
+        }
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/jvm/JvmMetricTag.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/jvm/JvmMetricTag.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.cloudbreak.jvm;
+
+public enum JvmMetricTag {
+
+    CATEGORY,
+    TYPE;
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/jvm/JvmMetricType.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/jvm/JvmMetricType.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.cloudbreak.jvm;
+
+import com.sequenceiq.cloudbreak.common.metrics.type.Metric;
+
+public enum JvmMetricType implements Metric {
+
+    JVM_NATIVE_MEMORY("jvm.native.memory");
+
+    private final String metricName;
+
+    JvmMetricType(String metricName) {
+        this.metricName = metricName;
+    }
+
+    @Override
+    public String getMetricName() {
+        return metricName;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/jvm/MemoryCategory.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/jvm/MemoryCategory.java
@@ -1,0 +1,4 @@
+package com.sequenceiq.cloudbreak.jvm;
+
+public record MemoryCategory(String name, double reserved, double committed) {
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/jvm/NativeMemoryMetricConfigurator.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/jvm/NativeMemoryMetricConfigurator.java
@@ -1,0 +1,106 @@
+package com.sequenceiq.cloudbreak.jvm;
+
+import static com.sequenceiq.cloudbreak.jvm.JvmMetricTag.CATEGORY;
+import static com.sequenceiq.cloudbreak.jvm.JvmMetricTag.TYPE;
+import static com.sequenceiq.cloudbreak.jvm.JvmMetricType.JVM_NATIVE_MEMORY;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.metrics.MetricService;
+import com.sequenceiq.cloudbreak.util.Benchmark;
+
+import io.github.mweirauch.micrometer.jvm.extras.ProcessMemoryMetrics;
+import io.micrometer.core.instrument.MeterRegistry;
+
+@Component
+public class NativeMemoryMetricConfigurator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NativeMemoryMetricConfigurator.class);
+
+    private static final String NATIVE_MEMORY_JVM_ARGUMENT = "-XX:NativeMemoryTracking=summary";
+
+    private static final String COMMITTED = "committed";
+
+    private static final String RESERVED = "reserved";
+
+    @Value("${vm.info.nativeMemory.enabled:true}")
+    private boolean nativeMemoryInfo;
+
+    @Qualifier("CommonMetricService")
+    @Inject
+    private MetricService metricService;
+
+    @Inject
+    private MeterRegistry meterRegistry;
+
+    @Inject
+    private DiagnosticCommandRunner diagnosticCommandRunner;
+
+    @Inject
+    private NativeMemoryParser nativeMemoryParser;
+
+    private boolean nativeMemoryMetricsEnabled;
+
+    @PostConstruct
+    public void init() {
+        if (nativeMemoryInfo) {
+            checkNativeMemoryJvmArgument();
+            enableProcMetrics();
+        }
+    }
+
+    @Scheduled(fixedDelayString = "${vm.info.nativeMemory.delay:60000}")
+    public void calculateNativeMemoryMetrics() {
+        if (nativeMemoryMetricsEnabled) {
+            Benchmark.measure(() -> calculateMetrics(), LOGGER, "Native memory metric calculation took {} ms.");
+        }
+    }
+
+    private void checkNativeMemoryJvmArgument() {
+        try {
+            RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
+            Optional<String> nativeMemoryJvmArgument = runtimeMxBean.getInputArguments().stream()
+                    .filter(argument -> argument.equals(NATIVE_MEMORY_JVM_ARGUMENT))
+                    .findAny();
+            if (nativeMemoryJvmArgument.isPresent()) {
+                nativeMemoryMetricsEnabled = true;
+            }
+        } catch (Exception e) {
+            LOGGER.error("Native memory metric initialization failed", e);
+        }
+    }
+
+    private void calculateMetrics() {
+        try {
+            String vmNativeMemory = diagnosticCommandRunner.vmNativeMemory();
+            List<MemoryCategory> vmNativeMemoryCategories = nativeMemoryParser.parseVmNativeMemory(vmNativeMemory);
+            vmNativeMemoryCategories.stream().forEach(category -> {
+                metricService.gauge(JVM_NATIVE_MEMORY, category.committed(), Map.of(CATEGORY.name(), category.name(), TYPE.name(), COMMITTED));
+                metricService.gauge(JVM_NATIVE_MEMORY, category.reserved(), Map.of(CATEGORY.name(), category.name(), TYPE.name(), RESERVED));
+            });
+        } catch (Exception e) {
+            LOGGER.error("Native memory metric calculation failed", e);
+        }
+    }
+
+    private void enableProcMetrics() {
+        if (SystemUtils.IS_OS_LINUX) {
+            new ProcessMemoryMetrics().bindTo(meterRegistry);
+        }
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/jvm/NativeMemoryParser.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/jvm/NativeMemoryParser.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.cloudbreak.jvm;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NativeMemoryParser {
+
+    private static final String RESERVED_PREFIX = "reserved=";
+
+    private static final String COMMITTED_PREFIX = "committed=";
+
+    private static final String KB_POSTFIX = "KB";
+
+    private static final String CATEGORY_LINE_PREFIX = "-";
+
+    private static final String CATEGORY_NAME_POSTFIX = "(";
+
+    public List<MemoryCategory> parseVmNativeMemory(String vmNativeMemory) {
+        List<MemoryCategory> vmNativeMemoryCategories = new ArrayList<>();
+        Iterator<String> lines = Arrays.asList(vmNativeMemory.split("\n")).iterator();
+        while (lines.hasNext()) {
+            String line = lines.next();
+            if (line.contains("Total:")) {
+                String reserved = StringUtils.substringBetween(line, RESERVED_PREFIX, KB_POSTFIX);
+                String committed = StringUtils.substringBetween(line, COMMITTED_PREFIX, KB_POSTFIX);
+                vmNativeMemoryCategories.add(new MemoryCategory("Total", Double.valueOf(reserved), Double.valueOf(committed)));
+            } else if (line.startsWith(CATEGORY_LINE_PREFIX)) {
+                String name = StringUtils.substringBetween(line, CATEGORY_LINE_PREFIX, CATEGORY_NAME_POSTFIX).trim();
+                String reserved = StringUtils.substringBetween(line, RESERVED_PREFIX, KB_POSTFIX);
+                String committed = StringUtils.substringBetween(line, COMMITTED_PREFIX, KB_POSTFIX);
+                vmNativeMemoryCategories.add(new MemoryCategory(name, Double.valueOf(reserved), Double.valueOf(committed)));
+            }
+        }
+        return vmNativeMemoryCategories;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/jvm/VmFlagsParser.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/jvm/VmFlagsParser.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.cloudbreak.jvm;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+public class VmFlagsParser {
+
+    public List<String> parseVmFlags(String vmFlags) {
+        List<String> vmFlagList = new ArrayList<>();
+        Iterator<String> lines = Arrays.asList(vmFlags.split("\n")).iterator();
+        while (lines.hasNext()) {
+            String line = lines.next();
+            vmFlagList.add(StringUtils.deleteWhitespace(StringUtils.substringBefore(line, "{")));
+        }
+        return vmFlagList;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/metric/JobCountMetricConfigurator.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/metric/JobCountMetricConfigurator.java
@@ -8,8 +8,6 @@ import java.util.Map;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.metrics.MetricService;
@@ -17,8 +15,6 @@ import com.sequenceiq.cloudbreak.quartz.JobSchedulerService;
 
 @Component
 public class JobCountMetricConfigurator {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(JobCountMetricConfigurator.class);
 
     @Inject
     private GroupNameToJobCountFunction groupNameToJobCountFunction;

--- a/common/src/test/java/com/sequenceiq/cloudbreak/jvm/NativeMemoryParserTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/jvm/NativeMemoryParserTest.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.cloudbreak.jvm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NativeMemoryParserTest {
+
+    // @formatter:off
+    // CHECKSTYLE:OFF
+    private static final String VM_NATIVE_MEMORY = """
+            Native Memory Tracking:
+            
+            (Omitting categories weighting less than 1KB)
+            
+            Total: reserved=10351844KB, committed=801708KB
+                   malloc: 111392KB #969179
+                   mmap:   reserved=10240452KB, committed=690316KB
+            
+            -                 Java Heap (reserved=8388608KB, committed=401408KB)
+                                        (mmap: reserved=8388608KB, committed=401408KB)
+            
+            -                     Class (reserved=1050964KB, committed=18900KB)
+                                        (classes #26546)
+                                        (  instance classes #24936, array classes #1610)
+                                        (malloc=2388KB #56982)
+                                        (mmap: reserved=1048576KB, committed=16512KB)
+                                        (  Metadata:   )
+                                        (    reserved=131072KB, committed=112576KB)
+                                        (    used=112276KB)
+                                        (    waste=300KB =0.27%)
+                                        (  Class space:)
+                                        (    reserved=1048576KB, committed=16512KB)
+                                        (    used=16156KB)
+                                        (    waste=356KB =2.16%)
+            
+            -                    Thread (reserved=63651KB, committed=63651KB)
+                                        (thread #63)
+                                        (stack: reserved=63488KB, committed=63488KB)
+                                        (malloc=91KB #444)
+                                        (arena=72KB #123)
+            """;
+    // CHECKSTYLE:ON
+    // @formatter:on
+
+    @InjectMocks
+    private NativeMemoryParser underTest;
+
+    @Test
+    void testParseVmNativeMemory() {
+        List<MemoryCategory> categories = underTest.parseVmNativeMemory(VM_NATIVE_MEMORY);
+        assertThat(categories).hasSize(4);
+        assertThat(categories)
+                .extracting(MemoryCategory::name, MemoryCategory::reserved, MemoryCategory::committed)
+                .containsExactly(
+                        tuple("Total", Double.valueOf(10351844), Double.valueOf(801708)),
+                        tuple("Java Heap", Double.valueOf(8388608), Double.valueOf(401408)),
+                        tuple("Class", Double.valueOf(1050964), Double.valueOf(18900)),
+                        tuple("Thread", Double.valueOf(63651), Double.valueOf(63651)));
+    }
+
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/jvm/VmFlagsParserTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/jvm/VmFlagsParserTest.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.cloudbreak.jvm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class VmFlagsParserTest {
+
+    // @formatter:off
+    // CHECKSTYLE:OFF
+    private static final String VM_FLAGS = """
+            [Global flags]
+                  int ActiveProcessorCount                     = -1                                        {product} {default}
+                uintx AdaptiveSizeDecrementScaleFactor         = 4                                         {product} {default}
+                uintx AdaptiveSizeMajorGCDecayTimeScale        = 10                                        {product} {default}
+            """;
+    // CHECKSTYLE:ON
+    // @formatter:on
+
+    @InjectMocks
+    private VmFlagsParser underTest;
+
+    @Test
+    void testParseVmFlags() {
+        List<String> vmFlags = underTest.parseVmFlags(VM_FLAGS);
+        assertThat(vmFlags).containsExactly("[Globalflags]", "intActiveProcessorCount=-1", "uintxAdaptiveSizeDecrementScaleFactor=4",
+                "uintxAdaptiveSizeMajorGCDecayTimeScale=10");
+    }
+
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -103,6 +103,7 @@ ext {
   // Tracing
   micrometerVersion = '1.10.4'
   micrometerJersey2Version = '1.8.13'
+  microMeterJvmExtrasVersion = '0.2.2'
 
   // TO REMOVE
   jasyptVersion = '1.9.2'


### PR DESCRIPTION
 - Add native memory metrics based on the -XX:NativeMemoryTracking=summary jvm flag and jmx
 - Add 'real' memory metrics from procfs '/proc/self/status'
 - Print vmFlags content on startup
 - Add new properties: vm.info.vmflags.enabled (default true), vm.info.nativeMemory.enabled (default true), vm.info.nativeMemory.delay (default 60 sec)
 - Fix gauge metrics related bug where gauge uses multiple tags as dimensions (xxx_flow_step)

See detailed description in the commit message.