### PR TITLE
CB-20343 bump the version of java-init-container to 1.0.0-b10775

### DIFF
--- a/cloudera/docker_images.yaml
+++ b/cloudera/docker_images.yaml
@@ -9,4 +9,4 @@ docker_images:
   cloudbreak-mock-thunderhead: hortonworks/cloudbreak-mock-thunderhead
   cloudbreak-mock-infrastructure: hortonworks/cloudbreak-mock-infrastructure
 external_images:
-  java-init-container: docker-private.infra.cloudera.com/cloudera/thunderhead-java-init-container-17:1.0.0-b10181
+  java-init-container: docker-private.infra.cloudera.com/cloudera/thunderhead-java-init-container-17:1.0.0-b10775


### PR DESCRIPTION
See detailed description in the commit message.